### PR TITLE
feat: ProviderCapabilities dataclasses + protocol + placeholder impl

### DIFF
--- a/src/image_generation_mcp/_server_deps.py
+++ b/src/image_generation_mcp/_server_deps.py
@@ -72,6 +72,9 @@ def make_service_lifespan(config: ServerConfig) -> Any:
                 A1111ImageProvider(host=config.a1111_host, model=config.a1111_model),
             )
 
+        # Discover capabilities for all registered providers
+        await service.discover_all_capabilities()
+
         try:
             yield {"service": service, "config": config}
         finally:

--- a/src/image_generation_mcp/providers/__init__.py
+++ b/src/image_generation_mcp/providers/__init__.py
@@ -3,6 +3,10 @@
 Re-exports core types for convenient access.
 """
 
+from image_generation_mcp.providers.capabilities import (
+    ModelCapabilities,
+    ProviderCapabilities,
+)
 from image_generation_mcp.providers.types import (
     SUPPORTED_ASPECT_RATIOS,
     SUPPORTED_QUALITY_LEVELS,
@@ -21,4 +25,6 @@ __all__ = [
     "ImageProviderConnectionError",
     "ImageProviderError",
     "ImageResult",
+    "ModelCapabilities",
+    "ProviderCapabilities",
 ]

--- a/src/image_generation_mcp/providers/a1111.py
+++ b/src/image_generation_mcp/providers/a1111.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
@@ -21,6 +21,9 @@ from image_generation_mcp.providers.types import (
     ImageProviderError,
     ImageResult,
 )
+
+if TYPE_CHECKING:
+    from image_generation_mcp.providers.capabilities import ProviderCapabilities
 
 logger = logging.getLogger(__name__)
 
@@ -237,3 +240,14 @@ class A1111ImageProvider:
             content_type="image/png",
             **metadata,
         )
+
+    async def discover_capabilities(self) -> ProviderCapabilities:
+        """Discover A1111 checkpoint capabilities via sd-models API.
+
+        Returns:
+            ProviderCapabilities with discovered checkpoints.
+
+        Raises:
+            NotImplementedError: Pending implementation in issue #29.
+        """
+        raise NotImplementedError("A1111 capability discovery not yet implemented")

--- a/src/image_generation_mcp/providers/capabilities.py
+++ b/src/image_generation_mcp/providers/capabilities.py
@@ -1,0 +1,116 @@
+"""Provider capability model — frozen dataclasses for runtime discovery.
+
+Defines :class:`ModelCapabilities` and :class:`ProviderCapabilities` which
+represent what each provider and model can do.  Populated at startup via
+each provider's ``discover_capabilities()`` method.
+
+See ADR-0007 for the design rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ModelCapabilities:
+    """Capabilities of a single model within a provider.
+
+    Attributes:
+        model_id: Model identifier (e.g., ``"gpt-image-1"``).
+        display_name: Human-readable display name.
+        can_generate: Supports text-to-image generation.
+        can_edit: Supports image editing (future).
+        supports_mask: Supports inpainting masks (future).
+        supported_aspect_ratios: Aspect ratio strings this model accepts.
+        supported_qualities: Quality level strings this model accepts.
+        supported_formats: Output format strings (e.g., ``"png"``, ``"webp"``).
+        supports_negative_prompt: Accepts negative prompt parameter.
+        supports_background: Supports background transparency control.
+        max_resolution: Maximum dimension in pixels, or ``None`` if unlimited.
+        default_steps: Default inference steps (A1111-specific), or ``None``.
+        default_cfg: Default CFG scale (A1111-specific), or ``None``.
+    """
+
+    model_id: str
+    display_name: str
+    can_generate: bool = True
+    can_edit: bool = False
+    supports_mask: bool = False
+    supported_aspect_ratios: tuple[str, ...] = ()
+    supported_qualities: tuple[str, ...] = ()
+    supported_formats: tuple[str, ...] = ()
+    supports_negative_prompt: bool = False
+    supports_background: bool = False
+    max_resolution: int | None = None
+    default_steps: int | None = None
+    default_cfg: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "model_id": self.model_id,
+            "display_name": self.display_name,
+            "can_generate": self.can_generate,
+            "can_edit": self.can_edit,
+            "supports_mask": self.supports_mask,
+            "supported_aspect_ratios": list(self.supported_aspect_ratios),
+            "supported_qualities": list(self.supported_qualities),
+            "supported_formats": list(self.supported_formats),
+            "supports_negative_prompt": self.supports_negative_prompt,
+            "supports_background": self.supports_background,
+            "max_resolution": self.max_resolution,
+            "default_steps": self.default_steps,
+            "default_cfg": self.default_cfg,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """Aggregate capabilities for a provider (one or more models).
+
+    Attributes:
+        provider_name: Registry key (e.g., ``"openai"``).
+        models: Per-model capability details.
+        supports_background: ``True`` if any model supports background control.
+        supports_negative_prompt: ``True`` if any model supports negative prompts.
+        discovered_at: Unix timestamp when discovery completed.
+        degraded: ``True`` if discovery failed (empty model list).
+    """
+
+    provider_name: str
+    models: tuple[ModelCapabilities, ...] = ()
+    supports_background: bool = False
+    supports_negative_prompt: bool = False
+    discovered_at: float = 0.0
+    degraded: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        result: dict[str, Any] = {
+            "provider_name": self.provider_name,
+            "models": [m.to_dict() for m in self.models],
+            "supports_background": self.supports_background,
+            "supports_negative_prompt": self.supports_negative_prompt,
+            "discovered_at": self.discovered_at,
+            "degraded": self.degraded,
+        }
+        return result
+
+
+def make_degraded(provider_name: str, discovered_at: float) -> ProviderCapabilities:
+    """Create a degraded capabilities entry for a provider that failed discovery.
+
+    Args:
+        provider_name: Provider registry key.
+        discovered_at: Unix timestamp of the failed discovery attempt.
+
+    Returns:
+        A ``ProviderCapabilities`` with ``degraded=True`` and empty model list.
+    """
+    return ProviderCapabilities(
+        provider_name=provider_name,
+        degraded=True,
+        discovered_at=discovered_at,
+    )

