### PR TITLE
fix: improve critical LLM-facing tool descriptions

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,7 +4,7 @@ image-generation-mcp exposes four domain tools plus two auto-generated resource-
 
 ## generate_image
 
-Generate an image from a text prompt. Returns immediately with a `status: "generating"` response while the image is generated in the background. Call `show_image` with the returned `image_id` to check progress and display the result. Read `info://prompt-guide` for provider-specific prompt writing tips.
+Generate an image from a text prompt. Returns immediately with a `status: "generating"` response while the image is generated in the background. Call `show_image(uri=original_uri)` to check progress and display the result. Check each model's `prompt_style` in `list_providers` to choose CLIP tags vs. natural language prompts.
 
 | Property | Value |
 |----------|-------|
@@ -90,7 +90,7 @@ Tool call: generate_image
 
 Display a registered image with optional on-demand transforms, or poll for generation status. Accepts a full `image://` resource URI with transforms encoded in the query string.
 
-Also serves as the polling endpoint for fire-and-forget generation: after calling `generate_image`, call `show_image` with the returned `image_id` to check progress and display the result once ready.
+Also serves as the polling endpoint for fire-and-forget generation: after calling `generate_image`, call `show_image(uri=original_uri)` to check progress and display the result once ready.
 
 | Property | Value |
 |----------|-------|

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -97,16 +97,18 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
     ) -> ToolResult:
         """Generate an image and return metadata with resource URIs.
 
-        Returns immediately with ``{"status": "generating", "image_id":
-        "..."}`` while the image is generated in the background. Call
-        ``show_image`` with the returned ``image_id`` to check progress
-        and display the result once ready.
+        Returns immediately with ``{"status": "generating",
+        "original_uri": "image://…/original"}`` while the image is
+        generated in the background.  Call
+        ``show_image(uri=original_uri)`` to check progress and display
+        the result once ready.
 
         Call list_providers first to see available providers and model IDs.
-        Read info://prompt-guide for provider-specific prompt writing tips.
-        SD WebUI prompt style depends on the model: use CLIP tags for
-        SD 1.5/SDXL, natural language for Flux (check ``prompt_style`` in
-        list_providers or in the returned metadata).
+        Check each model's ``prompt_style`` in list_providers to choose the
+        right prompt format: ``"clip"`` models (SD 1.5/SDXL) need
+        comma-separated CLIP tags; ``"natural_language"`` models (Flux,
+        OpenAI) need descriptive sentences.  Flux ignores
+        ``negative_prompt``.
 
         Args:
             prompt: Text description of the desired image.
@@ -127,9 +129,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 tier). SD WebUI and placeholder ignore this parameter.
             background: Background transparency. ``"opaque"`` (default)
                 generates a solid background. ``"transparent"`` requests
-                an image with a transparent background. Only supported
-                by some providers (OpenAI gpt-image-1, placeholder).
-                SD WebUI and dall-e-3 ignore this parameter.
+                an image with a transparent background. Supported by
+                gpt-image-1 and placeholder. dall-e-3 and SD WebUI
+                always produce opaque images (this parameter is ignored).
             model: Specific model to use (e.g., a checkpoint name for
                 SD WebUI, or ``"dall-e-3"`` for OpenAI). Use
                 ``list_providers`` to see available model IDs. Defaults
@@ -137,8 +139,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         Returns:
             JSON metadata with ``status``, ``image_id``, and resource
-            URIs. Call ``show_image`` with the image URI to check
-            progress and display the result.
+            URIs including ``original_uri``.  Call
+            ``show_image(uri=original_uri)`` to poll progress and
+            display the result.
         """
         if aspect_ratio not in SUPPORTED_ASPECT_RATIOS:
             msg = (
@@ -801,10 +804,12 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
     ) -> str:
         """List available image generation providers, models, and capabilities.
 
-        Returns provider names, available models, prompt_style (``"clip"``
-        or ``"natural_language"``), and capability details. Each call
-        includes a ``refreshed_at`` timestamp. Pass ``force_refresh=true``
-        if providers may have changed since the last check.
+        Returns provider names, available models, and capability details.
+        Each model includes a ``prompt_style`` field: use ``"clip"`` for
+        comma-separated CLIP tags (SD 1.5/SDXL) or ``"natural_language"``
+        for descriptive sentences (Flux, OpenAI).  Each call includes a
+        ``refreshed_at`` timestamp.  Pass ``force_refresh=true`` if
+        providers may have changed since the last check.
 
         Also available as the ``info://providers`` resource for clients
         that support MCP resources.

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -138,10 +138,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 to the provider's configured model.
 
         Returns:
-            JSON metadata with ``status``, ``image_id``, and resource
-            URIs including ``original_uri``.  Call
-            ``show_image(uri=original_uri)`` to poll progress and
-            display the result.
+            JSON metadata with ``status``, ``original_uri``, and other
+            resource URIs.  Call ``show_image(uri=original_uri)`` to
+            poll progress and display the result.
         """
         if aspect_ratio not in SUPPORTED_ASPECT_RATIOS:
             msg = (

--- a/src/image_generation_mcp/mcp_server.py
+++ b/src/image_generation_mcp/mcp_server.py
@@ -61,7 +61,9 @@ def _build_default_instructions(*, read_only: bool) -> str:
         "and a zero-cost placeholder). "
         f"{mode_line} "
         "Start by calling list_providers to see which providers are "
-        "configured, then use generate_image to create images."
+        "configured and check each model's prompt_style to choose "
+        "CLIP tags vs. natural language prompts, then use "
+        "generate_image to create images."
     )
 
 

