### PR TITLE
fix: add Flux prompt guidance and prompt_style metadata (#114)

### DIFF
--- a/docs/design/provider-system.md
+++ b/docs/design/provider-system.md
@@ -170,7 +170,7 @@ Compatible with AUTOMATIC1111, Forge, reForge, and Forge-neo.
 - **Checkpoint override:** When `model` is specified, sends `override_settings.sd_model_checkpoint`
 - **Negative prompt:** Native support via `negative_prompt` field in payload
 - **Background:** Ignored (SD does not support native transparent backgrounds); debug log emitted
-- **Discovery:** Calls `/sdapi/v1/sd-models` + `/sdapi/v1/options`, maps checkpoints to architecture-specific `ModelCapabilities`
+- **Discovery:** Calls `/sdapi/v1/sd-models` + `/sdapi/v1/options`, maps checkpoints to architecture-specific `ModelCapabilities`; `prompt_style` is populated per-architecture (`"clip"` for SD 1.5/SDXL, `"natural_language"` for Flux)
 - **Metadata:** Extracts seed and active model name from response `info` JSON
 - **Timeout:** 180s (SDXL at high res on consumer GPUs)
 - **Registered when:** `IMAGE_GENERATION_MCP_SD_WEBUI_HOST` is set (deprecated alias: `IMAGE_GENERATION_MCP_A1111_HOST`)
@@ -308,7 +308,7 @@ The `image://{id}/view` resource template supports:
 | Prompt | Description |
 |--------|-------------|
 | `select_provider` | Guides Claude on provider strengths and selection criteria |
-| `sd_prompt_guide` | Guides Claude on CLIP-based tag format, negative prompts, BREAK syntax |
+| `sd_prompt_guide` | Guides Claude on SD prompt writing: CLIP tag format for SD 1.5/SDXL, natural language for Flux, negative prompts, BREAK syntax |
 
 ## Configuration
 

--- a/docs/providers/sd-webui.md
+++ b/docs/providers/sd-webui.md
@@ -113,6 +113,30 @@ Used when checkpoint name contains both `flux` and `schnell`. Optimized for fast
 
 Sizes are the same as SDXL.
 
+## Prompt style
+
+Different SD architectures use different prompt styles. Check `list_providers` to see each model's `prompt_style` field.
+
+### SD 1.5 / SDXL / Lightning (`prompt_style: "clip"`)
+
+Use comma-separated CLIP tags ordered by importance. Include quality tags (`masterpiece, best quality`) and a negative prompt for best results. See the [Prompt Writing Guide](../guides/prompt-writing.md) for detailed tag recommendations and BREAK syntax.
+
+### Flux (`prompt_style: "natural_language"`)
+
+Flux models use a T5 text encoder instead of CLIP. Write prompts as natural language descriptions — complete sentences, not comma-separated tags.
+
+**Do NOT use with Flux:**
+- Quality tags (`masterpiece`, `best quality`) — meaningless to T5
+- Negative prompts — Flux does not support them (the server omits them automatically)
+- `BREAK` syntax — Flux does not use CLIP chunking
+
+**Example:**
+```
+A dramatic mountain landscape at sunset with towering peaks reflected
+in a perfectly still alpine lake, storm clouds lit orange and purple
+by the setting sun
+```
+
 ## Checkpoint override
 
 ### Server default (env var)

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -32,7 +32,8 @@ Provider capabilities and supported features.
             "supports_background": true,
             "max_resolution": 640,
             "default_steps": null,
-            "default_cfg": null
+            "default_cfg": null,
+            "prompt_style": null
           }
         ],
         "supports_background": true,
@@ -60,7 +61,8 @@ Provider capabilities and supported features.
             "supports_background": true,
             "max_resolution": 1536,
             "default_steps": null,
-            "default_cfg": null
+            "default_cfg": null,
+            "prompt_style": null
           }
         ],
         "supports_background": true,
@@ -92,7 +94,7 @@ Markdown document covering:
 
 - **General tips** — aspect ratio selection, quality levels, when to use negative prompts
 - **OpenAI** — natural-language prompts, style keywords, text rendering tips
