### PR TITLE
feat: MCP Apps widget redesign, HTTP logging middleware, log sanitization

### DIFF
--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -400,21 +400,33 @@ _IMAGE_VIEWER_HTML = """\
       return keys;
     }
 
+    // Returns store keys sorted oldest-first by timestamp for correct LRU eviction.
+    // localStorage.key(i) has no guaranteed iteration order, so we read the stored ts field.
+    function storeKeysByAge() {
+      return storeKeys().map(k => {
+        try {
+          const d = JSON.parse(localStorage.getItem(k));
+          return { k, ts: (d && d.ts) ? d.ts : 0 };
+        } catch (_) { return { k, ts: 0 }; }
+      }).sort((a, b) => a.ts - b.ts).map(e => e.k);
+    }
+
     function saveState(key, img, text) {
       if (!key) return;
       const fullKey = STORE + key;
-      const value = JSON.stringify({ img, text });
+      const value = JSON.stringify({ img, text, ts: Date.now() });
       try {
         localStorage.setItem(fullKey, value);
       } catch (e) {
-        const keys = storeKeys().filter(k => k !== fullKey);
+        const keys = storeKeysByAge().filter(k => k !== fullKey);
         while (keys.length > 0) {
           localStorage.removeItem(keys.shift());
           try { localStorage.setItem(fullKey, value); return; } catch (_) {}
         }
         console.warn('localStorage full — could not save state after eviction');
+        return;
       }
-      const all = storeKeys().filter(k => k !== fullKey);
+      const all = storeKeysByAge().filter(k => k !== fullKey);
       while (all.length >= MAX_ENTRIES) localStorage.removeItem(all.shift());
     }
 
@@ -520,7 +532,7 @@ _IMAGE_VIEWER_HTML = """\
       renderCompleted(img, text);
       let key = imageKey;
       if (!key && text) {
-        try { key = JSON.parse(text.text).image_id; } catch (e) {}
+        try { key = JSON.parse(text.text).image_id; } catch (e) { console.warn('Could not parse image_id from result text', e); }
       }
       if (key) saveState(key, img, text);
     };


### PR DESCRIPTION
## Summary

- Re-submission of changes reverted from direct main push
- Adds JSON-RPC-aware HTTP request logging middleware with session tracking
- Redesigns image viewer as a proper MCP App using ext-apps SDK v0.4.0
- Adds auto-computed Claude sandbox domain from BASE_URL sha256
- Download button with `downloadFile → openLink` fallback
- Log injection sanitization for all user-controlled logged fields

## Design Conformance

| # | Requirement | Status |
|---|---|---|
| 1 | Handlers registered before app.connect() | CONFORMANT |
| 2 | ext-apps SDK v0.4.0 | CONFORMANT |
| 3 | AppConfig domain/CSP pattern | CONFORMANT |
| 4 | downloadFile → openLink fallback | CONFORMANT |
| 5 | Download button hidden without capability | CONFORMANT |
| 6 | Host CSS variables for theming | CONFORMANT |
| 7 | Host context: theme, variables, fonts, safe area | CONFORMANT |
| 8 | url.path log sanitization | CONFORMANT (fixed) |
| 9 | Generating/failed/cancelled states | CONFORMANT |
| 10 | localStorage LRU cache | CONFORMANT |
| 11 | show_image wired via AppConfig(resourceUri=...) | CONFORMANT |
| 12 | generate_image has no app metadata | CONFORMANT |
| 13 | Middleware HTTP-transport only | CONFORMANT |
| 14 | Body caching for downstream | CONFORMANT |
| 15 | Session tracking memory bounded | CONFORMANT |
| 16-22 | Documentation requirements | ALL CONFORMANT |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan
- [ ] `uv run pytest tests/test_http_logging.py` — all 52 tests pass
- [ ] `uv run pytest tests/test_mcp_apps_viewer.py` — all tests pass
- [ ] Manual: start server, connect Claude, use show_image to verify viewer renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)