### PR TITLE
feat: surface provider capabilities in MCP tools, resources, and selector

### DIFF
--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -24,6 +24,7 @@ from image_generation_mcp.processing import (
 )
 from image_generation_mcp.providers.types import (
     SUPPORTED_ASPECT_RATIOS,
+    SUPPORTED_BACKGROUNDS,
     SUPPORTED_QUALITY_LEVELS,
     ImageProviderError,
 )
@@ -63,6 +64,7 @@ def register_resources(mcp: FastMCP) -> None:
                 "providers": providers,
                 "supported_aspect_ratios": SUPPORTED_ASPECT_RATIOS,
                 "supported_quality_levels": SUPPORTED_QUALITY_LEVELS,
+                "supported_backgrounds": SUPPORTED_BACKGROUNDS,
             },
             indent=2,
         )

--- a/src/image_generation_mcp/providers/selector.py
+++ b/src/image_generation_mcp/providers/selector.py
@@ -3,14 +3,21 @@
 Analyzes prompts to select the best image generation provider,
 inspired by the claude-skills provider selector but simplified
 for the current provider set (OpenAI, A1111, Placeholder).
+
+Capabilities (when available) act as a secondary filter — providers
+without a required capability are deprioritized but not excluded.
 """
 
 from __future__ import annotations
 
 import logging
 import re
+from typing import TYPE_CHECKING
 
 from image_generation_mcp.providers.types import ImageProviderError
+
+if TYPE_CHECKING:
+    from image_generation_mcp.providers.capabilities import ProviderCapabilities
 
 logger = logging.getLogger(__name__)
 
@@ -74,12 +81,22 @@ _DEFAULT_CHAIN = ["openai", "a1111", "placeholder"]
 def select_provider(
     prompt: str,
     available_providers: set[str],
+    *,
+    capabilities: dict[str, ProviderCapabilities] | None = None,
+    background: str = "opaque",
 ) -> str:
     """Select the best provider for a prompt based on keyword analysis.
+
+    Keyword heuristics are the primary selection mechanism. When
+    *capabilities* are available, they act as a secondary filter —
+    providers without a required capability are deprioritized in the
+    candidate list but not excluded entirely.
 
     Args:
         prompt: The image generation prompt.
         available_providers: Set of currently registered provider names.
+        capabilities: Discovered capabilities per provider, if available.
+        background: Requested background mode (used for capability filtering).
 
     Returns:
         Name of the selected provider.
