### PR TITLE
refactor: derive ProviderCapabilities.supports_* as properties from models (#53)

### DIFF
--- a/src/image_generation_mcp/providers/a1111.py
+++ b/src/image_generation_mcp/providers/a1111.py
@@ -377,7 +377,5 @@ class A1111ImageProvider:
         return ProviderCapabilities(
             provider_name="a1111",
             models=tuple(model_caps),
-            supports_negative_prompt=True,
-            supports_background=False,
             discovered_at=discovered_at,
         )

--- a/src/image_generation_mcp/providers/capabilities.py
+++ b/src/image_generation_mcp/providers/capabilities.py
@@ -73,18 +73,28 @@ class ProviderCapabilities:
     Attributes:
         provider_name: Registry key (e.g., ``"openai"``).
         models: Per-model capability details.
-        supports_background: ``True`` if any model supports background control.
-        supports_negative_prompt: ``True`` if any model supports negative prompts.
         discovered_at: Unix timestamp when discovery completed.
         degraded: ``True`` if discovery failed (empty model list).
+        supports_background: ``True`` if any model supports background control
+            (derived from ``models``).
+        supports_negative_prompt: ``True`` if any model supports negative prompts
+            (derived from ``models``).
     """
 
     provider_name: str
     models: tuple[ModelCapabilities, ...] = ()
-    supports_background: bool = False
-    supports_negative_prompt: bool = False
     discovered_at: float = 0.0
     degraded: bool = False
+
+    @property
+    def supports_background(self) -> bool:
+        """Return True if any model in this provider supports background control."""
+        return any(m.supports_background for m in self.models)
+
+    @property
+    def supports_negative_prompt(self) -> bool:
+        """Return True if any model in this provider supports negative prompts."""
+        return any(m.supports_negative_prompt for m in self.models)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""

--- a/src/image_generation_mcp/providers/openai.py
+++ b/src/image_generation_mcp/providers/openai.py
@@ -322,14 +322,8 @@ class OpenAIImageProvider:
                 )
             )
 
-        supports_background = any(m.supports_background for m in model_caps)
-
         return ProviderCapabilities(
             provider_name="openai",
             models=tuple(model_caps),
-            supports_background=supports_background,
-            # OpenAI has no native negative prompt API parameter; the provider
-            # implements it by appending "Avoid: ..." to the prompt text.
-            supports_negative_prompt=False,
             discovered_at=discovered_at,
         )

--- a/src/image_generation_mcp/providers/placeholder.py
+++ b/src/image_generation_mcp/providers/placeholder.py
@@ -160,7 +160,5 @@ class PlaceholderImageProvider:
         return ProviderCapabilities(
             provider_name="placeholder",
             models=(model,),
-            supports_background=True,
-            supports_negative_prompt=False,
             discovered_at=time.time(),
         )

--- a/tests/test_a1111_discovery.py
+++ b/tests/test_a1111_discovery.py
@@ -463,7 +463,7 @@ class TestA1111DiscoverProviderLevelFlags:
         caps = await provider.discover_capabilities()
         assert caps.degraded is False
         assert caps.models == ()
-        assert caps.supports_negative_prompt is True
+        assert caps.supports_negative_prompt is False
 
 
 # -- Response validation tests -----------------------------------------------

--- a/tests/test_mcp_capabilities_surface.py
+++ b/tests/test_mcp_capabilities_surface.py
@@ -47,8 +47,6 @@ def _make_caps(
     return ProviderCapabilities(
         provider_name=name,
         models=models,
-        supports_background=supports_background,
-        supports_negative_prompt=supports_negative_prompt,
         discovered_at=1000.0,
         degraded=degraded,
     )


### PR DESCRIPTION
## Summary

- Converts `supports_background` and `supports_negative_prompt` from dataclass fields to `@property` methods derived from `models`
- Updates all provider constructors and tests to remove the explicit boolean arguments
- Fixes latent bug where an empty checkpoint list incorrectly reported `supports_negative_prompt=True`

Closes #53

## Design Conformance

| # | Requirement | Status |
|---|-------------|--------|
| 1 | `supports_background` and `supports_negative_prompt` become `@property` methods | CONFORMANT |
| 2 | `to_dict()` still includes them in output | CONFORMANT |
| 3 | `make_degraded()` returns correct values (both False when models empty) | CONFORMANT |
| 4 | All callers updated (no constructor args) | CONFORMANT |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test Plan
- All existing tests updated and passing
- `make_degraded()` with empty models verified to return `False` for both properties

## Risk / Rollback
- No external API surface changed; `to_dict()` output is unchanged
- Bug fix in empty-model case is low-risk (previously incorrect value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)