### PR TITLE
feat(providers): add OpenAI image provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = ["httpx>=0.27"]
 
 [project.optional-dependencies]
 mcp = ["fastmcp>=3.0,<4"]
-all = ["fastmcp>=3.0,<4"]
+openai = ["openai>=1.0"]
+all = ["fastmcp>=3.0,<4", "openai>=1.0"]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ mcp = ["fastmcp>=3.0,<4"]
 openai = ["openai>=1.0"]
 all = ["fastmcp>=3.0,<4", "openai>=1.0"]
 dev = [
+    "image-gen-mcp[all]",
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",

--- a/src/image_gen_mcp/_server_deps.py
+++ b/src/image_gen_mcp/_server_deps.py
@@ -54,6 +54,15 @@ def make_service_lifespan(config: ServerConfig) -> Any:
         # Always register placeholder (zero-cost, no API key needed)
         service.register_provider("placeholder", PlaceholderImageProvider())
 
+        # Register OpenAI if API key is configured
+        if config.openai_api_key:
+            from image_gen_mcp.providers.openai import OpenAIImageProvider
+
+            service.register_provider(
+                "openai",
+                OpenAIImageProvider(api_key=config.openai_api_key),
+            )
+
         try:
             yield {"service": service, "config": config}
         finally:

--- a/src/image_gen_mcp/providers/openai.py
+++ b/src/image_gen_mcp/providers/openai.py
@@ -43,6 +43,8 @@ _FORMAT_TO_CONTENT_TYPE: dict[str, str] = {
     "webp": "image/webp",
 }
 
+_DALLE3_FORMATS: frozenset[str] = frozenset({"png", "jpeg"})
+
 
 def _is_gpt_image_model(model: str) -> bool:
     """Return True for gpt-image-* models (not dall-e)."""
@@ -75,8 +77,17 @@ class OpenAIImageProvider:
                 f"Unsupported output_format '{output_format}'. Supported: {supported}",
             )
 
-        self._content_type = _FORMAT_TO_CONTENT_TYPE[output_format]
         self._is_gpt_image = _is_gpt_image_model(model)
+
+        if not self._is_gpt_image and output_format not in _DALLE3_FORMATS:
+            supported_dalle3 = ", ".join(sorted(_DALLE3_FORMATS))
+            raise ImageProviderError(
+                "openai",
+                f"dall-e-3 does not support output_format '{output_format}'. "
+                f"Supported: {supported_dalle3}",
+            )
+
+        self._content_type = _FORMAT_TO_CONTENT_TYPE[output_format]
         self._sizes = _GPT_IMAGE_SIZES if self._is_gpt_image else _DALLE3_SIZES
         self._client: AsyncOpenAI = self._create_client()
 
@@ -195,7 +206,16 @@ class OpenAIImageProvider:
 
         if isinstance(error, APIStatusError):
             status = error.status_code
-            if status == 400 and "content_policy" in str(error).lower():
+            body = getattr(error, "body", None) or {}
+            code = (
+                body.get("error", {}).get("code", "")
+                if isinstance(body, dict)
+                else ""
+            )
+            if status == 400 and (
+                code == "content_policy_violation"
+                or "content_policy" in str(error).lower()
+            ):
                 raise ImageContentPolicyError(
                     "openai", f"Content policy rejection: {error}"
                 ) from error

--- a/src/image_gen_mcp/providers/openai.py
+++ b/src/image_gen_mcp/providers/openai.py
@@ -67,7 +67,6 @@ class OpenAIImageProvider:
         output_format: str = "png",
     ) -> None:
         self._model = model
-        self._api_key = api_key
         self._output_format = output_format
 
         if output_format not in _FORMAT_TO_CONTENT_TYPE:
@@ -89,9 +88,9 @@ class OpenAIImageProvider:
 
         self._content_type = _FORMAT_TO_CONTENT_TYPE[output_format]
         self._sizes = _GPT_IMAGE_SIZES if self._is_gpt_image else _DALLE3_SIZES
-        self._client: AsyncOpenAI = self._create_client()
+        self._client: AsyncOpenAI = self._create_client(api_key)
 