-- **SD WebUI (Stable Diffusion)** — CLIP tag format, negative prompts, BREAK syntax, model-specific advice
+- **SD WebUI (Stable Diffusion)** — CLIP tags for SD 1.5/SDXL, natural language for Flux, negative prompts, BREAK syntax, model-specific advice
 - **Placeholder** — prompt-to-color mapping explanation
 
 The `generate_image` tool description references this resource. LLM clients can read it before generating images to produce better prompts.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,7 +17,7 @@ Generate an image from a text prompt. Returns metadata with resource URIs and a 
 |-----------|------|---------|-------------|
 | `prompt` | str | *(required)* | Text description of the desired image |
 | `provider` | str | `"auto"` | Provider name (`openai`, `sd_webui`, `placeholder`) or `"auto"` for keyword-based selection |
-| `negative_prompt` | str | `null` | Things to avoid in the image. Native support on SD WebUI; appended as "Avoid:" on OpenAI. |
+| `negative_prompt` | str | `null` | Things to avoid in the image. Native support on SD WebUI (SD 1.5/SDXL only — Flux models do NOT support negative prompts); appended as "Avoid:" on OpenAI. |
 | `aspect_ratio` | str | `"1:1"` | Desired ratio: `1:1`, `16:9`, `9:16`, `3:2`, `2:3` |
 | `quality` | str | `"standard"` | Quality level: `standard` or `hd` |
 | `background` | str | `"opaque"` | Background mode: `opaque` or `transparent`. Supported by OpenAI (gpt-image-1) and Placeholder. SD WebUI ignores this parameter. |
@@ -185,7 +185,8 @@ JSON object with provider names, availability, and capability information:
           "supports_background": true,
           "max_resolution": 640,
           "default_steps": null,
-          "default_cfg": null
+          "default_cfg": null,
+          "prompt_style": null
         }
       ],
       "supports_background": true,
@@ -213,7 +214,8 @@ JSON object with provider names, availability, and capability information:
           "supports_background": true,
           "max_resolution": 1536,
           "default_steps": null,
-          "default_cfg": null
+          "default_cfg": null,
+          "prompt_style": null
         }
       ],
       "supports_background": true,
@@ -226,6 +228,8 @@ JSON object with provider names, availability, and capability information:
 ```
 
 Only registered (configured) providers appear in the response. The `capabilities` key is present after startup discovery completes. Degraded providers (where capability discovery failed) show `"degraded": true` with an empty model list.
+
+The `prompt_style` field on each model indicates the recommended prompt format: `"clip"` for SD 1.5/SDXL checkpoints (tag-based), `"natural_language"` for Flux checkpoints, and `null` for providers that do not set a preference (OpenAI, Placeholder).
 
 ### Example
 

--- a/src/image_generation_mcp/_server_prompts.py
+++ b/src/image_generation_mcp/_server_prompts.py
@@ -27,9 +27,12 @@ Choose the best provider for the user's request based on these guidelines:
 ### SD WebUI (Stable Diffusion WebUI)
 - **Best for:** Photorealism, portraits, product shots, artistic styles
 - **Good at:** Anime/manga, watercolor, oil painting, illustration
-- **Supports:** Native negative prompt, fine-grained parameter control
-- **Prompt style:** Comma-separated tags work best (see sd_prompt_guide)
+- **Supports:** Native negative prompt (SD 1.5/SDXL only), fine-grained parameter control
+- **Prompt style depends on the loaded model:**
+  - **SD 1.5 / SDXL:** Comma-separated CLIP tags (see sd_prompt_guide)
+  - **Flux (dev/schnell):** Natural language descriptions, like OpenAI (see sd_prompt_guide)
 - **Note:** Compatible with A1111, Forge, reForge, and Forge-neo
+- Check `list_providers` for each model's `prompt_style` field
 
 ### Placeholder
 - **Best for:** Quick drafts, testing, mock-ups
@@ -52,13 +55,13 @@ providers are currently available.
 """
 
 _SD_PROMPT_GUIDE = """\
-When generating images with the SD WebUI (Stable Diffusion) provider, format
-prompts as comma-separated tags for best results. This guide covers the
-CLIP-based prompt format used by Stable Diffusion models.
+Guide for writing SD WebUI prompts. The correct prompt style depends on the
+model architecture — check `list_providers` to see which models are loaded.
 
-## Prompt Format
+## SD 1.5 / SDXL — CLIP Tag Format
 
-Use comma-separated descriptive tags, ordered by importance:
+These models use a CLIP text encoder. Format prompts as comma-separated
+descriptive tags ordered by importance:
 
 ```
 subject, medium, style, lighting, camera, quality tags