--- a/src/image_generation_mcp/providers/openai.py
+++ b/src/image_generation_mcp/providers/openai.py
@@ -19,6 +19,8 @@ from image_generation_mcp.providers.types import (
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
 
+    from image_generation_mcp.providers.capabilities import ProviderCapabilities
+
 logger = logging.getLogger(__name__)
 
 _GPT_IMAGE_SIZES: dict[str, str] = {
@@ -220,3 +222,14 @@ class OpenAIImageProvider:
         raise ImageProviderError(
             "openai", f"Image generation failed: {error}"
         ) from error
+
+    async def discover_capabilities(self) -> ProviderCapabilities:
+        """Discover OpenAI image model capabilities via models.list().
+
+        Returns:
+            ProviderCapabilities with discovered image models.
+
+        Raises:
+            NotImplementedError: Pending implementation in issue #28.
+        """
+        raise NotImplementedError("OpenAI capability discovery not yet implemented")

--- a/src/image_generation_mcp/providers/placeholder.py
+++ b/src/image_generation_mcp/providers/placeholder.py
@@ -11,8 +11,13 @@ from __future__ import annotations
 import hashlib
 import logging
 import struct
+import time
 import zlib
 
+from image_generation_mcp.providers.capabilities import (
+    ModelCapabilities,
+    ProviderCapabilities,
+)
 from image_generation_mcp.providers.types import ImageResult
 
 logger = logging.getLogger(__name__)
@@ -112,4 +117,31 @@ class PlaceholderImageProvider:
                 "size": f"{width}x{height}",
                 "color": f"#{r:02x}{g:02x}{b:02x}",
             },
+        )
+
+    async def discover_capabilities(self) -> ProviderCapabilities:
+        """Return static capabilities for the placeholder provider.
+
+        Returns:
+            ProviderCapabilities with one model and fixed feature set.
+        """
+        model = ModelCapabilities(
+            model_id="placeholder",
+            display_name="Placeholder (solid-color PNG)",
+            can_generate=True,
+            can_edit=False,
+            supports_mask=False,
+            supported_aspect_ratios=tuple(_ASPECT_RATIO_TO_SIZE),
+            supported_qualities=("standard",),
+            supported_formats=("png",),
+            supports_negative_prompt=False,
+            supports_background=True,
+            max_resolution=640,
+        )
+        return ProviderCapabilities(
+            provider_name="placeholder",
+            models=(model,),
+            supports_background=True,
+            supports_negative_prompt=False,
+            discovered_at=time.time(),
         )

