### PR TITLE
feat: add server-level palette icon for MCP client UIs

### DIFF
--- a/src/image_generation_mcp/mcp_server.py
+++ b/src/image_generation_mcp/mcp_server.py
@@ -21,6 +21,7 @@ from urllib.parse import urlparse
 
 from fastmcp import FastMCP
 from fastmcp.server.transforms import ResourcesAsTools
+from mcp.types import Icon
 
 if TYPE_CHECKING:
     from fastmcp.server.event_store import EventStore
@@ -422,9 +423,12 @@ def create_server(transport: str = "stdio") -> FastMCP:
         "read-only" if is_read_only else "read-write",
     )
 
+    _LUCIDE = "https://unpkg.com/lucide-static/icons/{}.svg"
+
     mcp = FastMCP(
         server_name,
         instructions=instructions,
+        icons=[Icon(src=_LUCIDE.format("palette"), mimeType="image/svg+xml")],
         lifespan=make_service_lifespan(config),
         auth=auth,
     )


### PR DESCRIPTION
## Summary

- Add a Lucide `palette` icon to the FastMCP server constructor so MCP clients can display it next to the server name
- Uses the same `unpkg.com/lucide-static` CDN pattern already used for all tool, resource, and prompt icons
- All public tools, prompts, and resources already had icons; this was the only missing piece

## Design Conformance

No design documents cover server icon configuration — implementation is the spec.

## Test plan

- [x] `create_server()` returns server with `icons` containing the palette SVG URL
- [x] All 701 existing tests pass
- [x] Verified manually: `s.icons` returns `[Icon(src='...palette.svg', mimeType='image/svg+xml')]`

Generated with [Claude Code](https://claude.com/claude-code)