@@ -84,7 +87,7 @@ white sneakers, product photography, studio lighting, white background,
 sharp focus, commercial photography, high resolution
 ```
 
-## Quality Tags
+### Quality Tags
 
 Add these to improve output quality:
 - `masterpiece, best quality` — general quality boost
@@ -92,7 +95,7 @@ Add these to improve output quality:
 - `8k, ultra high res` — resolution boost (use sparingly)
 - `professional, award winning` — style refinement
 
-## Negative Prompt
+### Negative Prompt
 
 Always include a negative prompt to avoid common artifacts:
 
@@ -113,7 +116,7 @@ cartoon, anime, illustration, painting, drawing, art, sketch
 photo, realistic, 3d render
 ```
 
-## CLIP Token Limits
+### CLIP Token Limits
 
 - **SD 1.5:** 77 tokens per CLIP chunk. Use `BREAK` to start a new chunk.
 - **SDXL:** 77 tokens per chunk, but two CLIP encoders (ViT-L + ViT-bigG).
@@ -121,7 +124,7 @@ photo, realistic, 3d render
 Keep prompts concise. Front-load the most important tags — tokens beyond
 the first 77-token chunk have diminishing influence.
 
-## BREAK Syntax
+### BREAK Syntax
 
 Use `BREAK` to separate prompt concepts into different CLIP chunks:
 
