### PR TITLE
fix: remove non-functional download button from image viewer widget

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -233,4 +233,6 @@ This resource is an [MCP App](https://modelcontextprotocol.io/specification/2025
 
 The viewer persists rendered images in `localStorage` (keyed by image ID, LRU-capped at 5 entries). When a new widget instance loads, the `ontoolinput` handler restores cached state immediately so the image is visible before the tool result arrives. The live `ontoolresult` always takes precedence over the cached version.
 
+The widget does not render download links — the sandboxed iframe cannot navigate to external URLs. When `download_url` is present in the `show_image` metadata, the LLM should present it directly to the user as a clickable link in the conversation text.
+
 Clients without MCP Apps support ignore this resource entirely.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -133,7 +133,7 @@ Returns a `ToolResult` with:
 
 The `model` field contains the specific model used by the provider (e.g., `"gpt-image-1"`, `"dreamshaper_xl"`), or `null` if the provider does not report a model name.
 
-The `download_url` field is only present when `with_link` is `true` (default) and the server is running on HTTP transport with `IMAGE_GENERATION_MCP_BASE_URL` configured. The link is a one-time download URL (5-minute TTL) — see `create_download_link` for details.
+The `download_url` field is only present when `with_link` is `true` (default) and the server is running on HTTP transport with `IMAGE_GENERATION_MCP_BASE_URL` configured. The link is a one-time download URL (5-minute TTL) — see `create_download_link` for details. The MCP App widget cannot open this URL from its sandboxed iframe, so LLMs should present it directly to the user as a clickable link in the conversation text.
 
 The `dimensions` field reports the actual image size (or the transformed size if transforms were requested). The `thumbnail_dimensions` field reports the size of the inline preview, which is capped at 512px. When `dimensions` and `thumbnail_dimensions` differ, the inline preview is a downscaled version — use the `image://` resource URI or `create_download_link` for full resolution.
 
@@ -345,7 +345,6 @@ The viewer is a custom HTML resource at `ui://image-viewer/view.html` that:
 
 - Listens for `show_image` tool results via the `@modelcontextprotocol/ext-apps` SDK
 - Displays the image with metadata (prompt, provider, model name, dimensions, file size)
-- Shows a "Download full resolution" button when `download_url` is available
 - Supports light and dark color schemes
 
 No configuration is needed — the viewer activates automatically on MCP Apps-capable clients. Clients without Apps support see the standard base64 image + metadata response.

--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -228,15 +228,7 @@ _IMAGE_VIEWER_HTML = """\
       margin-top: 12px; font-size: 12px; color: #666;
       line-height: 1.6; width: 100%; white-space: pre-wrap;
     }
-    #download {
-      display: inline-block; margin-top: 10px; padding: 6px 14px;
-      font-size: 12px; font-weight: 500; text-decoration: none;
-      color: #fff; background: #2563eb; border-radius: 6px;
-    }
-    #download:hover { background: #1d4ed8; }
     @media (prefers-color-scheme: dark) {
-      #download { background: #3b82f6; }
-      #download:hover { background: #2563eb; }
       #meta { color: #aaa; }
       #placeholder { color: #777; }
     }
@@ -247,7 +239,6 @@ _IMAGE_VIEWER_HTML = """\
   <div id="viewer">
     <img id="image" alt="Generated image">
     <div id="meta"></div>
-    <a id="download" style="display:none" target="_blank" rel="noopener">Download full resolution</a>
   </div>
   <script type="module">
     import { App } from
@@ -334,13 +325,6 @@ _IMAGE_VIEWER_HTML = """\
           document.getElementById("meta").textContent =
             (meta.prompt ? `"${meta.prompt}"\\n` : "") +
             parts.join(" \\u00b7 ");
-          const dlEl = document.getElementById("download");
-          if (meta.download_url) {
-            dlEl.href = meta.download_url;
-            dlEl.style.display = "inline-block";
-          } else {
-            dlEl.style.display = "none";
-          }
         } catch (e) { console.warn("Image viewer: failed to parse metadata", e); }
       }
 
@@ -364,16 +348,7 @@ _IMAGE_VIEWER_HTML = """\
       if (!key && text) {
         try { key = JSON.parse(text.text).image_id; } catch (e) { console.warn("Image viewer: failed to get image_id from tool result", e); }
       }
-      // Strip download_url before persisting — tokens expire after 5 min
-      let persistText = text;
-      if (text && text.text) {
-        try {
-          const parsed = JSON.parse(text.text);
-          delete parsed.download_url;
-          persistText = Object.assign({}, text, { text: JSON.stringify(parsed, null, 2) });
-        } catch (e) { console.warn("Image viewer: failed to strip download_url before persisting", e); }
-      }
-      if (key) saveState(key, img, persistText);
+      if (key) saveState(key, img, text);
     };
 
     await app.connect();

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -361,6 +361,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             with_link: When ``True`` (default), include a one-time
                 ``download_url`` in the metadata if the server is
                 running on HTTP transport with ``BASE_URL`` configured.
+                Present this URL directly to the user as a clickable
+                link — the MCP App widget cannot open it from its
+                sandboxed iframe.
 
         Returns:
             For completed images: a WebP thumbnail preview (max 512px,


### PR DESCRIPTION
## Summary

Replaces auto-closed PR #122 (base branch deleted during stack merge).

- Remove download button HTML, CSS, and JS from the MCP Apps image viewer (sandboxed iframes can't navigate to external URLs)
- Remove `download_url` stripping from localStorage persistence
- Update `show_image` docstring to instruct LLMs to present `download_url` directly
- Update `docs/tools.md` and `docs/resources.md` to reflect the change

Closes #120

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | No download button/CSS/JS in viewer HTML | Issue #120, AC 1 | CONFORMANT | Grep for `#download`, `dlEl`, `download_url` returns 0 matches in viewer |
| 2 | `download_url` localStorage stripping removed | Issue #120, AC 2 | CONFORMANT | 7-line try/delete block removed |
| 3 | `show_image` docstring mentions presenting URL directly | Issue #120, AC 3 | CONFORMANT | `_server_tools.py:364-366` |
| 4 | `docs/resources.md` updated | Issue #120, AC 4 | CONFORMANT | Sandbox note added |
| 5 | `docs/tools.md` updated | Issue #120, AC 5 | CONFORMANT | Download button bullet removed, sandbox note added |
| 6 | `show_image` still returns `download_url` in metadata | Issue #120, AC 6 | CONFORMANT | Generation logic untouched |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan

- [x] No test changes needed — viewer HTML is not unit-tested for absence of elements
- [x] Full suite: 562 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)