-    def _create_client(self) -> AsyncOpenAI:
+    def _create_client(self, api_key: str) -> AsyncOpenAI:
         """Create the AsyncOpenAI client (deferred import)."""
         try:
             from openai import AsyncOpenAI as _AsyncOpenAI
@@ -99,7 +98,7 @@ class OpenAIImageProvider:
             raise ImageProviderError(
                 "openai", "openai package not installed. Run: uv add openai"
             ) from e
-        return _AsyncOpenAI(api_key=self._api_key)
+        return _AsyncOpenAI(api_key=api_key)
 
     async def generate(
         self,
@@ -129,8 +128,9 @@ class OpenAIImageProvider:
         if negative_prompt:
             effective_prompt = f"{prompt}\n\nAvoid: {negative_prompt}"
 
+        api_quality = quality
         if self._is_gpt_image:
-            quality = {"standard": "high", "hd": "high"}.get(quality, quality)
+            api_quality = {"standard": "high", "hd": "high"}.get(quality, quality)
 
         size = self._sizes.get(aspect_ratio)
         if size is None:
@@ -144,7 +144,7 @@ class OpenAIImageProvider:
             "OpenAI image generation: model=%s size=%s quality=%s",
             self._model,
             size,
-            quality,
+            api_quality,
         )
 
         try:
@@ -153,7 +153,7 @@ class OpenAIImageProvider:
                 "prompt": effective_prompt,
                 "n": 1,
                 "size": size,
-                "quality": quality,
+                "quality": api_quality,
             }
             if self._is_gpt_image:
                 api_kwargs["output_format"] = self._output_format
@@ -177,6 +177,7 @@ class OpenAIImageProvider:
             "model": self._model,
             "size": size,
             "quality": quality,
+            "api_quality": api_quality,
         }
         revised_prompt = getattr(image_item, "revised_prompt", None)
         if revised_prompt:
