### PR TITLE
fix: polish secondary LLM-facing descriptions

### DIFF
--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -1461,8 +1461,8 @@ def register_resources(mcp: FastMCP) -> None:
         "info://providers",
         description=(
             "Discover configured providers, available models, each "
-            "model's prompt_style, supported aspect ratios, and "
-            "quality levels."
+            "model's prompt_style, supported aspect ratios, quality "
+            "levels, and background options."
         ),
         icons=[Icon(src=_LUCIDE.format("info"), mimeType="image/svg+xml")],
     )

--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -1461,7 +1461,8 @@ def register_resources(mcp: FastMCP) -> None:
         "info://providers",
         description=(
             "Discover configured providers, available models, each "
-            "model's prompt_style, and supported aspect ratios."
+            "model's prompt_style, supported aspect ratios, and "
+            "quality levels."
         ),
         icons=[Icon(src=_LUCIDE.format("info"), mimeType="image/svg+xml")],
     )

--- a/src/image_generation_mcp/_server_resources.py
+++ b/src/image_generation_mcp/_server_resources.py
@@ -1441,10 +1441,10 @@ def register_resources(mcp: FastMCP) -> None:
     @mcp.resource(
         "info://prompt-guide",
         description=(
-            "Provider-specific prompt writing tips. Read before using "
-            "SD WebUI/Stable Diffusion to learn CLIP tag format, quality "
-            "tags, and negative prompt templates. Also covers OpenAI "
-            "prompt style and provider selection guidance."
+            "Provider-specific prompt writing tips. Covers CLIP tag "
+            "format for SD 1.5/SDXL, Flux natural language style, "
+            "OpenAI prompt guidance, quality tags, negative prompt "
+            "templates, and provider selection."
         ),
         mime_type="text/markdown",
         icons=[Icon(src=_LUCIDE.format("book-open-text"), mimeType="image/svg+xml")],
@@ -1460,8 +1460,8 @@ def register_resources(mcp: FastMCP) -> None:
     @mcp.resource(
         "info://providers",
         description=(
-            "Read this to discover which image providers are configured "
-            "and what aspect ratios and quality levels are supported."
+            "Discover configured providers, available models, each "
+            "model's prompt_style, and supported aspect ratios."
         ),
         icons=[Icon(src=_LUCIDE.format("info"), mimeType="image/svg+xml")],
     )

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -548,8 +548,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         and ``content_type``.  Pending/generating items include ``status``,
         ``progress``, and ``progress_message`` instead of a thumbnail.
 
-        Use ``browse_gallery`` to see all images; use ``show_image`` with
-        a specific ``image_id`` to view one image at full resolution.
+        Use ``browse_gallery`` to see all images; use
+        ``show_image(uri=original_uri)`` to view one image at full
+        resolution.
 
         Returns:
             JSON with gallery data (total count, page metadata, thumbnail

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -549,8 +549,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         ``progress``, and ``progress_message`` instead of a thumbnail.
 
         Use ``browse_gallery`` to see all images; use
-        ``show_image(uri=original_uri)`` to view one image at full
-        resolution.
+        ``show_image(uri="image://{image_id}/view")`` to view one
+        image at full resolution.
 
         Returns:
             JSON with gallery data (total count, page metadata, thumbnail

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -367,11 +367,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 ``width`` (pixels), ``height`` (pixels),
                 ``quality`` (1-100, for lossy formats).
             with_link: When ``True`` (default), include a one-time
-                ``download_url`` in the metadata if the server is
-                running on HTTP transport with ``BASE_URL`` configured.
-                Present this URL directly to the user as a clickable
-                link — the MCP App widget cannot open it from its
-                sandboxed iframe.
+                ``download_url`` in the metadata.  Only available on
+                HTTP deployments with ``BASE_URL`` configured — absent
+                on stdio transport.  If present in the response, show
+                the URL to the user as a clickable link (the MCP App
+                widget cannot open it from its sandboxed iframe).
 
         Returns:
             For completed images: a WebP thumbnail preview (max 512px,
@@ -539,9 +539,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         """Browse all generated images in an interactive visual gallery.
 
         Opens a gallery view showing thumbnail previews of every image in the
-        scratch directory.  The UI renders immediately from the first page of
-        thumbnails returned by this tool, then paginates using the
-        ``gallery_page`` helper.
+        scratch directory.
 
         For non-UI clients the response is a JSON object with ``total``,
         ``page``, ``page_size``, and ``items``.  Each completed item includes
@@ -550,8 +548,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         and ``content_type``.  Pending/generating items include ``status``,
         ``progress``, and ``progress_message`` instead of a thumbnail.
 
-        Use ``show_image`` with the returned ``image_id`` to view a single
-        image at full resolution with metadata.
+        Use ``browse_gallery`` to see all images; use ``show_image`` with
+        a specific ``image_id`` to view one image at full resolution.
 
         Returns:
             JSON with gallery data (total count, page metadata, thumbnail
@@ -864,9 +862,10 @@ def _register_download_link_tool(mcp: FastMCP) -> None:
     ) -> str:
         """Create a one-time download URL for an image.
 
-        Creates a temporary HTTP endpoint that serves the image once,
-        then invalidates the link. Use this to pass images to other
-        MCP servers (e.g., save to a vault, attach to email).
+        Creates a temporary HTTP endpoint that expires after a single
+        download OR when ``ttl_seconds`` elapses, whichever comes first.
+        Use this to pass images to other MCP servers (e.g., save to a
+        vault, attach to email).
 
         The URI should be an ``image://`` resource URI, optionally with
         transform parameters (``format``, ``width``, ``height``,

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -347,8 +347,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         """Display a registered image with optional on-demand transforms.
 
         Also serves as the polling endpoint for fire-and-forget generation.
-        After calling ``generate_image``, call ``show_image`` with the
-        returned ``image_id`` to check progress:
+        After calling ``generate_image``, call
+        ``show_image(uri=original_uri)`` to check progress:
 
         - ``{"status": "generating", ...}`` — image is still being generated
         - ``{"status": "failed", "error": "..."}`` — generation failed


### PR DESCRIPTION
## Summary

- `browse_gallery`: remove reference to app-only `gallery_page` tool, add browse vs show_image guidance
- `show_image`: make `with_link`/`download_url` conditional on HTTP transport
- `show_image`: align polling reference to `show_image(uri=original_uri)` (consistency with #143)
- `create_download_link`: add dual-expiry framing (single-use OR TTL)
- `info://prompt-guide` resource description: add Flux natural language mention
- `info://providers` resource description: add `prompt_style` as key field

Closes #144

**Stack:** PR 2 of 3 — depends on fix/143-critical-tool-descriptions

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1a | Remove `gallery_page` reference | Issue #144, AC 1a | CONFORMANT | `_server_tools.py:540-543` |
| 1b | Add browse vs show_image guidance | Issue #144, AC 1b | CONFORMANT | `_server_tools.py:552-553` |
| 2a | `with_link` conditional on HTTP transport | Issue #144, AC 2a | CONFORMANT | `_server_tools.py:370-372` |
| 2b | "If present in the response" framing | Issue #144, AC 2b | CONFORMANT | `_server_tools.py:373-374` |
| 3a | Dual-expiry framing (single-use OR TTL) | Issue #144, AC 3a | CONFORMANT | `_server_tools.py:866-867` |
| 4a | `info://prompt-guide` adds Flux mention | Issue #144, AC 4a | CONFORMANT | `_server_resources.py:1444-1445` |
| 4b | `info://providers` adds `prompt_style` | Issue #144, AC 4b | CONFORMANT | `_server_resources.py:1463-1464` |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan

- [x] `uv run pytest` passes (701 passed)
- [x] `ruff check` passes
- [x] No test changes needed — docstring/description text only