--- a/tests/test_prompt_guide_resource.py
+++ b/tests/test_prompt_guide_resource.py
@@ -78,11 +78,11 @@ class TestPromptGuideResourceRegistration:
 
 
 class TestGenerateImageToolDescription:
-    """Verify generate_image docstring references info://prompt-guide."""
+    """Verify generate_image docstring has inline prompt_style guidance."""
 
-    async def test_generate_image_description_mentions_prompt_guide(
+    async def test_generate_image_description_has_prompt_style_guidance(
         self, server
     ) -> None:
         tools = await server.list_tools()
         gen_tool = next(t for t in tools if t.name == "generate_image")
-        assert "info://prompt-guide" in gen_tool.description
+        assert "prompt_style" in gen_tool.description


### PR DESCRIPTION
## Summary

- `generate_image`: reference `original_uri` instead of `image_id` for polling with `show_image`
- `generate_image`: remove dead `info://prompt-guide` reference, inline `prompt_style` guidance with Flux `negative_prompt` note
- `generate_image`: resolve `background` param contradiction (name models explicitly)
- Server instructions: add `prompt_style` action cue after "call list_providers"
- `list_providers`: explain what to do with `prompt_style` values (CLIP tags vs natural language)
- Update test that checked for removed `info://prompt-guide` reference

Closes #143

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1a | Opening paragraph references `original_uri` | Issue #143, AC 1a | CONFORMANT | `_server_tools.py:100-104` |
| 1b | Returns section says `show_image(uri=original_uri)` | Issue #143, AC 1b | CONFORMANT | `_server_tools.py:142-144` |
| 2a | Remove `info://prompt-guide` reference | Issue #143, AC 2a | CONFORMANT | Grep returns 0 matches in `_server_tools.py` |
| 2b | Inline guidance self-contained with Flux negative_prompt note | Issue #143, AC 2b | CONFORMANT | `_server_tools.py:107-111` |
| 3a | Server instructions mention `prompt_style` | Issue #143, AC 3a | CONFORMANT | `mcp_server.py:63-66` |
| 3b | CLIP vs natural language clause added | Issue #143, AC 3b | CONFORMANT | `mcp_server.py:64` |
| 4a | `list_providers` explains `prompt_style` action | Issue #143, AC 4a | CONFORMANT | `_server_tools.py:808-810` |
| 5a | `background` contradiction resolved | Issue #143, AC 5a | CONFORMANT | `_server_tools.py:132-134` |
| 5b | Models named explicitly | Issue #143, AC 5b | CONFORMANT | `_server_tools.py:132-134` |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan

- [x] `uv run pytest` passes (701 passed)
- [x] `ruff check` passes
- [x] Updated `test_prompt_guide_resource.py` to verify new inline guidance pattern