@@ -208,9 +209,7 @@ class OpenAIImageProvider:
             status = error.status_code
             body = getattr(error, "body", None) or {}
             code = (
-                body.get("error", {}).get("code", "")
-                if isinstance(body, dict)
-                else ""
+                body.get("error", {}).get("code", "") if isinstance(body, dict) else ""
             )
             if status == 400 and (
                 code == "content_policy_violation"

--- a/src/image_gen_mcp/providers/openai.py
+++ b/src/image_gen_mcp/providers/openai.py
@@ -1,0 +1,208 @@
+"""OpenAI image generation provider.
+
+Supports gpt-image-1 (current) and dall-e-3 (legacy, deprecated May 2026).
+Ported from questfoundry — prompt distillation removed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from image_gen_mcp.providers.types import (
+    ImageContentPolicyError,
+    ImageProviderConnectionError,
+    ImageProviderError,
+    ImageResult,
+)
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+logger = logging.getLogger(__name__)
+
+_GPT_IMAGE_SIZES: dict[str, str] = {
+    "1:1": "1024x1024",
+    "16:9": "1536x1024",
+    "9:16": "1024x1536",
+    "3:2": "1536x1024",
+    "2:3": "1024x1536",
+}
+
+_DALLE3_SIZES: dict[str, str] = {
+    "1:1": "1024x1024",
+    "16:9": "1792x1024",
+    "9:16": "1024x1792",
+    "3:2": "1792x1024",
+    "2:3": "1024x1792",
+}
+
+_FORMAT_TO_CONTENT_TYPE: dict[str, str] = {
+    "png": "image/png",
+    "jpeg": "image/jpeg",
+    "webp": "image/webp",
+}
+
+
+def _is_gpt_image_model(model: str) -> bool:
+    """Return True for gpt-image-* models (not dall-e)."""
+    return model.startswith("gpt-image")
+
+
+class OpenAIImageProvider:
+    """Image generation via OpenAI's Images API.
+
+    Args:
+        model: Model name (``gpt-image-1`` or ``dall-e-3``).
+        api_key: OpenAI API key.
+        output_format: Image format (``png``, ``jpeg``, ``webp``).
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gpt-image-1",
+        output_format: str = "png",
+    ) -> None:
+        self._model = model
+        self._api_key = api_key
+        self._output_format = output_format
+
+        if output_format not in _FORMAT_TO_CONTENT_TYPE:
+            supported = ", ".join(sorted(_FORMAT_TO_CONTENT_TYPE))
+            raise ImageProviderError(
+                "openai",
+                f"Unsupported output_format '{output_format}'. Supported: {supported}",
+            )
+
+        self._content_type = _FORMAT_TO_CONTENT_TYPE[output_format]
+        self._is_gpt_image = _is_gpt_image_model(model)
+        self._sizes = _GPT_IMAGE_SIZES if self._is_gpt_image else _DALLE3_SIZES
+        self._client: AsyncOpenAI = self._create_client()
+
+    def _create_client(self) -> AsyncOpenAI:
+        """Create the AsyncOpenAI client (deferred import)."""
+        try:
+            from openai import AsyncOpenAI as _AsyncOpenAI
+        except ImportError as e:
+            raise ImageProviderError(
+                "openai", "openai package not installed. Run: uv add openai"
+            ) from e
+        return _AsyncOpenAI(api_key=self._api_key)
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: str | None = None,
+        aspect_ratio: str = "1:1",
+        quality: str = "standard",
+    ) -> ImageResult:
+        """Generate an image via OpenAI Images API.
+
+        Args:
+            prompt: Positive text prompt.
+            negative_prompt: Appended as ``"Avoid: ..."`` clause.
+            aspect_ratio: Maps to OpenAI size parameter.
+            quality: Quality level.
+
+        Returns:
+            ImageResult with generated image.
+
+        Raises:
+            ImageProviderError: On API errors.
+            ImageContentPolicyError: On content policy rejection.
+            ImageProviderConnectionError: On network errors.
+        """
+        effective_prompt = prompt
+        if negative_prompt:
+            effective_prompt = f"{prompt}\n\nAvoid: {negative_prompt}"
+
+        if self._is_gpt_image:
+            quality = {"standard": "high", "hd": "high"}.get(quality, quality)
+
+        size = self._sizes.get(aspect_ratio)
+        if size is None:
+            supported = ", ".join(sorted(self._sizes))
+            raise ImageProviderError(
+                "openai",
+                f"Unsupported aspect_ratio '{aspect_ratio}'. Supported: {supported}",
+            )
+
+        logger.debug(
+            "OpenAI image generation: model=%s size=%s quality=%s",
+            self._model,
+            size,
+            quality,
+        )
+
+        try:
+            api_kwargs: dict[str, Any] = {
+                "model": self._model,
+                "prompt": effective_prompt,
+                "n": 1,
+                "size": size,
+                "quality": quality,
+            }
+            if self._is_gpt_image:
+                api_kwargs["output_format"] = self._output_format
+            else:
+                api_kwargs["response_format"] = "b64_json"
+            response = await self._client.images.generate(**api_kwargs)
+        except ImageProviderError:
+            raise
+        except Exception as e:
+            self._handle_error(e)
+
+        if not response.data:
+            raise ImageProviderError("openai", "Empty response from image API")
+
+        image_item = response.data[0]
+        b64_data = image_item.b64_json
+        if not b64_data:
+            raise ImageProviderError("openai", "No image data in response")
+
+        metadata: dict[str, Any] = {
+            "model": self._model,
+            "size": size,
+            "quality": quality,
+        }
+        revised_prompt = getattr(image_item, "revised_prompt", None)
+        if revised_prompt:
+            metadata["revised_prompt"] = revised_prompt
+
+        logger.info("OpenAI image generated: model=%s size=%s", self._model, size)
+
+        return ImageResult.from_base64(
+            b64_data,
+            content_type=self._content_type,
+            **metadata,
+        )
+
+    def _handle_error(self, error: Exception) -> NoReturn:
+        """Convert OpenAI exceptions to ImageProvider exceptions."""
+        try:
+            from openai import APIConnectionError, APIStatusError
+        except ImportError:
+            raise ImageProviderError(
+                "openai", f"Image generation failed: {error}"
+            ) from error
+
+        if isinstance(error, APIConnectionError):
+            raise ImageProviderConnectionError(
+                "openai", f"Connection error: {error}"
+            ) from error
+
+        if isinstance(error, APIStatusError):
+            status = error.status_code
+            if status == 400 and "content_policy" in str(error).lower():
+                raise ImageContentPolicyError(
+                    "openai", f"Content policy rejection: {error}"
+                ) from error
+            raise ImageProviderError(
+                "openai", f"API error (HTTP {status}): {error}"
+            ) from error
+
+        raise ImageProviderError(
+            "openai", f"Image generation failed: {error}"
+        ) from error