--- a/src/image_generation_mcp/providers/types.py
+++ b/src/image_generation_mcp/providers/types.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import base64
 from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from image_generation_mcp.providers.capabilities import ProviderCapabilities
 
 
 @dataclass(frozen=True)
@@ -86,6 +89,20 @@ class ImageProvider(Protocol):
 
         Raises:
             ImageProviderError: If generation fails.
+        """
+        ...
+
+    async def discover_capabilities(self) -> ProviderCapabilities:
+        """Discover this provider's capabilities at startup.
+
+        Called once during server lifespan after provider construction.
+        Results are cached for the server lifetime.
+
+        Returns:
+            ProviderCapabilities describing models and features.
+
+        Raises:
+            Exception: Any error during discovery (caller handles gracefully).
         """
         ...
 

--- a/src/image_generation_mcp/service.py
+++ b/src/image_generation_mcp/service.py
@@ -20,6 +20,10 @@ from typing import Any, ClassVar
 
 from PIL import Image
 
+from image_generation_mcp.providers.capabilities import (
+    ProviderCapabilities,
+    make_degraded,
+)
 from image_generation_mcp.providers.types import (
     ImageProvider,
     ImageProviderError,
@@ -62,6 +66,7 @@ class ImageService:
         default_provider: str = "auto",
     ) -> None:
         self._providers: dict[str, ImageProvider] = {}
+        self._capabilities: dict[str, ProviderCapabilities] = {}
         self._scratch_dir = scratch_dir
         self._default_provider = default_provider
         self._images: dict[str, ImageRecord] = {}
@@ -85,6 +90,11 @@ class ImageService:
             if hasattr(provider, "aclose"):
                 await provider.aclose()
 
+    @property
+    def capabilities(self) -> dict[str, ProviderCapabilities]:
+        """Discovered provider capabilities (read-only view)."""
+        return self._capabilities
+
     def register_provider(self, name: str, provider: ImageProvider) -> None:
         """Register an image provider.
 
@@ -94,6 +104,32 @@ class ImageService:
         """
         self._providers[name] = provider
         logger.info("Registered image provider: %s", name)
+
+    async def discover_all_capabilities(self) -> None:
+        """Discover capabilities for all registered providers.
+
+        Calls ``discover_capabilities()`` on each provider. If a provider
+        raises an exception, it is registered with ``degraded=True`` and
+        an empty model list — server startup is not blocked.
+        """
+        for name, provider in self._providers.items():
+            try:
+                caps = await provider.discover_capabilities()
+                self._capabilities[name] = caps
+                model_count = len(caps.models)
+                logger.info(
+                    "Discovered capabilities for %s: %d model(s)%s",
+                    name,
+                    model_count,
+                    " (degraded)" if caps.degraded else "",
+                )
+            except Exception:
+                logger.warning(
+                    "Capability discovery failed for %s — marking degraded",
+                    name,
+                    exc_info=True,
+                )
+                self._capabilities[name] = make_degraded(name, time.time())
 
     _PROVIDER_DESCRIPTIONS: ClassVar[dict[str, str]] = {
         "openai": (
@@ -110,17 +146,21 @@ class ImageService:
     }
 
     def list_providers(self) -> dict[str, dict[str, Any]]:
-        """List registered providers with availability info.
+        """List registered providers with availability and capability info.
 
         Returns:
-            Dict of provider name -> ``{available: True, description: str}``.
+            Dict of provider name -> ``{available, description, capabilities}``.
+            The ``capabilities`` key is present only after discovery has run.
         """
         result: dict[str, dict[str, Any]] = {}
         for name in self._providers:
