### PR TITLE
feat(gallery): add lightbox zoom view and gallery_full_image app-only tool

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -269,8 +269,9 @@ This resource is an [MCP App](https://modelcontextprotocol.io/specification/2025
 - **Thumbnail grid** — responsive grid using CSS `auto-fill` with 140 px minimum card width; 3×3 at typical inline size, adapts to available width (4×3 at wider sizes)
 - **Page size** — fixed at 12 items per page, set server-side by `browse_gallery` and propagated via `data.page_size`
 - **Pagination** — Prev/Next buttons call the `gallery_page` app-only tool; page indicator shows current/total
-- **Hover overlay** — prompt excerpt (2-line clamp) and provider badge on thumbnail hover
-- **Download button** — shown when `downloadFile` host capability is available; uses `resource_link` to `image://{id}/view` for full-resolution download
+- **Hover overlay** — prompt excerpt (2-line clamp) and provider badge on thumbnail hover; keyboard-accessible (`:focus-within`)
+- **Download button** — uses `resource_link` to `image://{id}/view` with `downloadFile` → `openLink` fallback
+- **Lightbox** — clicking a thumbnail opens a full-resolution overlay via `gallery_full_image` (app-only); prev/next navigation with cross-page support; close via ✕ button, Escape key, or backdrop click; fullscreen toggle when `requestDisplayMode("fullscreen")` is available from the host
 - **Pending items** — in-progress generations appear with spinner overlay and prompt label
 - **Empty state** — friendly message with `generate_image` call-to-action when no images exist
 - **Host theming** — same theme/CSS-variable/safe-area integration as the image viewer

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -193,8 +193,43 @@ JSON with gallery data (for non-UI clients):
 For MCP Apps-capable clients, the gallery widget is rendered inline with:
 - Responsive thumbnail grid (3×3 default, adaptive to available width)
 - Hover overlay showing prompt excerpt and provider badge
-- Download button (requires `downloadFile` host capability)
+- Download button (`downloadFile` → `openLink` fallback)
 - Prev/Next pagination
+- Lightbox view on thumbnail click (see below)
+
+---
+
+## gallery_full_image (app-only)
+
+Load full-resolution image data for the gallery lightbox. App-only — not shown to the model; called internally by the gallery UI when a thumbnail is clicked.
+
+| Property | Value |
+|----------|-------|
+| **Tags** | *(none)* |
+| **Annotations** | `readOnlyHint: true`, `destructiveHint: false`, `openWorldHint: false` |
+| **MCP App** | `ui://image-gallery/view.html` (app-only, `visibility=["app"]`) |
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image_id` | str | *(required)* | Image ID to load |
+
+### Return value
+
+```json
+{
+  "image_id": "a1b2c3d4e5f6",
+  "b64": "<base64-encoded image bytes>",
+  "content_type": "image/png",
+  "dimensions": [1024, 1024],
+  "prompt": "a mountain landscape",
+  "provider": "openai",
+  "created_at": "2026-03-24T10:00:00+00:00"
+}
+```
+
+Images larger than 1 MB are resized to 1024 px wide WebP before encoding.
 
 ---
 

--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -932,15 +932,16 @@ _IMAGE_GALLERY_HTML = """\
     }
 
     async function loadFullImage(item) {
+      const capturedIndex = lbIndex;
       try {
         const result = await app.callServerTool("gallery_full_image", { image_id: item.image_id });
-        if (result.isError) { lbLoading.style.display = "none"; return; }
+        if (lbIndex !== capturedIndex) return; // navigated away while loading
+        if (result.isError) return;
         const text = result.content?.find(c => c.type === "text")?.text;
-        if (!text) { lbLoading.style.display = "none"; return; }
+        if (!text) return;
         const data = JSON.parse(text);
         lbImg.src = "data:" + (data.content_type || "image/webp") + ";base64," + data.b64;
         lbImg.removeAttribute("hidden");
-        lbLoading.style.display = "none";
         lbPromptEl.textContent = data.prompt || "";
         const parts = [data.provider];
         if (data.dimensions) parts.push(data.dimensions.join("\\u00d7") + "px");
@@ -949,7 +950,10 @@ _IMAGE_GALLERY_HTML = """\
         lbMeta.removeAttribute("hidden");
       } catch (e) {
         console.warn("Failed to load full image", e);
-        lbLoading.style.display = "none";
+      } finally {
+        // Only hide the loader if we're still showing the same image.
+        // If the user navigated away, the new loadFullImage owns the loader.
+        if (lbIndex === capturedIndex) lbLoading.style.display = "none";
       }
     }
 
@@ -960,6 +964,7 @@ _IMAGE_GALLERY_HTML = """\
       lbImg.setAttribute("hidden", "");
       lbImg.src = "";
       lbMeta.setAttribute("hidden", "");
+      lbFsBtn.setAttribute("hidden", "");
     }
 
     async function navigateLb(delta) {
@@ -1100,6 +1105,7 @@ _IMAGE_GALLERY_HTML = """\
         const card = makeCard(item);
         if (item.status === "completed" && item.image_id) {
           const capturedIdx = lbIdx++;
+          card.setAttribute("role", "button");
           card.addEventListener("click", (e) => {
             if (!e.target.closest(".card-dl")) openLightbox(capturedIdx);
           });

--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -897,12 +897,6 @@ _IMAGE_GALLERY_HTML = """\
       s = String(s || "");
       return s.length > n ? s.slice(0, n) + "\\u2026" : s;
     }
-    function computePageSize() {
-      const w = gridItems.offsetWidth || 300;
-      const cols = Math.max(3, Math.floor(w / 160));
-      return cols * 3;
-    }
-
     // --- Lightbox ---
     function updateLbNav() {
       const globalOffset = (currentPage - 1) * currentPageSize;

--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -747,6 +747,65 @@ _IMAGE_GALLERY_HTML = """\
       color: var(--color-text-secondary, #666);
       min-width: 90px; text-align: center;
     }
+
+    /* Lightbox */
+    #lightbox {
+      position: fixed; inset: 0; z-index: 100;
+      display: flex; align-items: center; justify-content: center;
+    }
+    #lightbox[hidden] { display: none; }
+    .lb-backdrop {
+      position: absolute; inset: 0; background: rgba(0,0,0,0.88); cursor: pointer;
+    }
+    .lb-panel {
+      position: relative; z-index: 1;
+      display: flex; flex-direction: column;
+      max-width: min(95vw, 1100px); max-height: 95vh;
+    }
+    .lb-toolbar {
+      display: flex; justify-content: flex-end; gap: 6px; padding-bottom: 6px;
+    }
+    .lb-btn {
+      background: rgba(0,0,0,0.5); border: none; cursor: pointer;
+      color: rgba(255,255,255,0.85); border-radius: var(--border-radius-sm, 4px);
+      padding: 5px 10px; font-size: 14px; line-height: 1;
+    }
+    .lb-btn:hover { color: #fff; background: rgba(0,0,0,0.75); }
+    .lb-body { display: flex; align-items: center; gap: 8px; }
+    .lb-nav-btn {
+      flex-shrink: 0; background: rgba(0,0,0,0.5); border: none; cursor: pointer;
+      color: rgba(255,255,255,0.85); border-radius: 50%;
+      width: 36px; height: 36px; font-size: 18px;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .lb-nav-btn:disabled { opacity: 0.2; cursor: default; }
+    .lb-nav-btn:not(:disabled):hover { background: rgba(0,0,0,0.75); color: #fff; }
+    .lb-img-wrap {
+      flex: 1; min-width: 0;
+      display: flex; align-items: center; justify-content: center; position: relative;
+      min-height: 60px;
+    }
+    .lb-loading {
+      position: absolute;
+      display: flex; align-items: center; justify-content: center;
+      width: 60px; height: 60px;
+    }
+    .lb-loading .spinner { width: 28px; height: 28px; }
+    #lb-img {
+      max-width: 100%; max-height: 75vh; object-fit: contain;
+      border-radius: var(--border-radius-sm, 4px); display: block;
+    }
+    #lb-img[hidden] { display: none; }
+    .lb-meta {
+      padding: 8px 0 0; color: rgba(255,255,255,0.85);
+      max-width: 600px; margin: 0 auto;
+    }
+    .lb-meta-prompt {
+      font-size: var(--font-text-sm-size, 13px); line-height: 1.4; margin-bottom: 4px;
+    }
+    .lb-meta-info {
+      font-size: var(--font-text-xs-size, 12px); color: rgba(255,255,255,0.6);
+    }
   </style>
 </head>
 <body>
@@ -773,6 +832,29 @@ _IMAGE_GALLERY_HTML = """\
     </div>
   </div>
 
+  <!-- Lightbox overlay -->
+  <div id="lightbox" hidden aria-modal="true" role="dialog" aria-label="Image viewer">
+    <div id="lb-backdrop" class="lb-backdrop"></div>
+    <div class="lb-panel">
+      <div class="lb-toolbar">
+        <button class="lb-btn" id="lb-fullscreen" hidden title="Enter fullscreen">\u26f6</button>
+        <button class="lb-btn" id="lb-close" title="Close (Esc)">\u2715</button>
+      </div>
+      <div class="lb-body">
+        <button class="lb-nav-btn" id="lb-prev" title="Previous" disabled>&#10094;</button>
+        <div class="lb-img-wrap">
+          <div class="lb-loading" id="lb-loading"><div class="spinner"></div></div>
+          <img id="lb-img" src="" alt="" hidden>
+        </div>
+        <button class="lb-nav-btn" id="lb-next" title="Next" disabled>&#10095;</button>
+      </div>
+      <div class="lb-meta" id="lb-meta" hidden>
+        <div class="lb-meta-prompt" id="lb-prompt"></div>
+        <div class="lb-meta-info" id="lb-info"></div>
+      </div>
+    </div>
+  </div>
+
   <script type="module">
     import { App, applyDocumentTheme, applyHostStyleVariables, applyHostFonts }
       from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps";
@@ -786,16 +868,151 @@ _IMAGE_GALLERY_HTML = """\
     const gridItems = document.getElementById("gallery-grid");
     const pagEl     = document.getElementById("pagination");
 
+    // Lightbox DOM refs
+    const lbOverlay  = document.getElementById("lightbox");
+    const lbBackdrop = document.getElementById("lb-backdrop");
+    const lbImg      = document.getElementById("lb-img");
+    const lbLoading  = document.getElementById("lb-loading");
+    const lbPrev     = document.getElementById("lb-prev");
+    const lbNext     = document.getElementById("lb-next");
+    const lbClose    = document.getElementById("lb-close");
+    const lbFsBtn    = document.getElementById("lb-fullscreen");
+    const lbMeta     = document.getElementById("lb-meta");
+    const lbPromptEl = document.getElementById("lb-prompt");
+    const lbInfoEl   = document.getElementById("lb-info");
+
     let currentPage = 1;
     let currentTotal = 0;
     let currentPageSize = 12;
     let dlMode = null; // "downloadFile" | "openLink" | null
+
+    // Lightbox state
+    let lbActive = false;
+    let lbIndex  = 0;       // index within lbPageItems
+    let lbPageItems = [];   // completed items on current page (for lightbox nav)
+    let lbFsAvailable = false;
 
     // --- Helpers ---
     function trunc(s, n) {
       s = String(s || "");
       return s.length > n ? s.slice(0, n) + "\\u2026" : s;
     }
+    function computePageSize() {
+      const w = gridItems.offsetWidth || 300;
+      const cols = Math.max(3, Math.floor(w / 160));
+      return cols * 3;
+    }
+
+    // --- Lightbox ---
+    function updateLbNav() {
+      const globalOffset = (currentPage - 1) * currentPageSize;
+      const globalIdx = globalOffset + lbIndex;
+      lbPrev.disabled = globalIdx <= 0;
+      lbNext.disabled = globalIdx >= currentTotal - 1;
+    }
+
+    function openLightbox(pageIndex) {
+      const item = lbPageItems[pageIndex];
+      if (!item) return;
+      lbActive = true;
+      lbIndex  = pageIndex;
+      lbOverlay.removeAttribute("hidden");
+      lbLoading.style.display = "flex";
+      lbMeta.setAttribute("hidden", "");
+      if (lbFsAvailable) lbFsBtn.removeAttribute("hidden");
+      updateLbNav();
+      // Preview with thumbnail immediately
+      if (item.thumbnail_b64) {
+        lbImg.src = "data:image/webp;base64," + item.thumbnail_b64;
+        lbImg.removeAttribute("hidden");
+      } else {
+        lbImg.setAttribute("hidden", "");
+      }
+      loadFullImage(item);
+    }
+
+    async function loadFullImage(item) {
+      try {
+        const result = await app.callServerTool("gallery_full_image", { image_id: item.image_id });
+        if (result.isError) { lbLoading.style.display = "none"; return; }
+        const text = result.content?.find(c => c.type === "text")?.text;
+        if (!text) { lbLoading.style.display = "none"; return; }
+        const data = JSON.parse(text);
+        lbImg.src = "data:" + (data.content_type || "image/webp") + ";base64," + data.b64;
+        lbImg.removeAttribute("hidden");
+        lbLoading.style.display = "none";
+        lbPromptEl.textContent = data.prompt || "";
+        const parts = [data.provider];
+        if (data.dimensions) parts.push(data.dimensions.join("\\u00d7") + "px");
+        if (data.created_at) parts.push(new Date(data.created_at).toLocaleDateString());
+        lbInfoEl.textContent = parts.filter(Boolean).join(" \\u00b7 ");
+        lbMeta.removeAttribute("hidden");
+      } catch (e) {
+        console.warn("Failed to load full image", e);
+        lbLoading.style.display = "none";
+      }
+    }
+
+    function closeLightbox() {
+      if (!lbActive) return;
+      lbActive = false;
+      lbOverlay.setAttribute("hidden", "");
+      lbImg.setAttribute("hidden", "");
+      lbImg.src = "";
+      lbMeta.setAttribute("hidden", "");
+    }
+
+    async function navigateLb(delta) {
+      const newIdx = lbIndex + delta;
+      if (newIdx >= 0 && newIdx < lbPageItems.length) {
+        openLightbox(newIdx);
+      } else {
+        // Cross-page: load adjacent page then open first/last item
+        const targetPage = delta > 0 ? currentPage + 1 : currentPage - 1;
+        if (targetPage < 1) return;
+        lbLoading.style.display = "flex";
+        lbImg.setAttribute("hidden", "");
+        lbMeta.setAttribute("hidden", "");
+        try {
+          const ps = currentPageSize;
+          const result = await app.callServerTool("gallery_page", { page: targetPage, page_size: ps });
+          if (result.isError) { lbLoading.style.display = "none"; return; }
+          const text = result.content?.find(c => c.type === "text")?.text;
+          if (!text) { lbLoading.style.display = "none"; return; }
+          const data = JSON.parse(text);
+          currentPage = data.page;
+          currentTotal = data.total;
+          currentPageSize = data.page_size;
+          renderGrid(data);
+          const newPageIdx = delta > 0 ? 0 : lbPageItems.length - 1;
+          if (lbPageItems[newPageIdx]) openLightbox(newPageIdx);
+        } catch (e) {
+          console.warn("Cross-page lightbox nav failed", e);
+          lbLoading.style.display = "none";
+        }
+      }
+    }
+
+    lbBackdrop.addEventListener("click", closeLightbox);
+    lbClose.addEventListener("click", closeLightbox);
+    lbPrev.addEventListener("click", () => navigateLb(-1));
+    lbNext.addEventListener("click", () => navigateLb(1));
+    lbFsBtn.addEventListener("click", async () => {
+      const mode = lbFsBtn.dataset.active === "1" ? "inline" : "fullscreen";
+      try {
+        const res = await app.requestDisplayMode({ mode });
+        const isFs = res.mode === "fullscreen";
+        lbFsBtn.dataset.active = isFs ? "1" : "0";
+        lbFsBtn.title = isFs ? "Exit fullscreen" : "Enter fullscreen";
+      } catch (e) { console.warn("requestDisplayMode failed", e); }
+    });
+    window.addEventListener("keydown", (e) => {
+      if (!lbActive) return;
+      if (e.key === "Escape") closeLightbox();
+      else if (e.key === "ArrowLeft")  navigateLb(-1);
+      else if (e.key === "ArrowRight") navigateLb(1);
+    });
+
     // --- Display states ---
     function show(which) {
       loadingEl.style.display = which === "loading" ? "flex" : "none";
@@ -867,6 +1084,9 @@ _IMAGE_GALLERY_HTML = """\
       currentTotal = total;
       gridItems.innerHTML = "";
 
+      // Update lightbox page items (completed images only)
+      lbPageItems = (items || []).filter(i => i.status === "completed" && i.image_id);
+
       if (!items || items.length === 0) {
         if (total === 0) { show("empty"); return; }
         show("grid");
@@ -875,8 +1095,19 @@ _IMAGE_GALLERY_HTML = """\
       }
 
       show("grid");
+      let lbIdx = 0;
       for (const item of items) {
-        gridItems.appendChild(makeCard(item));
+        const card = makeCard(item);
+        if (item.status === "completed" && item.image_id) {
+          const capturedIdx = lbIdx++;
+          card.addEventListener("click", (e) => {
+            if (!e.target.closest(".card-dl")) openLightbox(capturedIdx);
+          });
+          card.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openLightbox(capturedIdx); }
+          });
+        }
+        gridItems.appendChild(card);
       }
       renderPagination();
     }
@@ -977,6 +1208,11 @@ _IMAGE_GALLERY_HTML = """\
         mainEl.style.paddingRight  = (12 + right)  + "px";
         mainEl.style.paddingBottom = (12 + bottom) + "px";
         mainEl.style.paddingLeft   = (12 + left)   + "px";
+      }
+      lbFsAvailable = ctx.availableDisplayModes?.includes("fullscreen") ?? false;
+      if (lbActive) {
+        if (lbFsAvailable) lbFsBtn.removeAttribute("hidden");
+        else lbFsBtn.setAttribute("hidden", "");
       }
     }
 

--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -789,7 +789,7 @@ _IMAGE_GALLERY_HTML = """\
     let currentPage = 1;
     let currentTotal = 0;
     let currentPageSize = 12;
-    let dlMode = null; // "downloadFile" | null
+    let dlMode = null; // "downloadFile" | "openLink" | null
 
     // --- Helpers ---
     function trunc(s, n) {
@@ -851,8 +851,9 @@ _IMAGE_GALLERY_HTML = """\
       dlBtn.title = "Download";
       dlBtn.dataset.imageId = item.image_id;
       dlBtn.dataset.mime = item.content_type || "image/png";
+      if (item.download_url) dlBtn.dataset.downloadUrl = item.download_url;
       dlBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>';
-      if (dlMode === "downloadFile") dlBtn.style.display = "block";
+      if (dlMode === "downloadFile" || dlMode === "openLink") dlBtn.style.display = "block";
       footer.appendChild(dlBtn);
 
       overlay.appendChild(footer);

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -1,9 +1,10 @@
 """MCP tool registrations for image generation.
 
 Exposes ``generate_image``, ``show_image``, ``browse_gallery``,
-``gallery_page``, and ``list_providers`` tools to MCP clients.
-``generate_image`` is tagged ``write`` (hidden in read-only mode).
-``gallery_page`` is app-only (``visibility=["app"]``) and not shown to the model.
+``gallery_page``, ``gallery_full_image``, and ``list_providers`` tools to
+MCP clients.  ``generate_image`` is tagged ``write`` (hidden in read-only
+mode).  ``gallery_page`` and ``gallery_full_image`` are app-only
+(``visibility=["app"]``) and not shown to the model.
 """
 
 from __future__ import annotations
@@ -693,6 +694,62 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         return json.dumps(
             {"total": total, "page": page, "page_size": page_size, "items": items}
+        )
+
+    _LIGHTBOX_MAX_BYTES = 1 * 1024 * 1024  # 1 MB size cap for lightbox images
+    _LIGHTBOX_MAX_PX = 1024  # resize target when image exceeds size cap
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "openWorldHint": False,
+        },
+        app=AppConfig(resourceUri=_IMAGE_GALLERY_URI, visibility=["app"]),
+    )
+    async def gallery_full_image(
+        image_id: str,
+        service: ImageService = Depends(get_service),
+    ) -> str:
+        """Return full-resolution image data for the gallery lightbox.
+
+        App-only helper called by the gallery lightbox to load a single image
+        at full (or near-full) resolution.  Images larger than 1 MB are
+        downscaled to 1024 px wide WebP before encoding.
+
+        Args:
+            image_id: The image ID to load.
+
+        Returns:
+            JSON with ``image_id``, ``b64``, ``content_type``, ``dimensions``,
+            ``prompt``, ``provider``, and ``created_at``.
+        """
+        record = await asyncio.to_thread(service.get_image, image_id)
+        # get_transformed_image with no transforms returns original bytes
+        img_bytes, content_type = await asyncio.to_thread(
+            service.get_transformed_image, image_id
+        )
+        if len(img_bytes) > _LIGHTBOX_MAX_BYTES:
+            img_bytes, content_type = await asyncio.to_thread(
+                service.get_transformed_image,
+                image_id,
+                "webp",
+                _LIGHTBOX_MAX_PX,
+                0,
+                85,
+            )
+        return json.dumps(
+            {
+                "image_id": record.id,
+                "b64": base64.b64encode(img_bytes).decode(),
+                "content_type": content_type,
+                "dimensions": list(record.original_dimensions),
+                "prompt": record.prompt,
+                "provider": record.provider,
+                "created_at": datetime.fromtimestamp(
+                    record.created_at, tz=UTC
+                ).isoformat(),
+            }
         )
 
     @mcp.tool(

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -724,12 +724,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             JSON with ``image_id``, ``b64``, ``content_type``, ``dimensions``,
             ``prompt``, ``provider``, and ``created_at``.
         """
-        record = await asyncio.to_thread(service.get_image, image_id)
-        # get_transformed_image with no transforms returns original bytes
-        img_bytes, content_type = await asyncio.to_thread(
-            service.get_transformed_image, image_id
-        )
-        if len(img_bytes) > _LIGHTBOX_MAX_BYTES:
+        record = service.get_image(image_id)  # simple dict lookup, no I/O
+        # Check file size via stat to decide transform upfront — avoids double
+        # read: stat is O(1), reading bytes is O(size).
+        file_size = await asyncio.to_thread(lambda: record.original_path.stat().st_size)
+        if file_size > _LIGHTBOX_MAX_BYTES:
             img_bytes, content_type = await asyncio.to_thread(
                 service.get_transformed_image,
                 image_id,
@@ -737,6 +736,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 _LIGHTBOX_MAX_PX,
                 0,
                 85,
+            )
+        else:
+            img_bytes, content_type = await asyncio.to_thread(
+                service.get_transformed_image, image_id
             )
         return json.dumps(
             {

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -459,16 +459,17 @@ class TestGalleryFullImage:
         tools = await server.list_tools()
         tool = next((t for t in tools if t.name == "gallery_full_image"), None)
         assert tool is not None
-        if tool.meta:
-            app_meta = tool.meta.get("ui", {})
-            visibility = app_meta.get("visibility", [])
-            assert "model" not in visibility
+        assert tool.meta is not None, "gallery_full_image must have app meta"
+        app_meta = tool.meta.get("ui", {})
+        visibility = app_meta.get("visibility", [])
+        assert "app" in visibility, f"expected 'app' in visibility, got {visibility}"
+        assert "model" not in visibility
 
     async def test_gallery_full_image_returns_base64(
-        self, service: ImageService, tmp_path: Path
+        self, service: ImageService
     ) -> None:
         """gallery_full_image must return valid base64 image bytes."""
-        record = _add_image(service, tmp_path, 0)
+        record = _add_image(service, 0)
 
         mcp = self._mcp()
         tool = await mcp.get_tool("gallery_full_image")
@@ -483,10 +484,10 @@ class TestGalleryFullImage:
         assert len(img_bytes) > 0
 
     async def test_gallery_full_image_includes_metadata(
-        self, service: ImageService, tmp_path: Path
+        self, service: ImageService
     ) -> None:
         """gallery_full_image must include prompt, provider, dimensions, created_at."""
-        record = _add_image(service, tmp_path, 0)
+        record = _add_image(service, 0)
 
         mcp = self._mcp()
         tool = await mcp.get_tool("gallery_full_image")
@@ -510,7 +511,9 @@ class TestGalleryFullImage:
         tool = await mcp.get_tool("gallery_full_image")
         assert tool is not None
 
-        with pytest.raises(Exception):
+        from image_generation_mcp.providers.types import ImageProviderError
+
+        with pytest.raises(ImageProviderError):
             await tool.fn(image_id="nonexistent_id", service=service)
 
 
@@ -566,5 +569,5 @@ class TestLightboxHTML:
         text = result.contents[0].content
         assert "thumbnail_b64" in text
         # The lightbox code should reference thumbnail_b64 for preview
-        lb_section = text[text.index("openLightbox"):]
+        lb_section = text[text.index("openLightbox") :]
         assert "thumbnail_b64" in lb_section

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -439,3 +439,132 @@ class TestGalleryPage:
         assert item["status"] == "generating"
         assert "thumbnail_b64" not in item
         assert item["progress"] == 0.3
+
+
+# ---------------------------------------------------------------------------
+# gallery_full_image tool
+# ---------------------------------------------------------------------------
+
+
+class TestGalleryFullImage:
+    """gallery_full_image must return base64 image data + metadata."""
+
+    def _mcp(self) -> FastMCP:
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        return mcp
+
+    async def test_gallery_full_image_is_app_only(self, server) -> None:
+        """gallery_full_image must carry visibility=["app"] in its app meta."""
+        tools = await server.list_tools()
+        tool = next((t for t in tools if t.name == "gallery_full_image"), None)
+        assert tool is not None
+        if tool.meta:
+            app_meta = tool.meta.get("ui", {})
+            visibility = app_meta.get("visibility", [])
+            assert "model" not in visibility
+
+    async def test_gallery_full_image_returns_base64(
+        self, service: ImageService, tmp_path: Path
+    ) -> None:
+        """gallery_full_image must return valid base64 image bytes."""
+        record = _add_image(service, tmp_path, 0)
+
+        mcp = self._mcp()
+        tool = await mcp.get_tool("gallery_full_image")
+        assert tool is not None
+
+        result = await tool.fn(image_id=record.id, service=service)
+        data = json.loads(result)
+
+        assert data["image_id"] == record.id
+        assert "b64" in data
+        img_bytes = base64.b64decode(data["b64"])
+        assert len(img_bytes) > 0
+
+    async def test_gallery_full_image_includes_metadata(
+        self, service: ImageService, tmp_path: Path
+    ) -> None:
+        """gallery_full_image must include prompt, provider, dimensions, created_at."""
+        record = _add_image(service, tmp_path, 0)
+
+        mcp = self._mcp()
+        tool = await mcp.get_tool("gallery_full_image")
+        assert tool is not None
+
+        result = await tool.fn(image_id=record.id, service=service)
+        data = json.loads(result)
+
+        assert data["prompt"] == "prompt 0"
+        assert data["provider"] == "placeholder"
+        assert isinstance(data["dimensions"], list)
+        assert len(data["dimensions"]) == 2
+        assert "created_at" in data
+        assert "content_type" in data
+
+    async def test_gallery_full_image_unknown_id_raises(
+        self, service: ImageService
+    ) -> None:
+        """gallery_full_image must raise for unknown image IDs."""
+        mcp = self._mcp()
+        tool = await mcp.get_tool("gallery_full_image")
+        assert tool is not None
+
+        with pytest.raises(Exception):
+            await tool.fn(image_id="nonexistent_id", service=service)
+
+
+# ---------------------------------------------------------------------------
+# Lightbox HTML tests
+# ---------------------------------------------------------------------------
+
+
+class TestLightboxHTML:
+    """Gallery HTML must contain the lightbox overlay and JS."""
+
+    async def test_gallery_html_has_lightbox_overlay(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "lb-backdrop" in text
+        assert "lb-panel" in text
+        assert "lb-img" in text
+
+    async def test_gallery_html_has_lightbox_nav(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "lb-prev" in text
+        assert "lb-next" in text
+        assert "navigateLb" in text
+
+    async def test_gallery_html_has_close_button(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "lb-close" in text
+        assert "closeLightbox" in text
+
+    async def test_gallery_html_has_escape_key_handler(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "Escape" in text
+
+    async def test_gallery_html_has_fullscreen_button(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "lb-fullscreen" in text
+        assert "requestDisplayMode" in text
+        assert "availableDisplayModes" in text
+
+    async def test_gallery_html_calls_gallery_full_image(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "gallery_full_image" in text
+        assert "loadFullImage" in text
+
+    async def test_gallery_html_shows_thumbnail_preview(self, server) -> None:
+        """Lightbox must show thumbnail immediately before full-res loads."""
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "thumbnail_b64" in text
+        # The lightbox code should reference thumbnail_b64 for preview
+        lb_section = text[text.index("openLightbox"):]
+        assert "thumbnail_b64" in lb_section


### PR DESCRIPTION
Closes #130

## Summary

- Adds `gallery_full_image` app-only tool: loads full-resolution image (≤1MB; images over 1MB are resized to 1024px wide WebP) + metadata for lightbox display
- Lightbox overlay in gallery HTML: thumbnail preview shown immediately while full-res loads, metadata panel (prompt, provider, dimensions, date) below image
- Prev/next navigation with cross-page boundary support (loads adjacent page via `gallery_page` when reaching end of current page)
- Close via ✕ button, backdrop click, or Escape key
- Fullscreen toggle button shown when host reports `availableDisplayModes` includes `"fullscreen"`
- Graceful degradation: lightbox works inline when fullscreen not available

## Design Conformance

| # | Requirement | Status | Evidence |
|---|---|---|---|
| 1 | Thumbnail click opens lightbox; shows thumbnail preview then fetches full-res via `gallery_full_image` | CONFORMANT | `openLightbox()` sets thumbnail src immediately, then calls `loadFullImage()` which calls `gallery_full_image` |
| 2 | Lightbox shows metadata: prompt, provider, dimensions, created_at | CONFORMANT | `loadFullImage()` populates `lbPromptEl` + `lbInfoEl` with provider, dimensions, date |
| 3 | Fullscreen toggle shown when `availableDisplayModes` includes `"fullscreen"` | CONFORMANT | `handleHostContext()` sets `lbFsAvailable`; button shown/hidden accordingly; `requestDisplayMode` on click |
| 4 | Prev/next navigation, cross-page boundary support | CONFORMANT | `navigateLb(delta)` handles same-page and cross-page navigation via `gallery_page` |
| 5 | Close via X button, Escape key, or clicking outside the image | CONFORMANT | `lbClose`, `lbBackdrop` click handlers; `keydown` listener for `Escape` |
| 6 | Graceful degradation when fullscreen unavailable | CONFORMANT | Fullscreen button is `hidden` by default; lightbox works inline regardless |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan

- [ ] 39 tests pass: `uv run pytest tests/test_mcp_apps_gallery.py`
- [ ] `gallery_full_image` tool returns base64 + metadata JSON
- [ ] Unknown image_id raises exception
- [ ] Gallery HTML contains lightbox overlay, nav buttons, close button, fullscreen button, Escape handler, `gallery_full_image` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)