### PR TITLE
fix(gallery): update callServerTool to {name,arguments} API and bump ext-apps to 1.3.1

### DIFF
--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -359,7 +359,7 @@ _IMAGE_VIEWER_HTML = """\
 
   <script type="module">
     import { App, applyDocumentTheme, applyHostStyleVariables, applyHostFonts }
-      from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps";
+      from "https://unpkg.com/@modelcontextprotocol/ext-apps@1.3.1/app-with-deps";
 
     const app = new App({ name: "Image Viewer", version: "2.0.0" });
 
@@ -860,7 +860,7 @@ _IMAGE_GALLERY_HTML = """\
 
   <script type="module">
     import { App, applyDocumentTheme, applyHostStyleVariables, applyHostFonts }
-      from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps";
+      from "https://unpkg.com/@modelcontextprotocol/ext-apps@1.3.1/app-with-deps";
 
     const app = new App({ name: "Image Gallery", version: "1.0.0" });
 
@@ -932,7 +932,7 @@ _IMAGE_GALLERY_HTML = """\
     async function loadFullImage(item) {
       const capturedIndex = lbIndex;
       try {
-        const result = await app.callServerTool("gallery_full_image", { image_id: item.image_id });
+        const result = await app.callServerTool({ name: "gallery_full_image", arguments: { image_id: item.image_id } });
         if (lbIndex !== capturedIndex) return; // navigated away while loading
         if (result.isError) return;
         const text = result.content?.find(c => c.type === "text")?.text;
@@ -978,7 +978,7 @@ _IMAGE_GALLERY_HTML = """\
         lbMeta.setAttribute("hidden", "");
         try {
           const ps = currentPageSize;
-          const result = await app.callServerTool("gallery_page", { page: targetPage, page_size: ps });
+          const result = await app.callServerTool({ name: "gallery_page", arguments: { page: targetPage, page_size: ps } });
           if (result.isError) { lbLoading.style.display = "none"; return; }
           const text = result.content?.find(c => c.type === "text")?.text;
           if (!text) { lbLoading.style.display = "none"; return; }
@@ -1154,7 +1154,7 @@ _IMAGE_GALLERY_HTML = """\
       const ps = currentPageSize;
       show("loading");
       try {
-        const result = await app.callServerTool("gallery_page", { page, page_size: ps });
+        const result = await app.callServerTool({ name: "gallery_page", arguments: { page, page_size: ps } });
         if (result.isError) { show("empty"); return; }
         const text = result.content?.find(c => c.type === "text")?.text;
         if (!text) { show("empty"); return; }
@@ -1202,7 +1202,7 @@ _IMAGE_GALLERY_HTML = """\
       if (!confirm("Delete this image? This cannot be undone.")) return;
       btn.disabled = true;
       try {
-        const result = await app.callServerTool("delete_image", { image_id: id });
+        const result = await app.callServerTool({ name: "delete_image", arguments: { image_id: id } });
         if (result.isError) {
           alert("Delete failed: " + (result.content?.find(c => c.type === "text")?.text || "Unknown error"));
           return;
@@ -1226,7 +1226,7 @@ _IMAGE_GALLERY_HTML = """\
       if (!confirm("Delete this image? This cannot be undone.")) return;
       lbDelBtn.disabled = true;
       try {
-        const result = await app.callServerTool("delete_image", { image_id: item.image_id });
+        const result = await app.callServerTool({ name: "delete_image", arguments: { image_id: item.image_id } });
         if (result.isError) {
           alert("Delete failed: " + (result.content?.find(c => c.type === "text")?.text || "Unknown error"));
           return;

--- a/uv.lock
+++ b/uv.lock
@@ -784,6 +784,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -845,7 +846,7 @@ wheels = [
 
 [[package]]
 name = "image-generation-mcp"
-version = "1.1.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -856,6 +857,7 @@ dependencies = [
 all = [
     { name = "fastmcp", extra = ["tasks"] },
     { name = "openai" },
+    { name = "uvicorn" },
 ]
 dev = [
     { name = "diff-cover" },
@@ -867,6 +869,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "uvicorn" },
 ]
 docs = [
     { name = "mkdocs-llmstxt" },
@@ -875,6 +878,7 @@ docs = [
 ]
 mcp = [
     { name = "fastmcp", extra = ["tasks"] },
+    { name = "uvicorn" },
 ]
 openai = [
     { name = "openai" },
@@ -899,6 +903,8 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
+    { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.20" },
+    { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.20" },
 ]
 provides-extras = ["mcp", "openai", "all", "dev", "docs"]
 


### PR DESCRIPTION
## Problem

The gallery widget used the deprecated two-argument `callServerTool(name, args)` form. Since ext-apps ≥0.4.0 uses the single-object `callServerTool({name, arguments})` API, the string tool name was being passed as the JSON-RPC `params` field directly. The Claude host validates PostMessage messages with Zod; when `params` is a string instead of an object, all four union branches fail, producing `invalid_union` errors. This made clicking any gallery image or pagination button produce "Invalid JSON-RPC message received" errors.

Closes #139.

## Changes

- **5 `callServerTool` call sites fixed** in `_server_resources.py` (gallery_full_image, gallery_page ×2, delete_image ×2) — all converted from old `("name", args)` two-argument form to new `({name, arguments})` single-object form
- **ext-apps CDN import bumped** from `@0.4.0` → `@1.3.1` in both viewer widget (line 362) and gallery widget (line 863); the `@0.4.0` pin came from parametric knowledge and was never intentional
- **uv.lock synced** with `pyproject.toml` — `uvicorn>=0.20` was added to `mcp`/`all`/`dev` extras in PR #138 but the lockfile was not regenerated at that time

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | All `callServerTool` call sites use `{name, arguments}` object form | AC1 | CONFORMANT | 5 call sites at lines 935, 981, 1157, 1205, 1229 all use `callServerTool({ name: "...", arguments: {...} })` |
| 2 | No remaining `callServerTool("string",` patterns (old two-arg form) | AC2 | CONFORMANT | `grep 'callServerTool("'` returns 0 matches |
| 3 | ext-apps CDN import bumped from @0.4.0 to @1.3.1 in both widgets | AC3 | CONFORMANT | Viewer (line 362) and gallery (line 863) both import `ext-apps@1.3.1`; 0 matches for `ext-apps@0.` |
| 4 | uv.lock synced with pyproject.toml (uvicorn>=0.20 added) | AC4 | CONFORMANT | uv.lock adds uvicorn under `mcp`, `all`, and `dev` extras |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test Plan

- [ ] Verify `grep 'callServerTool("' src/image_generation_mcp/_server_resources.py` returns 0 matches
- [ ] Verify `grep 'ext-apps@0\.' src/image_generation_mcp/_server_resources.py` returns 0 matches
- [ ] Load gallery in Claude host — clicking an image should open the lightbox without "Invalid JSON-RPC message received" error
- [ ] Clicking next/previous page in gallery should navigate without error
- [ ] Clicking delete button on an image should work without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)