-            result[name] = {
+            entry: dict[str, Any] = {
                 "available": True,
                 "description": self._PROVIDER_DESCRIPTIONS.get(name, name),
             }
+            if name in self._capabilities:
+                entry["capabilities"] = self._capabilities[name].to_dict()
+            result[name] = entry
         return result
 
     def _resolve_provider(

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,235 @@
+"""Tests for provider capability model — dataclasses, discovery, and service integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from image_generation_mcp.providers.capabilities import (
+    ModelCapabilities,
+    ProviderCapabilities,
+    make_degraded,
+)
+from image_generation_mcp.providers.placeholder import PlaceholderImageProvider
+from image_generation_mcp.service import ImageService
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def scratch_dir(tmp_path: Path) -> Path:
+    return tmp_path / "scratch"
+
+
+class TestModelCapabilities:
+    """Tests for ModelCapabilities frozen dataclass."""
+
+    def test_frozen(self) -> None:
+        mc = ModelCapabilities(model_id="test", display_name="Test")
+        with pytest.raises(AttributeError):
+            mc.model_id = "other"  # type: ignore[misc]
+
+    def test_defaults(self) -> None:
+        mc = ModelCapabilities(model_id="m", display_name="M")
+        assert mc.can_generate is True
+        assert mc.can_edit is False
+        assert mc.supports_mask is False
+        assert mc.supported_aspect_ratios == ()
+        assert mc.supported_qualities == ()
+        assert mc.supported_formats == ()
+        assert mc.supports_negative_prompt is False
+        assert mc.supports_background is False
+        assert mc.max_resolution is None
+        assert mc.default_steps is None
+        assert mc.default_cfg is None
+
+    def test_to_dict(self) -> None:
+        mc = ModelCapabilities(
+            model_id="gpt-image-1",
+            display_name="GPT Image 1",
+            supported_aspect_ratios=("1:1", "16:9"),
+            supported_formats=("png", "webp"),
+            supports_background=True,
+            max_resolution=1536,
+        )
+        d = mc.to_dict()
+        assert d["model_id"] == "gpt-image-1"
+        assert d["supported_aspect_ratios"] == ["1:1", "16:9"]
+        assert d["supported_formats"] == ["png", "webp"]
+        assert d["supports_background"] is True
+        assert d["max_resolution"] == 1536
+
+    def test_to_dict_returns_lists_not_tuples(self) -> None:
+        mc = ModelCapabilities(
+            model_id="m",
+            display_name="M",
+            supported_aspect_ratios=("1:1",),
+        )
+        d = mc.to_dict()
+        assert isinstance(d["supported_aspect_ratios"], list)
+        assert isinstance(d["supported_qualities"], list)
+        assert isinstance(d["supported_formats"], list)
+
+
+class TestProviderCapabilities:
+    """Tests for ProviderCapabilities frozen dataclass."""
+
+    def test_frozen(self) -> None:
+        pc = ProviderCapabilities(provider_name="test")
+        with pytest.raises(AttributeError):
+            pc.provider_name = "other"  # type: ignore[misc]
+
+    def test_defaults(self) -> None:
+        pc = ProviderCapabilities(provider_name="test")
+        assert pc.models == ()
+        assert pc.supports_background is False
+        assert pc.supports_negative_prompt is False
+        assert pc.discovered_at == 0.0
+        assert pc.degraded is False
+
+    def test_to_dict_includes_models(self) -> None:
+        model = ModelCapabilities(model_id="m1", display_name="Model 1")
+        pc = ProviderCapabilities(
+            provider_name="prov",
+            models=(model,),
+            discovered_at=1000.0,
+        )
+        d = pc.to_dict()
+        assert d["provider_name"] == "prov"
+        assert len(d["models"]) == 1
+        assert d["models"][0]["model_id"] == "m1"
+        assert d["discovered_at"] == 1000.0
+        assert d["degraded"] is False
+
+
+class TestMakeDegraded:
+    """Tests for the make_degraded helper."""
+
+    def test_creates_degraded_capabilities(self) -> None:
+        caps = make_degraded("openai", 12345.0)
+        assert caps.provider_name == "openai"
+        assert caps.degraded is True
+        assert caps.models == ()
+        assert caps.discovered_at == 12345.0
+
+
+class TestPlaceholderDiscoverCapabilities:
+    """Tests for PlaceholderImageProvider.discover_capabilities()."""
+
+    async def test_returns_provider_capabilities(self) -> None:
+        provider = PlaceholderImageProvider()
+        caps = await provider.discover_capabilities()
+        assert isinstance(caps, ProviderCapabilities)
+        assert caps.provider_name == "placeholder"
+        assert caps.degraded is False
+
+    async def test_has_one_model(self) -> None:
+        provider = PlaceholderImageProvider()
+        caps = await provider.discover_capabilities()
+        assert len(caps.models) == 1
+        model = caps.models[0]
+        assert model.model_id == "placeholder"
+        assert model.can_generate is True
+        assert model.can_edit is False
+        assert model.supports_mask is False
+
+    async def test_model_capabilities_match_provider(self) -> None:
+        provider = PlaceholderImageProvider()
+        caps = await provider.discover_capabilities()
+        model = caps.models[0]
+        assert model.supports_negative_prompt is False
+        assert model.supports_background is True
+        assert "1:1" in model.supported_aspect_ratios
+        assert "16:9" in model.supported_aspect_ratios
+        assert model.supported_qualities == ("standard",)
+        assert model.supported_formats == ("png",)
+
+    async def test_provider_level_flags(self) -> None:
+        provider = PlaceholderImageProvider()
+        caps = await provider.discover_capabilities()
+        assert caps.supports_background is True
+        assert caps.supports_negative_prompt is False
+
+    async def test_discovered_at_is_set(self) -> None:
+        provider = PlaceholderImageProvider()
+        caps = await provider.discover_capabilities()
+        assert caps.discovered_at > 0
+
+
+class TestServiceDiscoverAll:
+    """Tests for ImageService.discover_all_capabilities()."""
+
+    async def test_populates_capabilities(self, scratch_dir: Path) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+        await svc.discover_all_capabilities()
+        assert "placeholder" in svc.capabilities
+        assert svc.capabilities["placeholder"].provider_name == "placeholder"
+
+    async def test_multiple_providers(self, scratch_dir: Path) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+        svc.register_provider("placeholder2", PlaceholderImageProvider())
+        await svc.discover_all_capabilities()
+        assert len(svc.capabilities) == 2
+
+    async def test_failure_marks_degraded(self, scratch_dir: Path) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+
+        # Create a mock provider whose discover_capabilities() raises
+        mock_provider = AsyncMock()
+        mock_provider.discover_capabilities.side_effect = RuntimeError("API down")
+        mock_provider.generate = AsyncMock()
+        svc.register_provider("broken", mock_provider)
+
+        await svc.discover_all_capabilities()
+        assert "broken" in svc.capabilities
+        assert svc.capabilities["broken"].degraded is True
+        assert svc.capabilities["broken"].models == ()
+
+    async def test_failure_does_not_block_other_providers(
+        self, scratch_dir: Path
+    ) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+
+        mock_provider = AsyncMock()
+        mock_provider.discover_capabilities.side_effect = RuntimeError("API down")
+        mock_provider.generate = AsyncMock()
+        svc.register_provider("broken", mock_provider)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+
+        await svc.discover_all_capabilities()
+        assert svc.capabilities["broken"].degraded is True
+        assert svc.capabilities["placeholder"].degraded is False
+
+
+class TestListProvidersIncludesCapabilities:
+    """Tests for enriched list_providers() response."""
+
+    async def test_includes_capabilities_after_discovery(
+        self, scratch_dir: Path
+    ) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+        await svc.discover_all_capabilities()
+        providers = svc.list_providers()
+        entry = providers["placeholder"]
+        assert "capabilities" in entry
+        assert entry["capabilities"]["provider_name"] == "placeholder"
+        assert len(entry["capabilities"]["models"]) == 1
+
+    def test_no_capabilities_before_discovery(self, scratch_dir: Path) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+        providers = svc.list_providers()
+        assert "capabilities" not in providers["placeholder"]
+
+    def test_backward_compatible_fields(self, scratch_dir: Path) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+        providers = svc.list_providers()
+        assert providers["placeholder"]["available"] is True
+        assert "description" in providers["placeholder"]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -85,6 +85,9 @@ class TestImageProvider:
             ) -> ImageResult:
                 return ImageResult(image_data=b"")
 
+            async def discover_capabilities(self) -> None:
+                raise NotImplementedError
+
         assert isinstance(_Good(), ImageProvider)
 
     def test_non_provider_fails_isinstance(self) -> None:


### PR DESCRIPTION
## Summary

- `ModelCapabilities` and `ProviderCapabilities` frozen dataclasses with `to_dict()` serialization
- `ImageProvider` protocol extended with `discover_capabilities()` method
- `PlaceholderImageProvider` implements discovery with static capabilities
- OpenAI/A1111 gain stub `discover_capabilities()` (implemented in #28/#29)
- `ImageService.discover_all_capabilities()` with graceful degradation on failure
- `list_providers()` enriched with capability data (backward-compatible)
- Server lifespan calls discovery after provider registration
- 20 new tests covering dataclasses, discovery, degradation, and enriched responses

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | `ProviderCapabilities` dataclass with specified fields | ADR-0007, Data Model | CONFORMANT | `providers/capabilities.py:69-90` |
| 2 | `ModelCapabilities` dataclass with specified fields | ADR-0007, Data Model | CONFORMANT | `providers/capabilities.py:17-66` |
| 3 | `discover_capabilities()` protocol method | ADR-0007, Protocol Extension | CONFORMANT | `providers/types.py:92-104` |
| 4 | Discovery during lifespan after registration | ADR-0007, Discovery Timing | CONFORMANT | `_server_deps.py:76` |
| 5 | Capabilities immutable for server lifetime | ADR-0007, Discovery Timing | CONFORMANT | Frozen dataclasses, no refresh mechanism |
| 6 | Failure → degraded=True, empty models, server continues | ADR-0007, Failure Mode | CONFORMANT | `service.py:119-132`, test `test_failure_marks_degraded` |
| 7 | Placeholder: static capabilities | ADR-0007, Per-Provider Strategy | CONFORMANT | `placeholder.py:117-137` |
| 8 | list_providers enriched with capabilities | ADR-0007, Integration Points | CONFORMANT | `service.py:146-158` |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan

- [ ] `uv run pytest tests/test_capabilities.py -v` — 20 tests pass
- [ ] `uv run pytest tests/ -v` — full suite (159 tests) passes
- [ ] `uv run ruff check src/ tests/` — no lint errors

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)