@@ -90,30 +107,48 @@ def select_provider(
     if not available_providers:
         raise ImageProviderError("auto", "No providers available")
 
+    # Build a capability-filtered view: capable providers first, then the rest
+    capable = available_providers
+    if capabilities and background == "transparent":
+        has_bg = {
+            name
+            for name in available_providers
+            if name in capabilities and capabilities[name].supports_background
+        }
+        if has_bg:
+            capable = has_bg
+            logger.debug(
+                "Capability filter: background=transparent → preferred providers: %s",
+                capable,
+            )
+
     prompt_lower = prompt.lower()
 
-    # Check each rule — first match wins
+    # Check each rule — first match wins (prefer capable providers)
     for keywords, preferred in _SELECTION_RULES:
         if _matches_any(prompt_lower, keywords):
-            for provider in preferred:
-                if provider in available_providers:
-                    matched_kw = next(
-                        kw
-                        for kw in keywords
-                        if re.search(r"\b" + re.escape(kw) + r"\b", prompt_lower)
-                    )
-                    logger.debug(
-                        "Provider selected by keyword: %s (matched: %s)",
-                        provider,
-                        matched_kw,
-                    )
-                    return provider
+            # Try capable providers first, then fall back to all available
+            for candidate_set in (capable, available_providers):
+                for provider in preferred:
+                    if provider in candidate_set:
+                        matched_kw = next(
+                            kw
+                            for kw in keywords
+                            if re.search(r"\b" + re.escape(kw) + r"\b", prompt_lower)
+                        )
+                        logger.debug(
+                            "Provider selected by keyword: %s (matched: %s)",
+                            provider,
+                            matched_kw,
+                        )
+                        return provider
 
-    # No keyword matched — use default fallback chain
-    for provider in _DEFAULT_CHAIN:
-        if provider in available_providers:
-            logger.debug("Provider selected by fallback chain: %s", provider)
-            return provider
+    # No keyword matched — use default fallback chain (prefer capable)
+    for candidate_set in (capable, available_providers):
+        for provider in _DEFAULT_CHAIN:
+            if provider in candidate_set:
+                logger.debug("Provider selected by fallback chain: %s", provider)
+                return provider
 
     # Last resort — return any available provider
     result = next(iter(available_providers))

--- a/src/image_generation_mcp/service.py
+++ b/src/image_generation_mcp/service.py
@@ -164,13 +164,18 @@ class ImageService:
         return result
 
     def _resolve_provider(
-        self, provider: str, prompt: str
+        self,
+        provider: str,
+        prompt: str,
+        *,
+        background: str = "opaque",
     ) -> tuple[str, ImageProvider]:
         """Resolve a provider name to an instance.
 
         Args:
             provider: Provider name or ``"auto"``.
             prompt: The generation prompt (used for auto-selection).
+            background: Requested background mode (used for capability filtering).
 
         Returns:
             Tuple of (resolved_name, provider_instance).
@@ -190,7 +195,12 @@ class ImageService:
         if provider == "auto":
             from image_generation_mcp.providers.selector import select_provider
 
-            selected = select_provider(prompt, set(self._providers))
+            selected = select_provider(
+                prompt,
+                set(self._providers),
+                capabilities=self._capabilities or None,
+                background=background,
+            )
             return selected, self._providers[selected]
 
         if provider not in self._providers:
@@ -229,8 +239,19 @@ class ImageService:
             ImageProviderError: If generation fails.
         """
         resolved_name, resolved_provider = self._resolve_provider(
-            provider or self._default_provider, prompt
+            provider or self._default_provider,
+            prompt,
+            background=background,
         )
+
+        # Warn if the resolved provider has degraded capabilities
+        caps = self._capabilities.get(resolved_name)
+        if caps and caps.degraded:
+            logger.warning(
+                "Generating with degraded provider %s — capability "
+                "discovery failed at startup",
+                resolved_name,
+            )
 
         logger.info(
             "Generating image with provider=%s, aspect_ratio=%s",

--- a/tests/test_mcp_capabilities_surface.py
+++ b/tests/test_mcp_capabilities_surface.py
@@ -1,0 +1,215 @@
+"""Tests for surfacing provider capabilities in MCP tools, resources, and selector."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from image_generation_mcp.providers.capabilities import (
+    ModelCapabilities,
+    ProviderCapabilities,
+)
+from image_generation_mcp.providers.placeholder import PlaceholderImageProvider
+from image_generation_mcp.providers.selector import select_provider
+from image_generation_mcp.service import ImageService
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def scratch_dir(tmp_path: Path) -> Path:
+    return tmp_path / "scratch"
+
+
+def _make_caps(
+    name: str,
+    *,
+    supports_background: bool = False,
+    supports_negative_prompt: bool = False,
+    degraded: bool = False,
+) -> ProviderCapabilities:
+    """Helper to create ProviderCapabilities with minimal boilerplate."""
+    models = ()
+    if not degraded:
+        models = (
+            ModelCapabilities(
+                model_id=f"{name}-model",
+                display_name=f"{name} Model",
+                supports_background=supports_background,
+                supports_negative_prompt=supports_negative_prompt,
+            ),
+        )
+    return ProviderCapabilities(
+        provider_name=name,
+        models=models,
+        supports_background=supports_background,
+        supports_negative_prompt=supports_negative_prompt,
+        discovered_at=1000.0,
+        degraded=degraded,
+    )
+
+
+# -- list_providers tool: full capabilities ----------------------------------
+
+
+class TestListProvidersFullCapabilities:
+    """Verify enriched list_providers response with model details."""
+
+    async def test_includes_model_details(self, scratch_dir: Path) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+        await svc.discover_all_capabilities()
+
+        providers = svc.list_providers()
+        caps = providers["placeholder"]["capabilities"]
+        assert len(caps["models"]) == 1
+        model = caps["models"][0]
+        assert model["model_id"] == "placeholder"
+        assert model["can_generate"] is True
+        assert "1:1" in model["supported_aspect_ratios"]
+
+    async def test_degraded_provider_marked(self, scratch_dir: Path) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+
+        mock = AsyncMock()
+        mock.discover_capabilities.side_effect = RuntimeError("API down")
+        mock.generate = AsyncMock()
+        svc.register_provider("broken", mock)
+        await svc.discover_all_capabilities()
+
+        providers = svc.list_providers()
+        caps = providers["broken"]["capabilities"]
+        assert caps["degraded"] is True
+        assert caps["models"] == []
+
+
+# -- info://providers resource: capability data -------------------------------
+
+
+class TestInfoProvidersResource:
+    """Verify JSON includes per-model capabilities."""
+
+    async def test_resource_includes_capabilities(self, scratch_dir: Path) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+        await svc.discover_all_capabilities()
+
+        providers = svc.list_providers()
+        data = {
+            "providers": providers,
+            "supported_aspect_ratios": ("1:1", "16:9", "9:16", "3:2", "2:3"),
+            "supported_quality_levels": ("standard", "hd"),
+            "supported_backgrounds": ("opaque", "transparent"),
+        }
+        payload = json.loads(json.dumps(data))
+        prov = payload["providers"]["placeholder"]
+        assert "capabilities" in prov
+        assert prov["capabilities"]["provider_name"] == "placeholder"
+        assert len(prov["capabilities"]["models"]) == 1
+
+    async def test_resource_includes_backgrounds(self) -> None:
+        # Verify supported_backgrounds is part of the response shape
+        from image_generation_mcp.providers.types import SUPPORTED_BACKGROUNDS
+
+        assert "transparent" in SUPPORTED_BACKGROUNDS
+        assert "opaque" in SUPPORTED_BACKGROUNDS
+
+
+# -- Selector: capability-aware filtering ------------------------------------
+
+
+class TestSelectorCapabilityFiltering:
+    """Verify selector deprioritizes providers without required capability."""
+
+    def test_deprioritizes_no_background(self) -> None:
+        """Provider with supports_background=True preferred for transparent."""
+        caps = {
+            "openai": _make_caps("openai", supports_background=True),
+            "a1111": _make_caps("a1111", supports_background=False),
+        }
+        # Default chain would pick openai anyway — test with a prompt
+        # that normally prefers a1111 (photorealism)
+        result = select_provider(
+            "realistic photo portrait",
+            {"openai", "a1111"},
+            capabilities=caps,
+            background="transparent",
+        )
+        assert result == "openai"
+
+    def test_falls_back_when_no_capable_provider(self) -> None:
+        """Falls back to keyword-based selection when no provider has capability."""
+        caps = {
+            "a1111": _make_caps("a1111", supports_background=False),
+        }
+        result = select_provider(
+            "realistic photo",
+            {"a1111"},
+            capabilities=caps,
+            background="transparent",
+        )
+        assert result == "a1111"  # only option, still selected
+
+    def test_without_capabilities_unchanged(self) -> None:
+        """Keyword heuristics work when capabilities=None."""
+        result = select_provider(
+            "a professional logo",
+            {"openai", "a1111", "placeholder"},
+            capabilities=None,
+        )
+        assert result == "openai"
+
+    def test_opaque_background_no_filtering(self) -> None:
+        """No capability filtering for opaque background (default)."""
+        caps = {
+            "openai": _make_caps("openai", supports_background=True),
+            "a1111": _make_caps("a1111", supports_background=False),
+        }
+        # "realistic photo" normally prefers a1111
+        result = select_provider(
+            "realistic photo portrait",
+            {"openai", "a1111"},
+            capabilities=caps,
+            background="opaque",
+        )
+        assert result == "a1111"
+
+
+# -- Degraded provider warning on generate -----------------------------------
+
+
+class TestDegradedProviderWarning:
+    """Verify degraded provider logs warning during generation."""
+
+    async def test_degraded_logs_warning(
+        self, scratch_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+
+        # Manually set degraded capabilities
+        from image_generation_mcp.providers.capabilities import make_degraded
+
+        svc._capabilities["placeholder"] = make_degraded("placeholder", 1000.0)
+
+        with caplog.at_level(logging.WARNING):
+            await svc.generate("test", provider="placeholder")
+
+        assert any("degraded" in r.message.lower() for r in caplog.records)
+
+    async def test_non_degraded_no_warning(
+        self, scratch_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        svc = ImageService(scratch_dir=scratch_dir)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+        await svc.discover_all_capabilities()
+
+        with caplog.at_level(logging.WARNING):
+            await svc.generate("test", provider="placeholder")
+
+        assert not any("degraded" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Summary\n\n- Enrich `list_providers()` with full serialized `ProviderCapabilities` per provider (model list, supports_background, degraded, etc.)\n- `info://providers` resource returns `supported_backgrounds` alongside existing aspect ratios and quality levels\n- `select_provider()` gains `capabilities` and `background` params — deprioritizes providers without `supports_background=True` for transparent requests\n- Keyword heuristics remain primary selection; capabilities act as secondary filter\n- `_resolve_provider()` passes capabilities to selector when available\n- Degraded providers log warning during generation (don't block)\n\nMerges three parallel branches:\n- `feat/openai-discovery` (#47 / closes #28)\n- `feat/a1111-discovery` (#48 / closes #29)\n- `feat/background-param` (#49 / closes #30)\n\n## Design Conformance\n\n| # | Requirement | Source | Status | Evidence |\n|---|---|---|---|---|\n| 1 | list_providers includes full ProviderCapabilities | Issue #31, AC1 | CONFORMANT | `service.py:161-162` — `to_dict()` serialization |\n| 2 | Human-readable description field | Issue #31, AC2 | CONFORMANT | `service.py:134-146` — `_PROVIDER_DESCRIPTIONS` |\n| 3 | info://providers returns full capability JSON | Issue #31, AC3 | CONFORMANT | `_server_resources.py:62-70` |\n| 4 | Degraded providers marked | Issue #31, AC4 | CONFORMANT | `capabilities.py` — `degraded=True` in `make_degraded()` |\n| 5 | select_provider gains capabilities param | Issue #31, AC5 | CONFORMANT | `selector.py:85` signature |\n| 6 | Transparent background deprioritizes non-capable | Issue #31, AC6 | CONFORMANT | `selector.py:112-123` — capability filter |\n| 7 | Keywords remain primary mechanism | Issue #31, AC7 | CONFORMANT | `selector.py:128-144` — keywords checked first |\n| 8 | _resolve_provider passes capabilities | Issue #31, AC8 | CONFORMANT | `service.py:198-203` |\n| 9 | Degraded provider warning on generate | Issue #31, AC9 | CONFORMANT | `service.py:248-254` |\n\nReviewed by @architect-reviewer — all requirements CONFORMANT.\n\n## Test plan\n\n- [x] 10 new tests in `test_mcp_capabilities_surface.py`\n- [x] Full suite: 237 tests pass\n- [x] Lint clean (`ruff check` + `ruff format --check`)\n\nCloses #31\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"