@@ -131,6 +134,48 @@ forest background, sunlight through trees BREAK
 masterpiece, best quality, sharp focus
 ```
 
+## Flux — Natural Language Format
+
+Flux models (flux-dev, flux-schnell) use a T5 text encoder, NOT CLIP.
+Write prompts as natural language descriptions — the same style as OpenAI.
+
+**Key differences from SD 1.5 / SDXL:**
+- Use complete sentences, not comma-separated tags
+- Do NOT include quality tags (`masterpiece`, `best quality`) — they are meaningless to Flux
+- Do NOT write a negative prompt — Flux does not support them (the server omits them automatically)
+- Do NOT use `BREAK` syntax — Flux does not use CLIP chunking
+- CFG scale and sampler are handled automatically by the server
+
+### Flux Example Prompts
+
+**Portrait:**
+```
+A young woman with long flowing hair and striking blue eyes wearing a
+school uniform, standing beneath cherry blossom trees with soft natural
+light filtering through the petals
+```
+
+**Landscape:**
+```
+A dramatic mountain landscape at sunset with towering peaks reflected in
+a perfectly still alpine lake, storm clouds lit orange and purple by the
+setting sun
+```
+
+**Product shot:**
+```
+A pair of pristine white sneakers on a clean white background, shot from
+a three-quarter angle with professional studio lighting and crisp focus
+```
+
+### Flux Schnell vs Flux Dev
+
+- **Flux Schnell:** 4 steps, fastest generation (~5-10s). Good for drafts.
+- **Flux Dev:** 20 steps, higher quality (~60-120s). Use for final output.
+
+Both use Euler sampler, Simple scheduler, CFG 1.0, and distilled CFG 3.5
+(all set automatically by the server).
+
 ## Aspect Ratios
 
 Supported aspect ratios: `1:1`, `16:9`, `9:16`, `3:2`, `2:3`.
@@ -138,15 +183,29 @@ The server maps these to optimal pixel dimensions for each SD model.
 
 ## Workflow
 
-1. Draft your prompt using comma-separated tags (subject first)
-2. Add quality tags and a negative prompt
-3. Call `generate_image` with `provider="sd_webui"`:
+1. Check `list_providers` to see available models and their `prompt_style`
+   (`"clip"` for SD 1.5/SDXL, `"natural_language"` for Flux)
+2. Write your prompt in the appropriate style for the model
+3. For SD 1.5/SDXL: add quality tags and a negative prompt
+4. For Flux: write a natural language description, skip negative prompt
+5. Call `generate_image` with `provider="sd_webui"`:
 
+**SD 1.5 / SDXL example:**
 ```
 generate_image(
     prompt="1girl, long hair, school uniform, cherry blossoms, masterpiece, best quality",
     negative_prompt="lowres, bad anatomy, bad hands, worst quality, low quality",
     provider="sd_webui",
+    aspect_ratio="2:3"
+)
+```
+
+**Flux example:**
+```
+generate_image(
+    prompt="A young woman with long hair in a school uniform standing beneath cherry blossom trees",
+    provider="sd_webui",
+    model="flux1-dev-bnb-nf4-v2.safetensors",
     aspect_ratio="2:3"
 )
 ```
@@ -178,8 +237,8 @@ def register_prompts(mcp: FastMCP) -> None:
     @mcp.prompt(
         name="sd_prompt_guide",
         description=(
-            "Guide for writing Stable Diffusion prompts "
-            "(CLIP tag format, negative prompts, BREAK syntax)"
+            "Guide for writing SD WebUI prompts — "
+            "CLIP tags for SD 1.5/SDXL, natural language for Flux"
         ),
         icons=[Icon(src=_LUCIDE.format("book-open-text"), mimeType="image/svg+xml")],
     )

--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -74,6 +74,12 @@ maps both to its highest quality tier.
 
 ## SD WebUI / Stable Diffusion
 
+SD WebUI supports multiple model architectures with different prompt styles.
+Check `list_providers` to see each model's `prompt_style` field (`"clip"` or
+`"natural_language"`).
+
+### SD 1.5 / SDXL (CLIP-based models)
+
 Use comma-separated CLIP tags for best results. Order tags by importance —
 tokens near the front of the prompt have the most influence.
 
@@ -137,6 +143,44 @@ masterpiece, best quality, sharp focus
   photorealism and high-detail scenes. Use for final-quality output.
 - **SDXL Lightning/Turbo** — Distilled models, only 6 steps needed, CFG 2.0.
   Very fast but less controllable. Good for rapid iteration.
+
+### Flux (natural language)
+
+Flux models use a T5 text encoder, NOT CLIP. Write prompts as natural language
+descriptions — the same style as OpenAI.
+
+**Key differences from SD 1.5 / SDXL:**
+- Use complete sentences, not comma-separated tags
+- Do NOT include quality tags (`masterpiece`, `best quality`) — meaningless to Flux
+- Do NOT write a negative prompt — Flux does not support them
+- Do NOT use `BREAK` syntax — Flux does not use CLIP chunking
+- CFG scale and sampler are handled automatically by the server
+
+**Example prompts:**
+
+Portrait:
+```
+A young woman with long flowing hair and striking blue eyes wearing a
+school uniform, standing beneath cherry blossom trees with soft natural
+light filtering through the petals
+```
+
+Landscape:
+```
+A dramatic mountain landscape at sunset with towering peaks reflected in
+a perfectly still alpine lake, storm clouds lit orange and purple by the
+setting sun
+```
+
+Product shot:
+```
+A pair of pristine white sneakers on a clean white background, shot from
+a three-quarter angle with professional studio lighting and crisp focus
+```
+
+**Flux Schnell vs Flux Dev:**
+- **Flux Schnell:** 4 steps, fastest generation. Good for drafts and iteration.
+- **Flux Dev:** 20 steps, higher quality. Use for final output.
 
 ## Placeholder
 

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -86,8 +86,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         """Generate an image and return metadata with resource URIs.
 
         Call list_providers first to see available providers and model IDs.
-        Read info://prompt-guide for provider-specific prompt writing tips
-        (especially important for SD WebUI/Stable Diffusion CLIP tag format).
+        Read info://prompt-guide for provider-specific prompt writing tips.
+        SD WebUI prompt style depends on the model: use CLIP tags for
+        SD 1.5/SDXL, natural language for Flux (check ``prompt_style`` in
+        list_providers or in the returned metadata).
         Returns metadata including the image_id and resource URIs. Call
         show_image with the image URI (e.g. ``image://{image_id}/view``) to
         display the image.
@@ -101,8 +103,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 ``"placeholder"`` — instant zero-cost solid-color PNG
                 for testing.
             negative_prompt: Things to avoid in the image. SD WebUI
-                supports this natively via CLIP. OpenAI appends as an
-                "Avoid:" clause (weaker effect). Placeholder ignores it.
+                supports this natively for SD 1.5/SDXL (CLIP-based) but
+                NOT for Flux models. OpenAI appends as an "Avoid:" clause
+                (weaker effect). Placeholder ignores it.
             aspect_ratio: Desired ratio (``1:1``, ``16:9``, ``9:16``,
                 ``3:2``, ``2:3``).
             quality: Quality level. ``"hd"`` vs ``"standard"`` only

--- a/src/image_generation_mcp/providers/capabilities.py
+++ b/src/image_generation_mcp/providers/capabilities.py
@@ -31,6 +31,9 @@ class ModelCapabilities:
         max_resolution: Maximum dimension in pixels, or ``None`` if unlimited.
         default_steps: Default inference steps (SD WebUI-specific), or ``None``.
         default_cfg: Default CFG scale (SD WebUI-specific), or ``None``.
+        prompt_style: Recommended prompt format — ``"clip"`` for CLIP-tag
+            models (SD 1.5, SDXL), ``"natural_language"`` for T5-based
+            models (Flux), or ``None`` for providers without guidance.
     """
 
     model_id: str
@@ -46,6 +49,7 @@ class ModelCapabilities:
     max_resolution: int | None = None
     default_steps: int | None = None
     default_cfg: float | None = None
+    prompt_style: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -63,6 +67,7 @@ class ModelCapabilities:
             "max_resolution": self.max_resolution,
             "default_steps": self.default_steps,
             "default_cfg": self.default_cfg,
+            "prompt_style": self.prompt_style,
         }
 
 

--- a/src/image_generation_mcp/providers/sd_webui.py
+++ b/src/image_generation_mcp/providers/sd_webui.py
@@ -54,6 +54,7 @@ class _SdWebuiPreset:
     quality_tier: str = "medium"
     supports_negative_prompt: bool = True
     distilled_cfg_scale: float | None = None
+    prompt_style: str = "clip"
 
 
 _SD15_PRESET = _SdWebuiPreset(
@@ -101,6 +102,7 @@ _FLUX_DEV_PRESET = _SdWebuiPreset(
     quality_tier="high",
     supports_negative_prompt=False,
     distilled_cfg_scale=3.5,
+    prompt_style="natural_language",
 )
 
 _FLUX_SCHNELL_PRESET = _SdWebuiPreset(
@@ -112,6 +114,7 @@ _FLUX_SCHNELL_PRESET = _SdWebuiPreset(
     quality_tier="high",
     supports_negative_prompt=False,
     distilled_cfg_scale=3.5,
+    prompt_style="natural_language",
 )
 
 _XL_TAGS = ("sdxl", "xl_", "_xl", "-xl")
@@ -313,6 +316,7 @@ class SdWebuiImageProvider:
             "model": active_model,
             "size": f"{width}x{height}",
             "steps": effective_preset.steps,
+            "prompt_style": effective_preset.prompt_style,
         }
         if seed is not None:
             metadata["seed"] = seed
@@ -429,6 +433,7 @@ class SdWebuiImageProvider:
                     max_resolution=max_resolution,
                     default_steps=preset.steps,
                     default_cfg=preset.cfg_scale,
+                    prompt_style=preset.prompt_style,
                 )
             )
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -45,6 +45,7 @@ class TestModelCapabilities:
         assert mc.max_resolution is None
         assert mc.default_steps is None
         assert mc.default_cfg is None
+        assert mc.prompt_style is None
 
     def test_to_dict(self) -> None:
         mc = ModelCapabilities(
@@ -61,6 +62,8 @@ class TestModelCapabilities:
         assert d["supported_formats"] == ["png", "webp"]
         assert d["supports_background"] is True
         assert d["max_resolution"] == 1536
+        assert "prompt_style" in d
+        assert d["prompt_style"] is None
 
     def test_to_dict_returns_lists_not_tuples(self) -> None:
         mc = ModelCapabilities(

--- a/tests/test_sd_webui_discovery.py
+++ b/tests/test_sd_webui_discovery.py
@@ -349,6 +349,7 @@ class TestSdWebuiDiscoverCapabilitiesSuccess:
         assert sd15.max_resolution == 768
         assert sd15.default_steps == 30
         assert sd15.default_cfg == 7.0
+        assert sd15.prompt_style == "clip"
         assert "1:1" in sd15.supported_aspect_ratios
         assert "16:9" in sd15.supported_aspect_ratios
 
@@ -363,6 +364,7 @@ class TestSdWebuiDiscoverCapabilitiesSuccess:
         assert sdxl.max_resolution == 1024
         assert sdxl.default_steps == 35
         assert sdxl.default_cfg == 7.5
+        assert sdxl.prompt_style == "clip"
 
     async def test_lightning_model_capabilities(self) -> None:
         provider = _make_provider()
@@ -683,6 +685,7 @@ class TestSdWebuiDiscoverFluxModels:
         assert flux_dev.default_steps == 20
         assert flux_dev.default_cfg == 1.0
         assert flux_dev.supports_negative_prompt is False
+        assert flux_dev.prompt_style == "natural_language"
 
     async def test_flux_schnell_capabilities(self) -> None:
         provider = _make_provider()
@@ -696,6 +699,7 @@ class TestSdWebuiDiscoverFluxModels:
         assert flux_schnell.default_steps == 4
         assert flux_schnell.default_cfg == 1.0
         assert flux_schnell.supports_negative_prompt is False
+        assert flux_schnell.prompt_style == "natural_language"
 
     async def test_provider_supports_negative_prompt_mixed(self) -> None:
         """Provider-level flag is True when at least one model supports it."""


### PR DESCRIPTION
## Summary
- Add `prompt_style` field to `ModelCapabilities` (`"clip"` for SD 1.5/SDXL, `"natural_language"` for Flux, `null` for others)
- Split SD prompt guide into CLIP tag format (SD 1.5/SDXL) and natural language (Flux) sections
- Update `generate_image` docstring to mention `prompt_style` guidance
- Update docs/tools.md and docs/design/provider-system.md with prompt_style documentation
- Add prompt_style tests for capabilities and SD WebUI discovery

Closes #114

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | prompt_style field in ModelCapabilities | Issue #114, AC 1 | CONFORMANT | capabilities.py:52 |
| 2 | SD WebUI populates prompt_style per architecture | Issue #114, AC 1 | CONFORMANT | sd_webui.py:57 (clip), sd_webui.py:105 (natural_language) |
| 3 | SD prompt guide split for CLIP vs natural language | Issue #114, AC 2 | CONFORMANT | _server_prompts.py:61, :137 |
| 4 | generate_image mentions prompt_style | Issue #114, AC 3 | CONFORMANT | _server_tools.py:90-92 |
| 5 | list_providers includes prompt_style | Issue #114, AC 4 | CONFORMANT | capabilities.py:70 to_dict() |
| 6 | docs/tools.md updated | CLAUDE.md mandate | CONFORMANT | docs/tools.md prompt_style in examples |
| 7 | docs/design/provider-system.md updated | CLAUDE.md mandate | CONFORMANT | sd_prompt_guide description, discovery bullet |
| 8 | Tests for prompt_style | Testing | CONFORMANT | test_capabilities.py, test_sd_webui_discovery.py |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan
- [ ] `uv run pytest tests/test_capabilities.py -x` passes (prompt_style defaults and serialization)
- [ ] `uv run pytest tests/test_sd_webui_discovery.py -x` passes (per-architecture prompt_style)
- [ ] `uv run pytest tests/test_sd_webui_provider.py -x` passes (prompt_style in metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Stack:** PR 1/4 — `fix/flux-prompt-guide` → `main`