--- a/src/image_gen_mcp/providers/openai.py
+++ b/src/image_gen_mcp/providers/openai.py
@@ -43,7 +43,7 @@ _FORMAT_TO_CONTENT_TYPE: dict[str, str] = {
     "webp": "image/webp",
 }
 
-_DALLE3_FORMATS: frozenset[str] = frozenset({"png", "jpeg"})
+_DALLE3_FORMATS: frozenset[str] = frozenset({"png"})
 
 
 def _is_gpt_image_model(model: str) -> bool:
@@ -193,12 +193,7 @@ class OpenAIImageProvider:
 
     def _handle_error(self, error: Exception) -> NoReturn:
         """Convert OpenAI exceptions to ImageProvider exceptions."""
-        try:
-            from openai import APIConnectionError, APIStatusError
-        except ImportError:
-            raise ImageProviderError(
-                "openai", f"Image generation failed: {error}"
-            ) from error
+        from openai import APIConnectionError, APIStatusError
 
         if isinstance(error, APIConnectionError):
             raise ImageProviderConnectionError(

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,0 +1,181 @@
+"""Tests for the OpenAI image provider."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from image_gen_mcp.providers.openai import (
+    _DALLE3_SIZES,
+    _GPT_IMAGE_SIZES,
+    OpenAIImageProvider,
+)
+from image_gen_mcp.providers.types import (
+    ImageContentPolicyError,
+    ImageProvider,
+    ImageProviderConnectionError,
+    ImageProviderError,
+)
+
+
+@pytest.fixture
+def _mock_openai():
+    """Patch openai imports so tests don't need the real package."""
+    with patch("image_gen_mcp.providers.openai.OpenAIImageProvider._create_client"):
+        yield
+
+
+@pytest.mark.usefixtures("_mock_openai")
+class TestOpenAIProvider:
+    """Tests for OpenAIImageProvider."""
+
+    def test_implements_protocol(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+        assert isinstance(provider, ImageProvider)
+
+    def test_default_model_is_gpt_image(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+        assert provider._model == "gpt-image-1"
+        assert provider._is_gpt_image is True
+
+    def test_dalle3_model(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test", model="dall-e-3")
+        assert provider._is_gpt_image is False
+        assert provider._sizes is _DALLE3_SIZES
+
+    def test_gpt_image_sizes(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+        assert provider._sizes is _GPT_IMAGE_SIZES
+        assert provider._sizes["1:1"] == "1024x1024"
+        assert provider._sizes["16:9"] == "1536x1024"
+
+    def test_dalle3_sizes(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test", model="dall-e-3")
+        assert provider._sizes["16:9"] == "1792x1024"
+
+    def test_unsupported_format_raises(self) -> None:
+        with pytest.raises(ImageProviderError, match="Unsupported output_format"):
+            OpenAIImageProvider(api_key="sk-test", output_format="gif")
+
+    async def test_unsupported_aspect_ratio_raises(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+        with pytest.raises(ImageProviderError, match="Unsupported aspect_ratio"):
+            await provider.generate("test", aspect_ratio="7:3")
+
+    async def test_generate_success(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+
+        b64_image = base64.b64encode(b"fake-png-data").decode()
+        mock_item = MagicMock()
+        mock_item.b64_json = b64_image
+        mock_item.revised_prompt = "enhanced prompt"
+
+        mock_response = MagicMock()
+        mock_response.data = [mock_item]
+
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.generate = AsyncMock(return_value=mock_response)
+
+        result = await provider.generate("a cat", aspect_ratio="1:1")
+
+        assert result.image_data == b"fake-png-data"
+        assert result.content_type == "image/png"
+        assert result.provider_metadata["model"] == "gpt-image-1"
+        assert result.provider_metadata["revised_prompt"] == "enhanced prompt"
+
+    async def test_negative_prompt_appended(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+
+        b64_image = base64.b64encode(b"data").decode()
+        mock_item = MagicMock()
+        mock_item.b64_json = b64_image
+        mock_item.revised_prompt = None
+
+        mock_response = MagicMock()
+        mock_response.data = [mock_item]
+
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.generate = AsyncMock(return_value=mock_response)
+
+        await provider.generate("a cat", negative_prompt="dogs")
+
+        call_kwargs = provider._client.images.generate.call_args[1]
+        assert "Avoid: dogs" in call_kwargs["prompt"]
+
+    async def test_empty_response_raises(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+
+        mock_response = MagicMock()
+        mock_response.data = []
+
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.generate = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(ImageProviderError, match="Empty response"):
+            await provider.generate("test")
+
+    async def test_quality_mapping_for_gpt_image(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+
+        b64_image = base64.b64encode(b"data").decode()
+        mock_item = MagicMock()
+        mock_item.b64_json = b64_image
+        mock_item.revised_prompt = None
+        mock_response = MagicMock()
+        mock_response.data = [mock_item]
+
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.generate = AsyncMock(return_value=mock_response)
+
+        await provider.generate("test", quality="standard")
+
+        call_kwargs = provider._client.images.generate.call_args[1]
+        assert call_kwargs["quality"] == "high"
+
+
+class TestErrorHandling:
+    """Tests for OpenAI error conversion."""
+
+    @pytest.mark.usefixtures("_mock_openai")
+    async def test_connection_error(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+
+        from openai import APIConnectionError
+
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.generate = AsyncMock(
+            side_effect=APIConnectionError(request=MagicMock())
+        )
+
+        with pytest.raises(ImageProviderConnectionError):
+            await provider.generate("test")
+
+    @pytest.mark.usefixtures("_mock_openai")
+    async def test_content_policy_error(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test")
+
+        from openai import APIStatusError
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {"error": {"message": "content_policy"}}
+
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.generate = AsyncMock(
+            side_effect=APIStatusError(
+                message="content_policy violation",
+                response=mock_response,
+                body=None,
+            )
+        )
+
+        with pytest.raises(ImageContentPolicyError):
+            await provider.generate("test")

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -187,3 +187,28 @@ class TestErrorHandling:
 
         with pytest.raises(ImageContentPolicyError):
             await provider.generate("test")
+
+    @pytest.mark.usefixtures("_mock_openai")
+    async def test_content_policy_error_structured_body(self) -> None:
+        """Structured body[error][code] path triggers content policy error."""
+        provider = OpenAIImageProvider(api_key="sk-test")
+
+        from openai import APIStatusError
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.generate = AsyncMock(
+            side_effect=APIStatusError(
+                message="Your request was rejected",
+                response=mock_response,
+                body={
+                    "error": {"code": "content_policy_violation", "message": "rejected"}
+                },
+            )
+        )
+
+        with pytest.raises(ImageContentPolicyError):
+            await provider.generate("test")

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -61,7 +61,9 @@ class TestOpenAIProvider:
 
     def test_dalle3_rejects_webp_format(self) -> None:
         with pytest.raises(ImageProviderError, match="dall-e-3 does not support"):
-            OpenAIImageProvider(api_key="sk-test", model="dall-e-3", output_format="webp")
+            OpenAIImageProvider(
+                api_key="sk-test", model="dall-e-3", output_format="webp"
+            )
 
     async def test_unsupported_aspect_ratio_raises(self) -> None:
         provider = OpenAIImageProvider(api_key="sk-test")
@@ -88,6 +90,8 @@ class TestOpenAIProvider:
         assert result.image_data == b"fake-png-data"
         assert result.content_type == "image/png"
         assert result.provider_metadata["model"] == "gpt-image-1"
+        assert result.provider_metadata["quality"] == "standard"
+        assert result.provider_metadata["api_quality"] == "high"
         assert result.provider_metadata["revised_prompt"] == "enhanced prompt"
 
     async def test_negative_prompt_appended(self) -> None:
@@ -107,7 +111,7 @@ class TestOpenAIProvider:
 
         await provider.generate("a cat", negative_prompt="dogs")
 
-        call_kwargs = provider._client.images.generate.call_args[1]
+        call_kwargs = provider._client.images.generate.call_args.kwargs
         assert "Avoid: dogs" in call_kwargs["prompt"]
 
     async def test_empty_response_raises(self) -> None:
@@ -139,7 +143,7 @@ class TestOpenAIProvider:
 
         await provider.generate("test", quality="standard")
 
-        call_kwargs = provider._client.images.generate.call_args[1]
+        call_kwargs = provider._client.images.generate.call_args.kwargs
         assert call_kwargs["quality"] == "high"
 
 

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -65,6 +65,32 @@ class TestOpenAIProvider:
                 api_key="sk-test", model="dall-e-3", output_format="webp"
             )
 
+    def test_dalle3_rejects_jpeg_format(self) -> None:
+        with pytest.raises(ImageProviderError, match="dall-e-3 does not support"):
+            OpenAIImageProvider(
+                api_key="sk-test", model="dall-e-3", output_format="jpeg"
+            )
+
+    async def test_dalle3_generate_sends_response_format(self) -> None:
+        provider = OpenAIImageProvider(api_key="sk-test", model="dall-e-3")
+
+        b64_image = base64.b64encode(b"data").decode()
+        mock_item = MagicMock()
+        mock_item.b64_json = b64_image
+        mock_item.revised_prompt = None
+        mock_response = MagicMock()
+        mock_response.data = [mock_item]
+
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.generate = AsyncMock(return_value=mock_response)
+
+        await provider.generate("a landscape")
+
+        call_kwargs = provider._client.images.generate.call_args.kwargs
+        assert call_kwargs["response_format"] == "b64_json"
+        assert "output_format" not in call_kwargs
+
     async def test_unsupported_aspect_ratio_raises(self) -> None:
         provider = OpenAIImageProvider(api_key="sk-test")
         with pytest.raises(ImageProviderError, match="Unsupported aspect_ratio"):

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -59,6 +59,10 @@ class TestOpenAIProvider:
         with pytest.raises(ImageProviderError, match="Unsupported output_format"):
             OpenAIImageProvider(api_key="sk-test", output_format="gif")
 
+    def test_dalle3_rejects_webp_format(self) -> None:
+        with pytest.raises(ImageProviderError, match="dall-e-3 does not support"):
+            OpenAIImageProvider(api_key="sk-test", model="dall-e-3", output_format="webp")
+
     async def test_unsupported_aspect_ratio_raises(self) -> None:
         provider = OpenAIImageProvider(api_key="sk-test")
         with pytest.raises(ImageProviderError, match="Unsupported aspect_ratio"):


### PR DESCRIPTION
## Summary

- Add `OpenAIImageProvider` — supports `gpt-image-1` (default) and `dall-e-3` models
- Model-specific size mappings, quality translation, negative prompt as "Avoid:" clause
- Typed error conversion: `APIConnectionError` → `ImageProviderConnectionError`, content policy detection
- API key passed at construction from config (not read from env)
- Add `openai>=1.0` as optional dependency

## Design Documentation

- [ADR-0001: Multi-Provider Architecture](docs/decisions/0001-multi-provider-architecture.md) — direct generation without prompt distillation
- [Provider System Design](docs/design/provider-system.md), "OpenAI Provider" section

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | `OpenAIImageProvider` implements `ImageProvider` protocol | ADR-0002 | CONFORMANT | `providers/openai.py:52-208` |
| 2 | Supports gpt-image-1 and dall-e-3 | Design doc | CONFORMANT | `openai.py:24-38,47-49` |
| 3 | No prompt distillation | ADR-0001 | CONFORMANT | No LangChain/distill imports |
| 4 | API key from config, not env | Design doc | CONFORMANT | `openai.py:61-69`, `_server_deps.py:62` |
| 5 | Error handling: connection, content policy, API errors | Design doc | CONFORMANT | `openai.py:182-208` |
| 6 | Registered when `openai_api_key` is set | ADR-0002 | CONFORMANT | `_server_deps.py:58-64` |
| 7 | `openai` as optional dependency | Design doc | CONFORMANT | `pyproject.toml:23` |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan

- [x] `tests/test_openai_provider.py` — 13 tests (protocol, models, sizes, formats, generate, negative prompt, content policy, connection errors)
- [ ] `uv run pytest` passes
- [ ] `uv run ruff check src/ tests/` clean

**Stack: 4/6** — depends on: #9, next: #feat/5-a1111-provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)