### PR TITLE
feat: add check_generation_status tool to avoid polling UI clutter

### DIFF
--- a/docs/decisions/0005-hybrid-background-tasks.md
+++ b/docs/decisions/0005-hybrid-background-tasks.md
@@ -39,11 +39,12 @@ on Claude.ai, Claude Desktop, and Claude Android.
 3. Spawns the provider call as a background `asyncio.create_task`
 4. Returns immediately with `{"status": "generating", "image_id": "..."}`
 
-The client then polls with `show_image(uri="image://{image_id}/view")`:
+The client polls with `check_generation_status(image_id)` (lightweight, no UI
+card), then calls `show_image` **once** when status is `"completed"`:
 
 - `{"status": "generating", "progress": 0.3, ...}` -- still in progress
+- `{"status": "completed"}` -- ready to display
 - `{"status": "failed", "error": "..."}` -- generation failed
-- Image thumbnail + metadata -- generation complete (normal `show_image` response)
 
 ### Key properties
 
@@ -77,15 +78,20 @@ service (tests, CLI) get synchronous behavior unchanged.
 
 - Works on every MCP client without timeout issues
 - Single code path for all providers
-- `show_image` doubles as both display tool and polling endpoint -- no new tools
+- `check_generation_status` is a lightweight polling tool that returns minimal
+  JSON — no image thumbnail, no AppConfig viewer card.  This prevents the
+  distracting stack of "Image Generation" cards that appeared when the LLM
+  polled via `show_image`
+- `show_image` is called only once for the completed image
 - Progress info (from SD WebUI `/sdapi/v1/progress`) can be stored in
-  `PendingGeneration` and returned via `show_image` polling
+  `PendingGeneration` and returned via `check_generation_status` polling
 - Background failures are captured and surfaced, not silently lost
 
 ### Negative
 
-- Client must call `show_image` at least once to see the result (not automatic)
-- Two tool calls minimum (generate + show) vs. one in the old foreground mode
+- Client must call `check_generation_status` + `show_image` to see the result
+- Three tool calls minimum (generate + check + show) vs. one in the old
+  foreground mode
 - In-process tasks are lost on server restart (acceptable -- no persistence needed
   for ephemeral image generation)
 - The `task=True` decorator is retained for forward compatibility but the tool

--- a/docs/decisions/0005-hybrid-background-tasks.md
+++ b/docs/decisions/0005-hybrid-background-tasks.md
@@ -1,8 +1,8 @@
-# ADR-0005: Inline-Wait Image Generation with Background Fallback
+# ADR-0005: Fire-and-Forget Image Generation
 
 ## Status
 
-Accepted — supersedes the original fire-and-forget decision.
+Accepted — supersedes the original hybrid background task decision.
 
 ## Context
 
@@ -17,47 +17,41 @@ that no server-side mechanism can extend:
 | Claude Code | Configurable, `resetTimeoutOnProgress=True` | **Yes** |
 | Claude Android | ~45s hard tool + ~25s SSE idle | No / Yes (keepalive) |
 
-The previous fire-and-forget approach returned immediately and required the
-LLM to poll via `show_image`.  In practice this created multiple visible
-tool-call cards in the UI (e.g. "Generating (22s)", "Generating (25s)")
-which was disruptive to the user experience.
+The original Option 3 (hybrid foreground progress + background tasks) was
+implemented but live testing on 2026-03-23 confirmed that progress notifications
+do not reset the timeout on any client except Claude Code. Both SD WebUI
+(Flux/60-120s) and OpenAI gpt-image-1 (consistently >45s) time out every time
+on Claude.ai, Claude Desktop, and Claude Android.
 
 ## Decision Drivers
 
-- **Minimal visible tool calls** -- one tool call should produce the result
 - **Universal compatibility** -- must work on all MCP clients without configuration
-- **Respect client timeouts** -- must not exceed the ~45s hard limit
+- **Sub-second tool response** -- tool must return before the shortest client timeout
 - **Zero mandatory infrastructure** -- no Redis, no message queue
+- **Polling via existing tools** -- clients poll with `show_image`, no new protocol
 
 ## Decision
 
-**Inline wait with background fallback.** The `generate_image` tool:
+**Fire-and-forget with polling.** The `generate_image` tool:
 
 1. Validates inputs and resolves the provider (synchronous, <1s)
 2. Pre-allocates an `image_id` and registers a `PendingGeneration`
 3. Spawns the provider call as a background `asyncio.create_task`
-4. **Waits up to 40 seconds** for the task to complete (using
-   `asyncio.wait_for(asyncio.shield(task), timeout=40)`)
-5. If the task completes in time, returns the **completed image inline**
-   (thumbnail + metadata) in a single tool response
-6. If the task times out, returns `{"status": "generating"}` and the
-   background task continues -- client can poll via `show_image`
+4. Returns immediately with `{"status": "generating", "image_id": "..."}`
+
+The client then polls with `show_image(uri="image://{image_id}/view")`:
+
+- `{"status": "generating", "progress": 0.3, ...}` -- still in progress
+- `{"status": "failed", "error": "..."}` -- generation failed
+- Image thumbnail + metadata -- generation complete (normal `show_image` response)
 
 ### Key properties
 
-- **Most providers complete within 40s** -- OpenAI (5-15s), placeholder
-  (instant), SD WebUI standard quality (<30s) all return inline
-- **Only very slow generations fall back to polling** -- HD SD WebUI
-  with complex prompts may exceed 40s
-- **Single tool call for the common case** -- no visible polling cards
-- **Background tasks are in-process `asyncio.Task`s** -- no external
-  infrastructure
-- **`asyncio.shield` prevents task cancellation on timeout** -- the task
-  continues running even when the wait times out
-- **`image://list` includes pending generations** -- clients can discover
-  in-progress work
-- **Cleanup is automatic** -- completed/failed entries expire after TTL
-  (10 min)
+- **All providers use the same path** -- no provider-specific branching
+- **The tool function returns in <1s** -- well within all client timeouts
+- **Background tasks are in-process `asyncio.Task`s** -- no external infrastructure
+- **`image://list` includes pending generations** -- clients can discover in-progress work
+- **Cleanup is automatic** -- completed/failed entries expire after TTL (10 min)
 
 ### Service layer API
 
@@ -74,25 +68,25 @@ service.register_image(..., image_id=...)    # accepts pre-allocated ID
 ### Synchronous callers
 
 `service.generate()` remains a normal async method that blocks until the image
-is ready. Only the MCP tool layer adds the timeout wrapper. Direct callers of
-the service (tests, CLI) get synchronous behavior unchanged.
+is ready. Only the MCP tool layer uses fire-and-forget. Direct callers of the
+service (tests, CLI) get synchronous behavior unchanged.
 
 ## Consequences
 
 ### Positive
 
-- One tool call = one result for the vast majority of generations
-- No visible polling cards cluttering the conversation UI
-- Works on every MCP client without timeout issues (40s < 45s limit)
-- Errors from fast providers surface directly in the tool response
-- Progress info (from SD WebUI `/sdapi/v1/progress`) is still stored in
-  `PendingGeneration` for the rare polling fallback case
+- Works on every MCP client without timeout issues
+- Single code path for all providers
+- `show_image` doubles as both display tool and polling endpoint -- no new tools
+- Progress info (from SD WebUI `/sdapi/v1/progress`) can be stored in
+  `PendingGeneration` and returned via `show_image` polling
+- Background failures are captured and surfaced, not silently lost
 
 ### Negative
 
-- For very slow generations (>40s), client must still call `show_image`
-  to retrieve the result (two tool calls minimum)
-- In-process tasks are lost on server restart (acceptable -- no persistence
-  needed for ephemeral image generation)
-- The `task=True` decorator is retained for forward compatibility but the
-  tool's inline wait handles most cases before MCP task mode activates
+- Client must call `show_image` at least once to see the result (not automatic)
+- Two tool calls minimum (generate + show) vs. one in the old foreground mode
+- In-process tasks are lost on server restart (acceptable -- no persistence needed
+  for ephemeral image generation)
+- The `task=True` decorator is retained for forward compatibility but the tool
+  no longer blocks long enough for MCP background task mode to be useful

--- a/docs/decisions/0005-hybrid-background-tasks.md
+++ b/docs/decisions/0005-hybrid-background-tasks.md
@@ -1,8 +1,8 @@
-# ADR-0005: Fire-and-Forget Image Generation
+# ADR-0005: Inline-Wait Image Generation with Background Fallback
 
 ## Status
 
-Accepted — supersedes the original hybrid background task decision.
+Accepted — supersedes the original fire-and-forget decision.
 
 ## Context
 
@@ -17,41 +17,47 @@ that no server-side mechanism can extend:
 | Claude Code | Configurable, `resetTimeoutOnProgress=True` | **Yes** |
 | Claude Android | ~45s hard tool + ~25s SSE idle | No / Yes (keepalive) |
 
-The original Option 3 (hybrid foreground progress + background tasks) was
-implemented but live testing on 2026-03-23 confirmed that progress notifications
-do not reset the timeout on any client except Claude Code. Both SD WebUI
-(Flux/60-120s) and OpenAI gpt-image-1 (consistently >45s) time out every time
-on Claude.ai, Claude Desktop, and Claude Android.
+The previous fire-and-forget approach returned immediately and required the
+LLM to poll via `show_image`.  In practice this created multiple visible
+tool-call cards in the UI (e.g. "Generating (22s)", "Generating (25s)")
+which was disruptive to the user experience.
 
 ## Decision Drivers
 
+- **Minimal visible tool calls** -- one tool call should produce the result
 - **Universal compatibility** -- must work on all MCP clients without configuration
-- **Sub-second tool response** -- tool must return before the shortest client timeout
+- **Respect client timeouts** -- must not exceed the ~45s hard limit
 - **Zero mandatory infrastructure** -- no Redis, no message queue
-- **Polling via existing tools** -- clients poll with `show_image`, no new protocol
 
 ## Decision
 
-**Fire-and-forget with polling.** The `generate_image` tool:
+**Inline wait with background fallback.** The `generate_image` tool:
 
 1. Validates inputs and resolves the provider (synchronous, <1s)
 2. Pre-allocates an `image_id` and registers a `PendingGeneration`
 3. Spawns the provider call as a background `asyncio.create_task`
-4. Returns immediately with `{"status": "generating", "image_id": "..."}`
-
-The client then polls with `show_image(uri="image://{image_id}/view")`:
-
-- `{"status": "generating", "progress": 0.3, ...}` -- still in progress
-- `{"status": "failed", "error": "..."}` -- generation failed
-- Image thumbnail + metadata -- generation complete (normal `show_image` response)
+4. **Waits up to 40 seconds** for the task to complete (using
+   `asyncio.wait_for(asyncio.shield(task), timeout=40)`)
+5. If the task completes in time, returns the **completed image inline**
+   (thumbnail + metadata) in a single tool response
+6. If the task times out, returns `{"status": "generating"}` and the
+   background task continues -- client can poll via `show_image`
 
 ### Key properties
 
-- **All providers use the same path** -- no provider-specific branching
-- **The tool function returns in <1s** -- well within all client timeouts
-- **Background tasks are in-process `asyncio.Task`s** -- no external infrastructure
-- **`image://list` includes pending generations** -- clients can discover in-progress work
-- **Cleanup is automatic** -- completed/failed entries expire after TTL (10 min)
+- **Most providers complete within 40s** -- OpenAI (5-15s), placeholder
+  (instant), SD WebUI standard quality (<30s) all return inline
+- **Only very slow generations fall back to polling** -- HD SD WebUI
+  with complex prompts may exceed 40s
+- **Single tool call for the common case** -- no visible polling cards
+- **Background tasks are in-process `asyncio.Task`s** -- no external
+  infrastructure
+- **`asyncio.shield` prevents task cancellation on timeout** -- the task
+  continues running even when the wait times out
+- **`image://list` includes pending generations** -- clients can discover
+  in-progress work
+- **Cleanup is automatic** -- completed/failed entries expire after TTL
+  (10 min)
 
 ### Service layer API
 
@@ -68,25 +74,25 @@ service.register_image(..., image_id=...)    # accepts pre-allocated ID
 ### Synchronous callers
 
 `service.generate()` remains a normal async method that blocks until the image
-is ready. Only the MCP tool layer uses fire-and-forget. Direct callers of the
-service (tests, CLI) get synchronous behavior unchanged.
+is ready. Only the MCP tool layer adds the timeout wrapper. Direct callers of
+the service (tests, CLI) get synchronous behavior unchanged.
 
 ## Consequences
 
 ### Positive
 
-- Works on every MCP client without timeout issues
-- Single code path for all providers
-- `show_image` doubles as both display tool and polling endpoint -- no new tools
-- Progress info (from SD WebUI `/sdapi/v1/progress`) can be stored in
-  `PendingGeneration` and returned via `show_image` polling
-- Background failures are captured and surfaced, not silently lost
+- One tool call = one result for the vast majority of generations
+- No visible polling cards cluttering the conversation UI
+- Works on every MCP client without timeout issues (40s < 45s limit)
+- Errors from fast providers surface directly in the tool response
+- Progress info (from SD WebUI `/sdapi/v1/progress`) is still stored in
+  `PendingGeneration` for the rare polling fallback case
 
 ### Negative
 
-- Client must call `show_image` at least once to see the result (not automatic)
-- Two tool calls minimum (generate + show) vs. one in the old foreground mode
-- In-process tasks are lost on server restart (acceptable -- no persistence needed
-  for ephemeral image generation)
-- The `task=True` decorator is retained for forward compatibility but the tool
-  no longer blocks long enough for MCP background task mode to be useful
+- For very slow generations (>40s), client must still call `show_image`
+  to retrieve the result (two tool calls minimum)
+- In-process tasks are lost on server restart (acceptable -- no persistence
+  needed for ephemeral image generation)
+- The `task=True` decorator is retained for forward compatibility but the
+  tool's inline wait handles most cases before MCP task mode activates

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,14 +4,14 @@ image-generation-mcp exposes four domain tools plus two auto-generated resource-
 
 ## generate_image
 
-Generate an image from a text prompt. Waits for completion (up to ~40s) and returns the image inline with a thumbnail preview and metadata. If generation takes longer, returns `status: "generating"` — call `show_image(uri=original_uri)` to retrieve the result later. Check each model's `prompt_style` in `list_providers` to choose CLIP tags vs. natural language prompts.
+Generate an image from a text prompt. Returns immediately with a `status: "generating"` response while the image is generated in the background. Call `show_image(uri=original_uri)` to check progress and display the result. Check each model's `prompt_style` in `list_providers` to choose CLIP tags vs. natural language prompts.
 
 | Property | Value |
 |----------|-------|
 | **Tags** | `write` (hidden in read-only mode) |
 | **Annotations** | `readOnlyHint: false`, `destructiveHint: false`, `openWorldHint: true` |
-| **Task** | `task=True` (retained for forward compatibility) |
-| **Pattern** | Inline wait (up to 40s) with background fallback |
+| **Task** | `task=True` (retained for forward compatibility; no longer blocks) |
+| **Pattern** | Fire-and-forget — returns in &lt;1s, client polls `show_image` |
 
 ### Parameters
 
@@ -27,46 +27,36 @@ Generate an image from a text prompt. Waits for completion (up to ~40s) and retu
 
 ### Return value
 
-Returns a `ToolResult` containing:
+Returns immediately with a `ToolResult` containing:
 
-**When completed inline (most cases):**
-
-1. **ImageContent** -- WebP thumbnail (max 512px, <1MB)
-2. **TextContent** -- JSON metadata with `status: "completed"`
-3. **ResourceLink** -- URI reference to `image://{id}/view`
+1. **TextContent** -- JSON metadata with `status: "generating"`:
+2. **ResourceLink** -- URI reference to `image://{id}/view` (image pending)
 
 ```json
 {
-  "status": "completed",
+  "status": "generating",
   "image_id": "a1b2c3d4e5f6",
   "prompt": "watercolor painting of a mountain landscape at sunset",
   "provider": "openai",
-  "model": "gpt-image-1",
-  "dimensions": [1024, 1024],
+  "prompt_style": null,
   "original_uri": "image://a1b2c3d4e5f6/view",
   "metadata_uri": "image://a1b2c3d4e5f6/metadata",
   "resource_template": "image://a1b2c3d4e5f6/view{?format,width,height,quality,crop_x,crop_y,crop_w,crop_h,rotate,flip}"
 }
 ```
 
-**When generation exceeds 40s (rare):**
+Call `show_image` with the `original_uri` to poll for completion and display the image once ready.
 
-1. **TextContent** -- JSON metadata with `status: "generating"`
-2. **ResourceLink** -- URI reference to `image://{id}/view` (image pending)
+### Fire-and-forget workflow
 
-Call `show_image` with the `original_uri` to retrieve the result once ready.
+The tool uses a fire-and-forget pattern to avoid client tool-execution timeouts (~45s on Claude.ai/Desktop/Android):
 
-### Inline wait with background fallback
-
-The tool waits up to 40 seconds for the image to be generated. Most providers complete well within this window:
-
-- **Placeholder**: instant
-- **OpenAI**: 5-15s
-- **SD WebUI (standard)**: 10-30s
-
-If generation completes within the timeout, the result is returned directly — **one tool call, one result, no polling**. This avoids the disruptive pattern of multiple visible tool-call cards in the conversation UI.
-
-For very slow generations (>40s, e.g., HD SD WebUI with complex prompts), the tool falls back to returning `status: "generating"`. The background task continues running and the client can poll via `show_image`.
+1. **`generate_image`** returns in &lt;1s with `"status": "generating"` and a pre-allocated `image_id`
+2. **Background task** generates the image and registers it in the scratch directory
+3. **`show_image`** polls for status:
+    - `{"status": "generating", "progress": 0.3, "progress_message": "Step 9/30 (ETA 12s)", ...}` -- still in progress (SD WebUI reports step-level detail; other providers report `0.0` until complete)
+    - `{"status": "failed", "error": "..."}` -- generation failed
+    - Image thumbnail + metadata -- generation complete
 
 The `image://list` resource also includes pending generations with their status.
 
@@ -98,9 +88,9 @@ Tool call: generate_image
 
 ## show_image
 
-Display a registered image with optional on-demand transforms. Accepts a full `image://` resource URI with transforms encoded in the query string.
+Display a registered image with optional on-demand transforms, or poll for generation status. Accepts a full `image://` resource URI with transforms encoded in the query string.
 
-Normally `generate_image` returns the completed image directly. Use `show_image` when you need to apply transforms (resize, crop, format conversion) or as a fallback if `generate_image` returned `status: "generating"`.
+Also serves as the polling endpoint for fire-and-forget generation: after calling `generate_image`, call `show_image(uri=original_uri)` to check progress and display the result once ready.
 
 | Property | Value |
 |----------|-------|

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,14 +4,14 @@ image-generation-mcp exposes four domain tools plus two auto-generated resource-
 
 ## generate_image
 
-Generate an image from a text prompt. Returns immediately with a `status: "generating"` response while the image is generated in the background. Call `show_image(uri=original_uri)` to check progress and display the result. Check each model's `prompt_style` in `list_providers` to choose CLIP tags vs. natural language prompts.
+Generate an image from a text prompt. Waits for completion (up to ~40s) and returns the image inline with a thumbnail preview and metadata. If generation takes longer, returns `status: "generating"` — call `show_image(uri=original_uri)` to retrieve the result later. Check each model's `prompt_style` in `list_providers` to choose CLIP tags vs. natural language prompts.
 
 | Property | Value |
 |----------|-------|
 | **Tags** | `write` (hidden in read-only mode) |
 | **Annotations** | `readOnlyHint: false`, `destructiveHint: false`, `openWorldHint: true` |
-| **Task** | `task=True` (retained for forward compatibility; no longer blocks) |
-| **Pattern** | Fire-and-forget — returns in &lt;1s, client polls `show_image` |
+| **Task** | `task=True` (retained for forward compatibility) |
+| **Pattern** | Inline wait (up to 40s) with background fallback |
 
 ### Parameters
 
@@ -27,36 +27,46 @@ Generate an image from a text prompt. Returns immediately with a `status: "gener
 
 ### Return value
 
-Returns immediately with a `ToolResult` containing:
+Returns a `ToolResult` containing:
 
-1. **TextContent** -- JSON metadata with `status: "generating"`:
-2. **ResourceLink** -- URI reference to `image://{id}/view` (image pending)
+**When completed inline (most cases):**
+
+1. **ImageContent** -- WebP thumbnail (max 512px, <1MB)
+2. **TextContent** -- JSON metadata with `status: "completed"`
+3. **ResourceLink** -- URI reference to `image://{id}/view`
 
 ```json
 {
-  "status": "generating",
+  "status": "completed",
   "image_id": "a1b2c3d4e5f6",
   "prompt": "watercolor painting of a mountain landscape at sunset",
   "provider": "openai",
-  "prompt_style": null,
+  "model": "gpt-image-1",
+  "dimensions": [1024, 1024],
   "original_uri": "image://a1b2c3d4e5f6/view",
   "metadata_uri": "image://a1b2c3d4e5f6/metadata",
   "resource_template": "image://a1b2c3d4e5f6/view{?format,width,height,quality,crop_x,crop_y,crop_w,crop_h,rotate,flip}"
 }
 ```
 
-Call `show_image` with the `original_uri` to poll for completion and display the image once ready.
+**When generation exceeds 40s (rare):**
 
-### Fire-and-forget workflow
+1. **TextContent** -- JSON metadata with `status: "generating"`
+2. **ResourceLink** -- URI reference to `image://{id}/view` (image pending)
 
-The tool uses a fire-and-forget pattern to avoid client tool-execution timeouts (~45s on Claude.ai/Desktop/Android):
+Call `show_image` with the `original_uri` to retrieve the result once ready.
 
-1. **`generate_image`** returns in &lt;1s with `"status": "generating"` and a pre-allocated `image_id`
-2. **Background task** generates the image and registers it in the scratch directory
-3. **`show_image`** polls for status:
-    - `{"status": "generating", "progress": 0.3, "progress_message": "Step 9/30 (ETA 12s)", ...}` -- still in progress (SD WebUI reports step-level detail; other providers report `0.0` until complete)
-    - `{"status": "failed", "error": "..."}` -- generation failed
-    - Image thumbnail + metadata -- generation complete
+### Inline wait with background fallback
+
+The tool waits up to 40 seconds for the image to be generated. Most providers complete well within this window:
+
+- **Placeholder**: instant
+- **OpenAI**: 5-15s
+- **SD WebUI (standard)**: 10-30s
+
+If generation completes within the timeout, the result is returned directly — **one tool call, one result, no polling**. This avoids the disruptive pattern of multiple visible tool-call cards in the conversation UI.
+
+For very slow generations (>40s, e.g., HD SD WebUI with complex prompts), the tool falls back to returning `status: "generating"`. The background task continues running and the client can poll via `show_image`.
 
 The `image://list` resource also includes pending generations with their status.
 
@@ -88,9 +98,9 @@ Tool call: generate_image
 
 ## show_image
 
-Display a registered image with optional on-demand transforms, or poll for generation status. Accepts a full `image://` resource URI with transforms encoded in the query string.
+Display a registered image with optional on-demand transforms. Accepts a full `image://` resource URI with transforms encoded in the query string.
 
-Also serves as the polling endpoint for fire-and-forget generation: after calling `generate_image`, call `show_image(uri=original_uri)` to check progress and display the result once ready.
+Normally `generate_image` returns the completed image directly. Use `show_image` when you need to apply transforms (resize, crop, format conversion) or as a fallback if `generate_image` returned `status: "generating"`.
 
 | Property | Value |
 |----------|-------|

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,14 +4,14 @@ image-generation-mcp exposes four domain tools plus two auto-generated resource-
 
 ## generate_image
 
-Generate an image from a text prompt. Returns immediately with a `status: "generating"` response while the image is generated in the background. Call `show_image(uri=original_uri)` to check progress and display the result. Check each model's `prompt_style` in `list_providers` to choose CLIP tags vs. natural language prompts.
+Generate an image from a text prompt. Returns immediately with a `status: "generating"` response while the image is generated in the background (typically 30-90 seconds). Use `check_generation_status(image_id)` to wait for completion, then call `show_image(uri=original_uri)` **once** to display the result. Check each model's `prompt_style` in `list_providers` to choose CLIP tags vs. natural language prompts.
 
 | Property | Value |
 |----------|-------|
 | **Tags** | `write` (hidden in read-only mode) |
 | **Annotations** | `readOnlyHint: false`, `destructiveHint: false`, `openWorldHint: true` |
 | **Task** | `task=True` (retained for forward compatibility; no longer blocks) |
-| **Pattern** | Fire-and-forget — returns in &lt;1s, client polls `show_image` |
+| **Pattern** | Fire-and-forget — returns in &lt;1s, poll via `check_generation_status`, display via `show_image` |
 
 ### Parameters
 
@@ -45,7 +45,7 @@ Returns immediately with a `ToolResult` containing:
 }
 ```
 
-Call `show_image` with the `original_uri` to poll for completion and display the image once ready.
+Use `check_generation_status(image_id)` to poll for completion, then call `show_image(uri=original_uri)` **once** to display the finished image.
 
 ### Fire-and-forget workflow
 
@@ -53,12 +53,16 @@ The tool uses a fire-and-forget pattern to avoid client tool-execution timeouts 
 
 1. **`generate_image`** returns in &lt;1s with `"status": "generating"` and a pre-allocated `image_id`
 2. **Background task** generates the image and registers it in the scratch directory
-3. **`show_image`** polls for status:
-    - `{"status": "generating", "progress": 0.3, "progress_message": "Step 9/30 (ETA 12s)", ...}` -- still in progress (SD WebUI reports step-level detail; other providers report `0.0` until complete)
+3. **`check_generation_status`** polls for status (lightweight, no UI card):
+    - `{"status": "generating", "progress": 0.3, "progress_message": "Step 9/30 (ETA 12s)", ...}` -- still in progress
+    - `{"status": "completed"}` -- ready to display
     - `{"status": "failed", "error": "..."}` -- generation failed
-    - Image thumbnail + metadata -- generation complete
+4. **`show_image`** displays the finished image **once** when status is `"completed"`
 
 The `image://list` resource also includes pending generations with their status.
+
+!!! note "Why a separate polling tool?"
+    `show_image` renders a full image viewer card with thumbnail — calling it repeatedly to poll creates a distracting stack of cards in the conversation UI. `check_generation_status` returns minimal JSON text, keeping polling invisible to the user.
 
 ### Cost confirmation (elicitation)
 
@@ -88,9 +92,37 @@ Tool call: generate_image
 
 ## show_image
 
-Display a registered image with optional on-demand transforms, or poll for generation status. Accepts a full `image://` resource URI with transforms encoded in the query string.
+## check_generation_status
 
-Also serves as the polling endpoint for fire-and-forget generation: after calling `generate_image`, call `show_image(uri=original_uri)` to check progress and display the result once ready.
+Lightweight status check for background image generation. Returns a short JSON string with `status`, `image_id`, and progress info — no image data, no heavy UI card.
+
+| Property | Value |
+|----------|-------|
+| **Tags** | *(none)* — always visible |
+| **Annotations** | `readOnlyHint: true`, `destructiveHint: false`, `openWorldHint: false`, `idempotentHint: true` |
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image_id` | str | *(required)* | The `image_id` returned by `generate_image` |
+
+### Return values
+
+| Status | Meaning | Next step |
+|--------|---------|-----------|
+| `"generating"` | Still in progress | Wait and check again |
+| `"completed"` | Image ready | Call `show_image(uri=original_uri)` |
+| `"failed"` | Generation failed | Report `error` to the user |
+| `"unknown"` | ID not found | Invalid or expired `image_id` |
+
+---
+
+## show_image
+
+Display a completed image with optional on-demand transforms. Accepts a full `image://` resource URI with transforms encoded in the query string.
+
+**Only call this for completed images** — use `check_generation_status` to poll, then call `show_image` once when status is `"completed"`.
 
 | Property | Value |
 |----------|-------|

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -100,13 +100,23 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         config: ServerConfig = Depends(get_config),
         ctx: Context = CurrentContext(),
     ) -> ToolResult:
-        """Generate an image and return metadata with resource URIs.
+        """Generate an image in the background and return metadata.
 
-        Returns immediately with ``{"status": "generating",
-        "original_uri": "image://…/original"}`` while the image is
-        generated in the background.  Call
-        ``show_image(uri=original_uri)`` to check progress and display
-        the result once ready.
+        Returns immediately while the image generates in the background
+        (typically 30-90 seconds).
+
+        **After calling this tool:**
+
+        1. Tell the user the image is being generated.
+        2. Call ``check_generation_status(image_id)`` to wait for
+           completion.  It returns ``"completed"``, ``"generating"``,
+           or ``"failed"``.
+        3. Only when status is ``"completed"``, call
+           ``show_image(uri=original_uri)`` **once** to display the
+           finished image.
+
+        **Do NOT call show_image to poll** — it renders a heavy UI
+        card each time.  Use ``check_generation_status`` instead.
 
         Call list_providers first to see available providers and model IDs.
         Check each model's ``prompt_style`` in list_providers to choose the
@@ -143,9 +153,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 to the provider's configured model.
 
         Returns:
-            JSON metadata with ``status``, ``original_uri``, and other
-            resource URIs.  Call ``show_image(uri=original_uri)`` to
-            poll progress and display the result.
+            JSON metadata with ``status``, ``image_id``, and
+            ``original_uri``.  Use ``check_generation_status(image_id)``
+            to wait, then ``show_image(uri=original_uri)`` once ready.
         """
         if aspect_ratio not in SUPPORTED_ASPECT_RATIOS:
             msg = (
@@ -339,6 +349,69 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "readOnlyHint": True,
             "destructiveHint": False,
             "openWorldHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def check_generation_status(
+        image_id: str,
+        service: ImageService = Depends(get_service),
+    ) -> str:
+        """Check whether a background image generation has finished.
+
+        Call this after ``generate_image`` to wait for completion.
+        Returns a short JSON status — no image data, no heavy UI.
+
+        - ``"completed"`` → call ``show_image(uri=original_uri)`` to
+          display the finished image.
+        - ``"generating"`` → wait and check again.
+        - ``"failed"`` → report the error to the user.
+
+        Args:
+            image_id: The ``image_id`` returned by ``generate_image``.
+
+        Returns:
+            JSON with ``status`` and, for failed generations, ``error``.
+        """
+        pending = service.get_pending(image_id)
+
+        if pending is None:
+            # No pending entry — either already completed or unknown
+            try:
+                await asyncio.to_thread(service.get_image, image_id)
+                return json.dumps({"status": "completed", "image_id": image_id})
+            except Exception:
+                return json.dumps(
+                    {"status": "unknown", "image_id": image_id,
+                     "error": "No pending or completed image with this ID."}
+                )
+
+        if pending.status == "generating":
+            return json.dumps({
+                "status": "generating",
+                "image_id": image_id,
+                "progress": pending.progress,
+                "progress_message": pending.progress_message,
+                "elapsed_seconds": round(time.time() - pending.created_at, 1),
+            })
+
+        if pending.status == "failed":
+            error = pending.error or "Unknown error"
+            service.cleanup_pending(image_id)
+            return json.dumps({
+                "status": "failed",
+                "image_id": image_id,
+                "error": error,
+            })
+
+        # completed
+        service.cleanup_pending(image_id)
+        return json.dumps({"status": "completed", "image_id": image_id})
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "openWorldHint": False,
         },
         icons=[Icon(src=_LUCIDE.format("eye"), mimeType="image/svg+xml")],
         app=AppConfig(resourceUri=_IMAGE_VIEWER_URI),
@@ -349,15 +422,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         service: ImageService = Depends(get_service),
         config: ServerConfig = Depends(get_config),
     ) -> ToolResult:
-        """Display a registered image with optional on-demand transforms.
+        """Display a completed image with optional on-demand transforms.
 
-        Also serves as the polling endpoint for fire-and-forget generation.
-        After calling ``generate_image``, call
-        ``show_image(uri=original_uri)`` to check progress:
-
-        - ``{"status": "generating", ...}`` — image is still being generated
-        - ``{"status": "failed", "error": "..."}`` — generation failed
-        - Image thumbnail + metadata — generation complete
+        **Only call this for completed images** — use
+        ``check_generation_status`` to poll, then call this once when
+        ``status`` is ``"completed"``.
 
         Accepts a full ``image://`` resource URI (e.g.
         ``image://abc123/view`` or
@@ -398,7 +467,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         quality = int(qs.get("quality", ["90"])[0])
         quality = max(1, min(100, quality))
 
-        # Check for pending (fire-and-forget) generation
+        # Check for pending (fire-and-forget) generation — delegate
+        # to check_generation_status for the lightweight response.
         pending = service.get_pending(image_id)
         if pending is not None and pending.status == "generating":
             meta = {

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -66,7 +66,6 @@ _THUMBNAIL_MAX_PX = 512
 _GALLERY_THUMBNAIL_MAX_PX = 128
 _GALLERY_PAGE_SIZE = 12
 _BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
-_INLINE_WAIT_S = 40.0  # max seconds to wait inline before falling back
 
 
 def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
@@ -101,13 +100,13 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         config: ServerConfig = Depends(get_config),
         ctx: Context = CurrentContext(),
     ) -> ToolResult:
-        """Generate an image and return the result with a thumbnail preview.
+        """Generate an image and return metadata with resource URIs.
 
-        Waits for the image to be generated (up to ~40 s) and returns the
-        completed image inline with a thumbnail and metadata.  If the
-        generation takes longer, returns ``{"status": "generating"}`` —
-        call ``show_image(uri=original_uri)`` to retrieve the result
-        later.  Most providers complete well within the timeout.
+        Returns immediately with ``{"status": "generating",
+        "original_uri": "image://…/original"}`` while the image is
+        generated in the background.  Call
+        ``show_image(uri=original_uri)`` to check progress and display
+        the result once ready.
 
         Call list_providers first to see available providers and model IDs.
         Check each model's ``prompt_style`` in list_providers to choose the
@@ -219,23 +218,23 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             model=model,
         )
 
-        # Progress callback updates PendingGeneration so show_image
-        # polling returns step-level detail for SD WebUI.
-        pending = service.get_pending(image_id)
-        if pending is None:
-            logger.warning(
-                "get_pending(%s) returned None; progress updates will be lost",
-                image_id,
-            )
-
-        def _on_progress(fraction: float, message: str) -> None:
-            if pending is not None:
-                pending.progress = fraction
-                pending.progress_message = message
-
         # Spawn background generation task
         async def _background_generate() -> None:
             try:
+                # Progress callback updates PendingGeneration so show_image
+                # polling returns step-level detail for SD WebUI.
+                pending = service.get_pending(image_id)
+                if pending is None:
+                    logger.warning(
+                        "get_pending(%s) returned None; progress updates will be lost",
+                        image_id,
+                    )
+
+                def _on_progress(fraction: float, message: str) -> None:
+                    if pending is not None:
+                        pending.progress = fraction
+                        pending.progress_message = message
+
                 provider_name, result = await service.generate(
                     prompt,
                     provider=resolved_name,
@@ -295,19 +294,6 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         _BACKGROUND_TASKS.add(task)
         task.add_done_callback(_BACKGROUND_TASKS.discard)
 
-        # Try to await completion within timeout.  MCP clients (Claude)
-        # enforce a hard ~45 s tool-call timeout, so we wait up to 40 s
-        # for the image.  If the generation finishes in time, return the
-        # completed image inline — no polling required.  Otherwise fall
-        # back to "generating" status so the client can poll via
-        # show_image (rare for most providers).
-        try:
-            await asyncio.wait_for(asyncio.shield(task), timeout=_INLINE_WAIT_S)
-        except TimeoutError:
-            pass  # generation still running — fall through to pending response
-        except Exception:
-            pass  # error already handled inside _background_generate
-
         # Resolve prompt_style from capabilities for the response
         prompt_style = None
         caps = service.capabilities.get(resolved_name)
@@ -320,49 +306,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             elif len(caps.models) == 1:
                 prompt_style = caps.models[0].prompt_style
 
-        # Check if the generation completed (or failed) in time
-        completed_pending = service.get_pending(image_id)
-
-        if completed_pending is not None and completed_pending.status == "failed":
-            error = completed_pending.error or "Unknown error"
-            service.cleanup_pending(image_id)
-            return ToolResult(
-                content=[
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {
-                                "status": "failed",
-                                "image_id": image_id,
-                                "error": error,
-                            },
-                            indent=2,
-                        ),
-                    )
-                ],
-            )
-
-        if completed_pending is None or completed_pending.status == "completed":
-            # Generation completed — return the image inline
-            if completed_pending is not None:
-                service.cleanup_pending(image_id)
-            try:
-                record = await asyncio.to_thread(service.get_image, image_id)
-            except Exception:
-                # Edge case: completed_pending was cleaned up but image
-                # not yet registered. Fall through to pending response.
-                pass
-            else:
-                return await _build_completed_response(
-                    record=record,
-                    image_id=image_id,
-                    prompt=prompt,
-                    provider_name=resolved_name,
-                    prompt_style=prompt_style,
-                    config=config,
-                )
-
-        # Generation still in progress — return pending status
+        # Return immediately with pending status
         metadata = {
             "status": "generating",
             "image_id": image_id,
@@ -390,78 +334,6 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             ]
         )
 
-    async def _build_completed_response(
-        *,
-        record: ImageRecord,
-        image_id: str,
-        prompt: str,
-        provider_name: str,
-        prompt_style: str | None,
-        config: ServerConfig,
-    ) -> ToolResult:
-        """Build the completed-image ToolResult with thumbnail + metadata."""
-        data = await asyncio.to_thread(record.original_path.read_bytes)
-
-        def _make_thumb(src: bytes) -> tuple[bytes, str, tuple[int, int]]:
-            td, tm = generate_thumbnail(src, _THUMBNAIL_MAX_PX, "webp", 80)
-            tw, th = PILImage.open(io.BytesIO(td)).size
-            return td, tm, (tw, th)
-
-        thumb_data, thumb_mime, thumb_dims = await asyncio.to_thread(
-            _make_thumb, data
-        )
-        thumb_b64 = base64.b64encode(thumb_data).decode("ascii")
-        original_stat = await asyncio.to_thread(record.original_path.stat)
-
-        metadata: dict[str, object] = {
-            "status": "completed",
-            "image_id": image_id,
-            "prompt": prompt,
-            "provider": provider_name,
-            "prompt_style": prompt_style,
-            "model": record.provider_metadata.get("model"),
-            "dimensions": list(record.original_dimensions),
-            "thumbnail_dimensions": list(thumb_dims),
-            "original_size_bytes": original_stat.st_size,
-            "original_uri": f"image://{image_id}/view",
-            "metadata_uri": f"image://{image_id}/metadata",
-            "resource_template": (
-                f"image://{image_id}/view{{?format,width,height,quality,crop_x,crop_y,crop_w,crop_h,rotate,flip}}"
-            ),
-        }
-
-        base_url = (config.base_url or "").rstrip("/")
-        if base_url:
-            from .artifacts import get_artifact_store
-
-            try:
-                store = get_artifact_store()
-                token = store.create_token(
-                    f"image://{image_id}/view", ttl_seconds=300
-                )
-                metadata["download_url"] = f"{base_url}/artifacts/{token}"
-            except RuntimeError:
-                pass
-
-        return ToolResult(
-            content=[
-                ImageContent(
-                    type="image",
-                    data=thumb_b64,
-                    mimeType=thumb_mime,
-                ),
-                TextContent(
-                    type="text",
-                    text=json.dumps(metadata, indent=2),
-                ),
-                ResourceLink(
-                    type="resource_link",
-                    uri=AnyUrl(f"image://{image_id}/view"),
-                    name="Generated image",
-                ),
-            ]
-        )
-
     @mcp.tool(
         annotations={
             "readOnlyHint": True,
@@ -479,10 +351,13 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
     ) -> ToolResult:
         """Display a registered image with optional on-demand transforms.
 
-        Normally ``generate_image`` returns the completed image directly.
-        Use ``show_image`` only when you need to apply transforms (resize,
-        crop, format conversion) via the URI query string, or as a
-        fallback if ``generate_image`` returned ``status="generating"``:
+        Also serves as the polling endpoint for fire-and-forget generation.
+        After calling ``generate_image``, call
+        ``show_image(uri=original_uri)`` to check progress:
+
+        - ``{"status": "generating", ...}`` — image is still being generated
+        - ``{"status": "failed", "error": "..."}`` — generation failed
+        - Image thumbnail + metadata — generation complete
 
         Accepts a full ``image://`` resource URI (e.g.
         ``image://abc123/view`` or

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -66,6 +66,7 @@ _THUMBNAIL_MAX_PX = 512
 _GALLERY_THUMBNAIL_MAX_PX = 128
 _GALLERY_PAGE_SIZE = 12
 _BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
+_INLINE_WAIT_S = 40.0  # max seconds to wait inline before falling back
 
 
 def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
@@ -100,13 +101,13 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         config: ServerConfig = Depends(get_config),
         ctx: Context = CurrentContext(),
     ) -> ToolResult:
-        """Generate an image and return metadata with resource URIs.
+        """Generate an image and return the result with a thumbnail preview.
 
-        Returns immediately with ``{"status": "generating",
-        "original_uri": "image://…/original"}`` while the image is
-        generated in the background.  Call
-        ``show_image(uri=original_uri)`` to check progress and display
-        the result once ready.
+        Waits for the image to be generated (up to ~40 s) and returns the
+        completed image inline with a thumbnail and metadata.  If the
+        generation takes longer, returns ``{"status": "generating"}`` —
+        call ``show_image(uri=original_uri)`` to retrieve the result
+        later.  Most providers complete well within the timeout.
 
         Call list_providers first to see available providers and model IDs.
         Check each model's ``prompt_style`` in list_providers to choose the
@@ -218,23 +219,23 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             model=model,
         )
 
+        # Progress callback updates PendingGeneration so show_image
+        # polling returns step-level detail for SD WebUI.
+        pending = service.get_pending(image_id)
+        if pending is None:
+            logger.warning(
+                "get_pending(%s) returned None; progress updates will be lost",
+                image_id,
+            )
+
+        def _on_progress(fraction: float, message: str) -> None:
+            if pending is not None:
+                pending.progress = fraction
+                pending.progress_message = message
+
         # Spawn background generation task
         async def _background_generate() -> None:
             try:
-                # Progress callback updates PendingGeneration so show_image
-                # polling returns step-level detail for SD WebUI.
-                pending = service.get_pending(image_id)
-                if pending is None:
-                    logger.warning(
-                        "get_pending(%s) returned None; progress updates will be lost",
-                        image_id,
-                    )
-
-                def _on_progress(fraction: float, message: str) -> None:
-                    if pending is not None:
-                        pending.progress = fraction
-                        pending.progress_message = message
-
                 provider_name, result = await service.generate(
                     prompt,
                     provider=resolved_name,
@@ -294,6 +295,19 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         _BACKGROUND_TASKS.add(task)
         task.add_done_callback(_BACKGROUND_TASKS.discard)
 
+        # Try to await completion within timeout.  MCP clients (Claude)
+        # enforce a hard ~45 s tool-call timeout, so we wait up to 40 s
+        # for the image.  If the generation finishes in time, return the
+        # completed image inline — no polling required.  Otherwise fall
+        # back to "generating" status so the client can poll via
+        # show_image (rare for most providers).
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=_INLINE_WAIT_S)
+        except TimeoutError:
+            pass  # generation still running — fall through to pending response
+        except Exception:
+            pass  # error already handled inside _background_generate
+
         # Resolve prompt_style from capabilities for the response
         prompt_style = None
         caps = service.capabilities.get(resolved_name)
@@ -306,7 +320,49 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             elif len(caps.models) == 1:
                 prompt_style = caps.models[0].prompt_style
 
-        # Return immediately with pending status
+        # Check if the generation completed (or failed) in time
+        completed_pending = service.get_pending(image_id)
+
+        if completed_pending is not None and completed_pending.status == "failed":
+            error = completed_pending.error or "Unknown error"
+            service.cleanup_pending(image_id)
+            return ToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "status": "failed",
+                                "image_id": image_id,
+                                "error": error,
+                            },
+                            indent=2,
+                        ),
+                    )
+                ],
+            )
+
+        if completed_pending is None or completed_pending.status == "completed":
+            # Generation completed — return the image inline
+            if completed_pending is not None:
+                service.cleanup_pending(image_id)
+            try:
+                record = await asyncio.to_thread(service.get_image, image_id)
+            except Exception:
+                # Edge case: completed_pending was cleaned up but image
+                # not yet registered. Fall through to pending response.
+                pass
+            else:
+                return await _build_completed_response(
+                    record=record,
+                    image_id=image_id,
+                    prompt=prompt,
+                    provider_name=resolved_name,
+                    prompt_style=prompt_style,
+                    config=config,
+                )
+
+        # Generation still in progress — return pending status
         metadata = {
             "status": "generating",
             "image_id": image_id,
@@ -334,6 +390,78 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             ]
         )
 
+    async def _build_completed_response(
+        *,
+        record: ImageRecord,
+        image_id: str,
+        prompt: str,
+        provider_name: str,
+        prompt_style: str | None,
+        config: ServerConfig,
+    ) -> ToolResult:
+        """Build the completed-image ToolResult with thumbnail + metadata."""
+        data = await asyncio.to_thread(record.original_path.read_bytes)
+
+        def _make_thumb(src: bytes) -> tuple[bytes, str, tuple[int, int]]:
+            td, tm = generate_thumbnail(src, _THUMBNAIL_MAX_PX, "webp", 80)
+            tw, th = PILImage.open(io.BytesIO(td)).size
+            return td, tm, (tw, th)
+
+        thumb_data, thumb_mime, thumb_dims = await asyncio.to_thread(
+            _make_thumb, data
+        )
+        thumb_b64 = base64.b64encode(thumb_data).decode("ascii")
+        original_stat = await asyncio.to_thread(record.original_path.stat)
+
+        metadata: dict[str, object] = {
+            "status": "completed",
+            "image_id": image_id,
+            "prompt": prompt,
+            "provider": provider_name,
+            "prompt_style": prompt_style,
+            "model": record.provider_metadata.get("model"),
+            "dimensions": list(record.original_dimensions),
+            "thumbnail_dimensions": list(thumb_dims),
+            "original_size_bytes": original_stat.st_size,
+            "original_uri": f"image://{image_id}/view",
+            "metadata_uri": f"image://{image_id}/metadata",
+            "resource_template": (
+                f"image://{image_id}/view{{?format,width,height,quality,crop_x,crop_y,crop_w,crop_h,rotate,flip}}"
+            ),
+        }
+
+        base_url = (config.base_url or "").rstrip("/")
+        if base_url:
+            from .artifacts import get_artifact_store
+
+            try:
+                store = get_artifact_store()
+                token = store.create_token(
+                    f"image://{image_id}/view", ttl_seconds=300
+                )
+                metadata["download_url"] = f"{base_url}/artifacts/{token}"
+            except RuntimeError:
+                pass
+
+        return ToolResult(
+            content=[
+                ImageContent(
+                    type="image",
+                    data=thumb_b64,
+                    mimeType=thumb_mime,
+                ),
+                TextContent(
+                    type="text",
+                    text=json.dumps(metadata, indent=2),
+                ),
+                ResourceLink(
+                    type="resource_link",
+                    uri=AnyUrl(f"image://{image_id}/view"),
+                    name="Generated image",
+                ),
+            ]
+        )
+
     @mcp.tool(
         annotations={
             "readOnlyHint": True,
@@ -351,13 +479,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
     ) -> ToolResult:
         """Display a registered image with optional on-demand transforms.
 
-        Also serves as the polling endpoint for fire-and-forget generation.
-        After calling ``generate_image``, call
-        ``show_image(uri=original_uri)`` to check progress:
-
-        - ``{"status": "generating", ...}`` — image is still being generated
-        - ``{"status": "failed", "error": "..."}`` — generation failed
-        - Image thumbnail + metadata — generation complete
+        Normally ``generate_image`` returns the completed image directly.
+        Use ``show_image`` only when you need to apply transforms (resize,
+        crop, format conversion) via the URI query string, or as a
+        fallback if ``generate_image`` returned ``status="generating"``:
 
         Accepts a full ``image://`` resource URI (e.g.
         ``image://abc123/view`` or

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -55,6 +55,7 @@ from .providers.types import (
     SUPPORTED_QUALITY_LEVELS,
     ImageContentPolicyError,
     ImageProviderConnectionError,
+    ImageProviderError,
     ImageResult,
 )
 from .service import ImageRecord, ImageService, PendingGeneration
@@ -370,7 +371,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             image_id: The ``image_id`` returned by ``generate_image``.
 
         Returns:
-            JSON with ``status`` and, for failed generations, ``error``.
+            JSON with ``status``, ``image_id``, and optional
+            ``progress``, ``progress_message``, ``elapsed_seconds``,
+            or ``error``.
         """
         pending = service.get_pending(image_id)
 
@@ -379,29 +382,36 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             try:
                 await asyncio.to_thread(service.get_image, image_id)
                 return json.dumps({"status": "completed", "image_id": image_id})
-            except Exception:
+            except ImageProviderError:
                 return json.dumps(
-                    {"status": "unknown", "image_id": image_id,
-                     "error": "No pending or completed image with this ID."}
+                    {
+                        "status": "unknown",
+                        "image_id": image_id,
+                        "error": "No pending or completed image with this ID.",
+                    }
                 )
 
         if pending.status == "generating":
-            return json.dumps({
-                "status": "generating",
-                "image_id": image_id,
-                "progress": pending.progress,
-                "progress_message": pending.progress_message,
-                "elapsed_seconds": round(time.time() - pending.created_at, 1),
-            })
+            return json.dumps(
+                {
+                    "status": "generating",
+                    "image_id": image_id,
+                    "progress": pending.progress,
+                    "progress_message": pending.progress_message,
+                    "elapsed_seconds": round(time.time() - pending.created_at, 1),
+                }
+            )
 
         if pending.status == "failed":
             error = pending.error or "Unknown error"
             service.cleanup_pending(image_id)
-            return json.dumps({
-                "status": "failed",
-                "image_id": image_id,
-                "error": error,
-            })
+            return json.dumps(
+                {
+                    "status": "failed",
+                    "image_id": image_id,
+                    "error": error,
+                }
+            )
 
         # completed
         service.cleanup_pending(image_id)
@@ -467,34 +477,27 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         quality = int(qs.get("quality", ["90"])[0])
         quality = max(1, min(100, quality))
 
-        # Check for pending (fire-and-forget) generation — delegate
-        # to check_generation_status for the lightweight response.
+        # If image is still generating or failed, redirect to the
+        # lightweight polling tool instead of rendering a heavy card.
         pending = service.get_pending(image_id)
-        if pending is not None and pending.status == "generating":
-            meta = {
-                "status": "generating",
-                "image_id": image_id,
-                "prompt": pending.prompt,
-                "provider": pending.provider,
-                "progress": pending.progress,
-                "progress_message": pending.progress_message,
-                "elapsed_seconds": round(time.time() - pending.created_at, 1),
-            }
+        if pending is not None and pending.status in ("generating", "failed"):
             return ToolResult(
-                content=[TextContent(type="text", text=json.dumps(meta, indent=2))]
-            )
-
-        if pending is not None and pending.status == "failed":
-            meta = {
-                "status": "failed",
-                "image_id": image_id,
-                "prompt": pending.prompt,
-                "provider": pending.provider,
-                "error": pending.error,
-            }
-            service.cleanup_pending(image_id)
-            return ToolResult(
-                content=[TextContent(type="text", text=json.dumps(meta, indent=2))]
+                content=[
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "status": pending.status,
+                                "image_id": image_id,
+                                "error": (
+                                    "Image not ready. Use "
+                                    "check_generation_status(image_id) to poll."
+                                ),
+                            },
+                            indent=2,
+                        ),
+                    )
+                ]
             )
 
         # Completed pending — clean up and fall through to normal display

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -378,10 +378,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         pending = service.get_pending(image_id)
 
         if pending is None:
-            # No pending entry — either already completed or unknown
+            # No pending entry — either already completed or unknown.
+            # get_image is a dict lookup (no file I/O).
             try:
                 await asyncio.to_thread(service.get_image, image_id)
-                return json.dumps({"status": "completed", "image_id": image_id})
             except ImageProviderError:
                 return json.dumps(
                     {
@@ -390,6 +390,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                         "error": "No pending or completed image with this ID.",
                     }
                 )
+            return json.dumps({"status": "completed", "image_id": image_id})
 
         if pending.status == "generating":
             return json.dumps(

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -38,9 +38,11 @@ async def _generate_and_wait(
     provider: str = "placeholder",
     **kwargs: str,
 ) -> str:
-    """Generate an image via fire-and-forget and wait for completion.
+    """Generate an image and return the image_id.
 
-    Returns the image_id once the image is ready.
+    With the inline-wait behaviour, generate_image returns the completed
+    image directly for fast providers like placeholder.  Falls back to
+    polling via show_image only if the tool returned ``status="generating"``.
 
     Args:
         client: An active FastMCP Client.
@@ -59,9 +61,12 @@ async def _generate_and_wait(
     text_items = [c for c in result.content if isinstance(c, TextContent)]
     metadata = json.loads(text_items[0].text)
     image_id = metadata["image_id"]
-    assert metadata["status"] == "generating"
 
-    # Poll until complete (placeholder is near-instant)
+    # If inline wait succeeded, image is already completed
+    if metadata["status"] == "completed":
+        return image_id
+
+    # Fallback: poll until complete (rare — only for slow providers)
     for _ in range(50):
         await asyncio.sleep(0.05)
         show = await client.call_tool("show_image", {"uri": f"image://{image_id}/view"})
@@ -128,7 +133,7 @@ class TestGenerateImageThroughClient:
         assert "resource_template" in metadata
         assert metadata["original_uri"].startswith("image://")
         assert "{?format" in metadata["resource_template"]
-        assert metadata["status"] == "generating"
+        assert metadata["status"] == "completed"
 
     async def test_returns_resource_link(self, rw_server) -> None:
         """Result contains a ResourceLink with an image:// URI."""
@@ -142,19 +147,19 @@ class TestGenerateImageThroughClient:
         link_items = [c for c in result.content if isinstance(c, ResourceLink)]
         assert len(link_items) == 1
         assert str(link_items[0].uri).startswith("image://")
-        assert link_items[0].name == "Generated image (generating)"
+        assert link_items[0].name == "Generated image"
 
-    async def test_no_image_content_in_result(self, rw_server) -> None:
-        """generate_image must not return ImageContent (thumbnail is in show_image)."""
+    async def test_returns_image_content_inline(self, rw_server) -> None:
+        """generate_image returns ImageContent inline for fast providers."""
         async with Client(rw_server) as client:
             result = await client.call_tool(
                 "generate_image",
-                {"prompt": "no image content test", "provider": "placeholder"},
+                {"prompt": "inline image test", "provider": "placeholder"},
             )
 
         assert not result.is_error
         image_items = [c for c in result.content if isinstance(c, ImageContent)]
-        assert image_items == [], "generate_image must not return ImageContent"
+        assert len(image_items) == 1, "generate_image should return ImageContent inline"
 
     async def test_resource_link_uri_matches_image_id(self, rw_server) -> None:
         """ResourceLink URI matches the image_id from the TextContent metadata."""

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -38,11 +38,9 @@ async def _generate_and_wait(
     provider: str = "placeholder",
     **kwargs: str,
 ) -> str:
-    """Generate an image and return the image_id.
+    """Generate an image via fire-and-forget and wait for completion.
 
-    With the inline-wait behaviour, generate_image returns the completed
-    image directly for fast providers like placeholder.  Falls back to
-    polling via show_image only if the tool returned ``status="generating"``.
+    Returns the image_id once the image is ready.
 
     Args:
         client: An active FastMCP Client.
@@ -61,12 +59,9 @@ async def _generate_and_wait(
     text_items = [c for c in result.content if isinstance(c, TextContent)]
     metadata = json.loads(text_items[0].text)
     image_id = metadata["image_id"]
+    assert metadata["status"] == "generating"
 
-    # If inline wait succeeded, image is already completed
-    if metadata["status"] == "completed":
-        return image_id
-
-    # Fallback: poll until complete (rare — only for slow providers)
+    # Poll until complete (placeholder is near-instant)
     for _ in range(50):
         await asyncio.sleep(0.05)
         show = await client.call_tool("show_image", {"uri": f"image://{image_id}/view"})
@@ -133,7 +128,7 @@ class TestGenerateImageThroughClient:
         assert "resource_template" in metadata
         assert metadata["original_uri"].startswith("image://")
         assert "{?format" in metadata["resource_template"]
-        assert metadata["status"] == "completed"
+        assert metadata["status"] == "generating"
 
     async def test_returns_resource_link(self, rw_server) -> None:
         """Result contains a ResourceLink with an image:// URI."""
@@ -147,19 +142,19 @@ class TestGenerateImageThroughClient:
         link_items = [c for c in result.content if isinstance(c, ResourceLink)]
         assert len(link_items) == 1
         assert str(link_items[0].uri).startswith("image://")
-        assert link_items[0].name == "Generated image"
+        assert link_items[0].name == "Generated image (generating)"
 
-    async def test_returns_image_content_inline(self, rw_server) -> None:
-        """generate_image returns ImageContent inline for fast providers."""
+    async def test_no_image_content_in_result(self, rw_server) -> None:
+        """generate_image must not return ImageContent (thumbnail is in show_image)."""
         async with Client(rw_server) as client:
             result = await client.call_tool(
                 "generate_image",
-                {"prompt": "inline image test", "provider": "placeholder"},
+                {"prompt": "no image content test", "provider": "placeholder"},
             )
 
         assert not result.is_error
         image_items = [c for c in result.content if isinstance(c, ImageContent)]
-        assert len(image_items) == 1, "generate_image should return ImageContent inline"
+        assert image_items == [], "generate_image must not return ImageContent"
 
     async def test_resource_link_uri_matches_image_id(self, rw_server) -> None:
         """ResourceLink URI matches the image_id from the TextContent metadata."""

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -112,7 +112,7 @@ async def test_background_tasks_set_holds_reference(tmp_path: Path) -> None:
     assert len(_BACKGROUND_TASKS) > size_before
 
     # Wait for the background task to finish
-    await asyncio.sleep(0.3)
+    await asyncio.sleep(0.5)
     # Task removed itself on completion
     assert len(_BACKGROUND_TASKS) == size_before
 
@@ -164,10 +164,10 @@ async def test_background_task_completes_after_return(tmp_path: Path) -> None:
     assert show_meta.get("status") not in ("generating", "failed")
 
 
-async def test_show_image_returns_generating_for_in_progress(
+async def test_show_image_redirects_to_check_for_in_progress(
     tmp_path: Path,
 ) -> None:
-    """show_image returns status='generating' while background task is running."""
+    """show_image redirects to check_generation_status while task is running."""
     svc = ImageService(scratch_dir=tmp_path)
 
     # Use a slow provider so we can inspect mid-generation state
@@ -205,7 +205,7 @@ async def test_show_image_returns_generating_for_in_progress(
     text_items = [c for c in result.content if isinstance(c, TextContent)]
     image_id = json.loads(text_items[0].text)["image_id"]
 
-    # Call show_image immediately — background task is still running
+    # Call show_image immediately — should redirect to check_generation_status
     show_cfg = MagicMock()
     show_cfg.base_url = None
     show_result = await show_tool.fn(
@@ -217,10 +217,10 @@ async def test_show_image_returns_generating_for_in_progress(
     show_meta = json.loads(show_text[0].text)
     assert show_meta["status"] == "generating"
     assert show_meta["image_id"] == image_id
-    assert "elapsed_seconds" in show_meta
+    assert "check_generation_status" in show_meta["error"]
 
     # Wait for background task to finish to avoid warnings
-    await asyncio.sleep(0.6)
+    await asyncio.sleep(0.8)
 
 
 async def test_check_generation_status_returns_generating(
@@ -271,7 +271,7 @@ async def test_check_generation_status_returns_generating(
     assert "elapsed_seconds" in status
 
     # Wait for completion and check again
-    await asyncio.sleep(0.6)
+    await asyncio.sleep(0.8)
     status_json = await check_tool.fn(image_id=image_id, service=svc)
     status = json.loads(status_json)
     assert status["status"] == "completed"
@@ -315,6 +315,35 @@ async def test_check_generation_status_returns_completed(
     assert status["status"] == "completed"
 
 
+async def test_check_generation_status_completed_pending_entry(
+    tmp_path: Path,
+) -> None:
+    """check_generation_status returns 'completed' when pending.status == 'completed'."""
+    svc = ImageService(scratch_dir=tmp_path)
+    svc.register_provider("placeholder", PlaceholderImageProvider())
+
+    # Manually register a pending entry and mark it completed
+    svc.register_pending(
+        image_id="test123",
+        prompt="manual test",
+        provider="placeholder",
+    )
+    svc.complete_pending("test123")
+
+    mcp = FastMCP("test")
+    register_tools(mcp)
+    check_tool = await mcp.get_tool("check_generation_status")
+    assert check_tool is not None
+
+    status_json = await check_tool.fn(image_id="test123", service=svc)
+    status = json.loads(status_json)
+    assert status["status"] == "completed"
+    assert status["image_id"] == "test123"
+
+    # Pending entry should be cleaned up
+    assert svc.get_pending("test123") is None
+
+
 async def test_check_generation_status_returns_failed(
     tmp_path: Path,
 ) -> None:
@@ -326,8 +355,8 @@ async def test_check_generation_status_returns_failed(
     async def _always_raise(*_args: object, **_kwargs: object) -> None:
         raise ImageContentPolicyError("placeholder", "blocked")
 
-    svc.generate = _always_raise  # type: ignore[assignment]
     svc.register_provider("placeholder", PlaceholderImageProvider())
+    svc.generate = _always_raise  # type: ignore[assignment]
 
     mcp = FastMCP("test")
     register_tools(mcp)
@@ -424,4 +453,4 @@ async def test_image_list_includes_pending_generation(
         assert "progress_message" in pending_match[0]
 
         # Wait for background task to finish to avoid warnings
-        await asyncio.sleep(0.6)
+        await asyncio.sleep(0.8)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -223,6 +223,160 @@ async def test_show_image_returns_generating_for_in_progress(
     await asyncio.sleep(0.6)
 
 
+async def test_check_generation_status_returns_generating(
+    tmp_path: Path,
+) -> None:
+    """check_generation_status returns 'generating' while task is running."""
+    svc = ImageService(scratch_dir=tmp_path)
+
+    original_provider = PlaceholderImageProvider()
+    original_generate = original_provider.generate
+
+    async def slow_generate(*args: object, **kwargs: object) -> object:
+        await asyncio.sleep(0.5)
+        return await original_generate(*args, **kwargs)  # type: ignore[arg-type]
+
+    original_provider.generate = slow_generate  # type: ignore[assignment]
+    svc.register_provider("placeholder", original_provider)
+
+    mcp = FastMCP("test")
+    register_tools(mcp)
+    gen_tool = await mcp.get_tool("generate_image")
+    check_tool = await mcp.get_tool("check_generation_status")
+    assert gen_tool is not None
+    assert check_tool is not None
+
+    ctx = MagicMock()
+    ctx.report_progress = AsyncMock()
+    ctx.info = AsyncMock()
+    ctx.session.check_client_capability.return_value = False
+    cfg = MagicMock()
+    cfg.paid_providers = frozenset()
+
+    result = await gen_tool.fn(
+        prompt="status check test",
+        provider="placeholder",
+        service=svc,
+        config=cfg,
+        ctx=ctx,
+    )
+    text_items = [c for c in result.content if isinstance(c, TextContent)]
+    image_id = json.loads(text_items[0].text)["image_id"]
+
+    # Check immediately — should be generating
+    status_json = await check_tool.fn(image_id=image_id, service=svc)
+    status = json.loads(status_json)
+    assert status["status"] == "generating"
+    assert status["image_id"] == image_id
+    assert "elapsed_seconds" in status
+
+    # Wait for completion and check again
+    await asyncio.sleep(0.6)
+    status_json = await check_tool.fn(image_id=image_id, service=svc)
+    status = json.loads(status_json)
+    assert status["status"] == "completed"
+
+
+async def test_check_generation_status_returns_completed(
+    tmp_path: Path,
+) -> None:
+    """check_generation_status returns 'completed' for finished images."""
+    svc = ImageService(scratch_dir=tmp_path)
+    svc.register_provider("placeholder", PlaceholderImageProvider())
+
+    mcp = FastMCP("test")
+    register_tools(mcp)
+    gen_tool = await mcp.get_tool("generate_image")
+    check_tool = await mcp.get_tool("check_generation_status")
+    assert gen_tool is not None
+    assert check_tool is not None
+
+    ctx = MagicMock()
+    ctx.report_progress = AsyncMock()
+    ctx.info = AsyncMock()
+    ctx.session.check_client_capability.return_value = False
+    cfg = MagicMock()
+    cfg.paid_providers = frozenset()
+
+    result = await gen_tool.fn(
+        prompt="completed check test",
+        provider="placeholder",
+        service=svc,
+        config=cfg,
+        ctx=ctx,
+    )
+    text_items = [c for c in result.content if isinstance(c, TextContent)]
+    image_id = json.loads(text_items[0].text)["image_id"]
+
+    # Placeholder is near-instant
+    await asyncio.sleep(0.1)
+    status_json = await check_tool.fn(image_id=image_id, service=svc)
+    status = json.loads(status_json)
+    assert status["status"] == "completed"
+
+
+async def test_check_generation_status_returns_failed(
+    tmp_path: Path,
+) -> None:
+    """check_generation_status returns 'failed' with error for failed generations."""
+    svc = ImageService(scratch_dir=tmp_path)
+
+    from image_generation_mcp.providers.types import ImageContentPolicyError
+
+    async def _always_raise(*_args: object, **_kwargs: object) -> None:
+        raise ImageContentPolicyError("placeholder", "blocked")
+
+    svc.generate = _always_raise  # type: ignore[assignment]
+    svc.register_provider("placeholder", PlaceholderImageProvider())
+
+    mcp = FastMCP("test")
+    register_tools(mcp)
+    gen_tool = await mcp.get_tool("generate_image")
+    check_tool = await mcp.get_tool("check_generation_status")
+    assert gen_tool is not None
+    assert check_tool is not None
+
+    ctx = MagicMock()
+    ctx.report_progress = AsyncMock()
+    ctx.info = AsyncMock()
+    ctx.session.check_client_capability.return_value = False
+    cfg = MagicMock()
+    cfg.paid_providers = frozenset()
+
+    result = await gen_tool.fn(
+        prompt="fail check test",
+        provider="placeholder",
+        service=svc,
+        config=cfg,
+        ctx=ctx,
+    )
+    text_items = [c for c in result.content if isinstance(c, TextContent)]
+    image_id = json.loads(text_items[0].text)["image_id"]
+
+    # Let the background task fail
+    await asyncio.sleep(0.1)
+    status_json = await check_tool.fn(image_id=image_id, service=svc)
+    status = json.loads(status_json)
+    assert status["status"] == "failed"
+    assert "error" in status
+
+
+async def test_check_generation_status_unknown_id(
+    tmp_path: Path,
+) -> None:
+    """check_generation_status returns 'unknown' for non-existent image_id."""
+    svc = ImageService(scratch_dir=tmp_path)
+
+    mcp = FastMCP("test")
+    register_tools(mcp)
+    check_tool = await mcp.get_tool("check_generation_status")
+    assert check_tool is not None
+
+    status_json = await check_tool.fn(image_id="nonexistent", service=svc)
+    status = json.loads(status_json)
+    assert status["status"] == "unknown"
+
+
 async def test_image_list_includes_pending_generation(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,17 +1,17 @@
-"""Tests for inline-wait and background task fallback in generate_image."""
+"""Tests for fire-and-forget background task support in generate_image."""
 
 from __future__ import annotations
 
 import asyncio
 import json
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 from fastmcp import FastMCP
-from mcp.types import ImageContent, TextContent
+from mcp.types import TextContent
 
 from image_generation_mcp._server_tools import _BACKGROUND_TASKS, register_tools
 from image_generation_mcp.providers.placeholder import PlaceholderImageProvider
@@ -39,10 +39,10 @@ async def test_list_providers_no_task() -> None:
     assert tool.task_config.mode == "forbidden"
 
 
-async def test_generate_image_returns_completed_for_fast_provider(
+async def test_generate_image_returns_generating_immediately(
     tmp_path: Path,
 ) -> None:
-    """generate_image returns status='completed' with image for fast providers."""
+    """generate_image returns status='generating' without waiting for completion."""
     svc = ImageService(scratch_dir=tmp_path)
     svc.register_provider("placeholder", PlaceholderImageProvider())
 
@@ -57,10 +57,9 @@ async def test_generate_image_returns_completed_for_fast_provider(
     ctx.session.check_client_capability.return_value = False
     cfg = MagicMock()
     cfg.paid_providers = frozenset()
-    cfg.base_url = None
 
     result = await tool.fn(
-        prompt="inline wait test",
+        prompt="fire-and-forget test",
         provider="placeholder",
         service=svc,
         config=cfg,
@@ -70,71 +69,8 @@ async def test_generate_image_returns_completed_for_fast_provider(
     text_items = [c for c in result.content if isinstance(c, TextContent)]
     assert len(text_items) == 1
     metadata = json.loads(text_items[0].text)
-    assert metadata["status"] == "completed"
-    assert "image_id" in metadata
-    assert "dimensions" in metadata
-
-    # Should include an inline thumbnail
-    image_items = [c for c in result.content if isinstance(c, ImageContent)]
-    assert len(image_items) == 1
-
-
-async def test_generate_image_falls_back_to_generating_on_timeout(
-    tmp_path: Path,
-) -> None:
-    """generate_image returns 'generating' when the inline wait times out."""
-    svc = ImageService(scratch_dir=tmp_path)
-
-    # Provider that takes much longer than the inline wait
-    original_provider = PlaceholderImageProvider()
-    original_generate = original_provider.generate
-
-    async def very_slow_generate(*args: object, **kwargs: object) -> object:
-        await asyncio.sleep(60)  # longer than the 40s timeout
-        return await original_generate(*args, **kwargs)  # type: ignore[arg-type]
-
-    original_provider.generate = very_slow_generate  # type: ignore[assignment]
-    svc.register_provider("placeholder", original_provider)
-
-    mcp = FastMCP("test")
-    register_tools(mcp)
-    tool = await mcp.get_tool("generate_image")
-    assert tool is not None
-
-    ctx = MagicMock()
-    ctx.report_progress = AsyncMock()
-    ctx.info = AsyncMock()
-    ctx.session.check_client_capability.return_value = False
-    cfg = MagicMock()
-    cfg.paid_providers = frozenset()
-    cfg.base_url = None
-
-    # Patch the inline wait timeout to a short value for testing
-    with patch(
-        "image_generation_mcp._server_tools._INLINE_WAIT_S", 0.1
-    ):
-        result = await tool.fn(
-            prompt="timeout fallback test",
-            provider="placeholder",
-            service=svc,
-            config=cfg,
-            ctx=ctx,
-        )
-
-    text_items = [c for c in result.content if isinstance(c, TextContent)]
-    assert len(text_items) == 1
-    metadata = json.loads(text_items[0].text)
     assert metadata["status"] == "generating"
     assert "image_id" in metadata
-
-    # No inline image for pending generation
-    image_items = [c for c in result.content if isinstance(c, ImageContent)]
-    assert image_items == []
-
-    # Clean up: cancel the lingering background task
-    for task in list(_BACKGROUND_TASKS):
-        task.cancel()
-    await asyncio.sleep(0.1)
 
 
 async def test_background_tasks_set_holds_reference(tmp_path: Path) -> None:
@@ -146,7 +82,7 @@ async def test_background_tasks_set_holds_reference(tmp_path: Path) -> None:
     original_generate = original_provider.generate
 
     async def slow_generate(*args: object, **kwargs: object) -> object:
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.2)
         return await original_generate(*args, **kwargs)  # type: ignore[arg-type]
 
     original_provider.generate = slow_generate  # type: ignore[assignment]
@@ -163,32 +99,26 @@ async def test_background_tasks_set_holds_reference(tmp_path: Path) -> None:
     ctx.session.check_client_capability.return_value = False
     cfg = MagicMock()
     cfg.paid_providers = frozenset()
-    cfg.base_url = None
 
     size_before = len(_BACKGROUND_TASKS)
-
-    # Use a short inline wait so we return while background task is still running
-    with patch(
-        "image_generation_mcp._server_tools._INLINE_WAIT_S", 0.1
-    ):
-        await tool.fn(
-            prompt="background tasks test",
-            provider="placeholder",
-            service=svc,
-            config=cfg,
-            ctx=ctx,
-        )
+    await tool.fn(
+        prompt="background tasks test",
+        provider="placeholder",
+        service=svc,
+        config=cfg,
+        ctx=ctx,
+    )
     # Task was added to _BACKGROUND_TASKS while still running
     assert len(_BACKGROUND_TASKS) > size_before
 
     # Wait for the background task to finish
-    await asyncio.sleep(0.6)
+    await asyncio.sleep(0.3)
     # Task removed itself on completion
     assert len(_BACKGROUND_TASKS) == size_before
 
 
-async def test_completed_image_available_via_show_image(tmp_path: Path) -> None:
-    """After generate_image completes inline, show_image returns the image."""
+async def test_background_task_completes_after_return(tmp_path: Path) -> None:
+    """Background task registers the image after generate_image returns."""
     svc = ImageService(scratch_dir=tmp_path)
     svc.register_provider("placeholder", PlaceholderImageProvider())
 
@@ -203,7 +133,6 @@ async def test_completed_image_available_via_show_image(tmp_path: Path) -> None:
     ctx.session.check_client_capability.return_value = False
     cfg = MagicMock()
     cfg.paid_providers = frozenset()
-    cfg.base_url = None
 
     result = await tool.fn(
         prompt="completion test",
@@ -216,6 +145,9 @@ async def test_completed_image_available_via_show_image(tmp_path: Path) -> None:
     text_items = [c for c in result.content if isinstance(c, TextContent)]
     image_id = json.loads(text_items[0].text)["image_id"]
 
+    # Placeholder is near-instant; after a brief wait the image is registered
+    await asyncio.sleep(0.1)
+
     show_tool = await mcp.get_tool("show_image")
     assert show_tool is not None
     show_cfg = MagicMock()
@@ -227,6 +159,8 @@ async def test_completed_image_available_via_show_image(tmp_path: Path) -> None:
     )
     show_text = [c for c in show_result.content if isinstance(c, TextContent)]
     show_meta = json.loads(show_text[0].text)
+    # After completion the pending entry is cleaned up and show_image returns
+    # the normal image thumbnail (status key absent or not 'generating'/'failed')
     assert show_meta.get("status") not in ("generating", "failed")
 
 
@@ -260,19 +194,14 @@ async def test_show_image_returns_generating_for_in_progress(
     ctx.session.check_client_capability.return_value = False
     cfg = MagicMock()
     cfg.paid_providers = frozenset()
-    cfg.base_url = None
 
-    # Short inline wait so generate_image returns while still generating
-    with patch(
-        "image_generation_mcp._server_tools._INLINE_WAIT_S", 0.1
-    ):
-        result = await gen_tool.fn(
-            prompt="slow generation test",
-            provider="placeholder",
-            service=svc,
-            config=cfg,
-            ctx=ctx,
-        )
+    result = await gen_tool.fn(
+        prompt="slow generation test",
+        provider="placeholder",
+        service=svc,
+        config=cfg,
+        ctx=ctx,
+    )
     text_items = [c for c in result.content if isinstance(c, TextContent)]
     image_id = json.loads(text_items[0].text)["image_id"]
 
@@ -306,44 +235,39 @@ async def test_image_list_includes_pending_generation(
 
     config = ServerConfig(scratch_dir=tmp_path, read_only=False)
 
-    # Monkeypatch PlaceholderImageProvider.generate at the class level so
-    # the lifespan-created service uses the slow version.
-    _original_generate = PlaceholderImageProvider.generate
+    # Patch PlaceholderImageProvider to be slow so generation stays pending
+    original_provider = PlaceholderImageProvider()
+    original_generate = original_provider.generate
 
-    async def slow_generate(self: object, *args: object, **kwargs: object) -> object:
-        await asyncio.sleep(5.0)
-        return await _original_generate(self, *args, **kwargs)  # type: ignore[arg-type]
+    async def slow_generate(*args: object, **kwargs: object) -> object:
+        await asyncio.sleep(0.5)
+        return await original_generate(*args, **kwargs)  # type: ignore[arg-type]
+
+    original_provider.generate = slow_generate  # type: ignore[assignment]
 
     mcp = FastMCP("test-list-pending", lifespan=make_service_lifespan(config))
     register_tools(mcp)
     register_resources(mcp)
 
-    # Short inline wait so call_tool returns while generation is pending
-    with (
-        patch.object(PlaceholderImageProvider, "generate", slow_generate),
-        patch("image_generation_mcp._server_tools._INLINE_WAIT_S", 0.1),
-    ):
-        async with Client(mcp) as client:
-            gen_result = await client.call_tool(
-                "generate_image",
-                {"prompt": "list pending test", "provider": "placeholder"},
-            )
-            text = next(c for c in gen_result.content if c.type == "text")
-            image_id = json.loads(text.text)["image_id"]
+    async with Client(mcp) as client:
+        gen_result = await client.call_tool(
+            "generate_image",
+            {"prompt": "list pending test", "provider": "placeholder"},
+        )
+        text = next(c for c in gen_result.content if c.type == "text")
+        image_id = json.loads(text.text)["image_id"]
 
-            # Read image://list while generation is still pending
-            list_result = await client.read_resource("image://list")
-            items = json.loads(list_result[0].text)  # type: ignore[union-attr]
-            pending_items = [i for i in items if i.get("status") == "generating"]
-            assert len(pending_items) >= 1
-            pending_match = [i for i in pending_items if i["image_id"] == image_id]
-            assert len(pending_match) == 1
-            assert pending_match[0]["provider"] == "placeholder"
-            assert pending_match[0]["prompt"] == "list pending test"
-            assert "progress" in pending_match[0]
-            assert "progress_message" in pending_match[0]
+        # Read image://list while generation is still pending
+        list_result = await client.read_resource("image://list")
+        items = json.loads(list_result[0].text)  # type: ignore[union-attr]
+        pending_items = [i for i in items if i.get("status") == "generating"]
+        assert len(pending_items) >= 1
+        pending_match = [i for i in pending_items if i["image_id"] == image_id]
+        assert len(pending_match) == 1
+        assert pending_match[0]["provider"] == "placeholder"
+        assert pending_match[0]["prompt"] == "list pending test"
+        assert "progress" in pending_match[0]
+        assert "progress_message" in pending_match[0]
 
-    # Clean up: cancel lingering background tasks
-    for t in list(_BACKGROUND_TASKS):
-        t.cancel()
-    await asyncio.sleep(0.1)
+        # Wait for background task to finish to avoid warnings
+        await asyncio.sleep(0.6)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,17 +1,17 @@
-"""Tests for fire-and-forget background task support in generate_image."""
+"""Tests for inline-wait and background task fallback in generate_image."""
 
 from __future__ import annotations
 
 import asyncio
 import json
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 from fastmcp import FastMCP
-from mcp.types import TextContent
+from mcp.types import ImageContent, TextContent
 
 from image_generation_mcp._server_tools import _BACKGROUND_TASKS, register_tools
 from image_generation_mcp.providers.placeholder import PlaceholderImageProvider
@@ -39,10 +39,10 @@ async def test_list_providers_no_task() -> None:
     assert tool.task_config.mode == "forbidden"
 
 
-async def test_generate_image_returns_generating_immediately(
+async def test_generate_image_returns_completed_for_fast_provider(
     tmp_path: Path,
 ) -> None:
-    """generate_image returns status='generating' without waiting for completion."""
+    """generate_image returns status='completed' with image for fast providers."""
     svc = ImageService(scratch_dir=tmp_path)
     svc.register_provider("placeholder", PlaceholderImageProvider())
 
@@ -57,9 +57,10 @@ async def test_generate_image_returns_generating_immediately(
     ctx.session.check_client_capability.return_value = False
     cfg = MagicMock()
     cfg.paid_providers = frozenset()
+    cfg.base_url = None
 
     result = await tool.fn(
-        prompt="fire-and-forget test",
+        prompt="inline wait test",
         provider="placeholder",
         service=svc,
         config=cfg,
@@ -69,8 +70,71 @@ async def test_generate_image_returns_generating_immediately(
     text_items = [c for c in result.content if isinstance(c, TextContent)]
     assert len(text_items) == 1
     metadata = json.loads(text_items[0].text)
+    assert metadata["status"] == "completed"
+    assert "image_id" in metadata
+    assert "dimensions" in metadata
+
+    # Should include an inline thumbnail
+    image_items = [c for c in result.content if isinstance(c, ImageContent)]
+    assert len(image_items) == 1
+
+
+async def test_generate_image_falls_back_to_generating_on_timeout(
+    tmp_path: Path,
+) -> None:
+    """generate_image returns 'generating' when the inline wait times out."""
+    svc = ImageService(scratch_dir=tmp_path)
+
+    # Provider that takes much longer than the inline wait
+    original_provider = PlaceholderImageProvider()
+    original_generate = original_provider.generate
+
+    async def very_slow_generate(*args: object, **kwargs: object) -> object:
+        await asyncio.sleep(60)  # longer than the 40s timeout
+        return await original_generate(*args, **kwargs)  # type: ignore[arg-type]
+
+    original_provider.generate = very_slow_generate  # type: ignore[assignment]
+    svc.register_provider("placeholder", original_provider)
+
+    mcp = FastMCP("test")
+    register_tools(mcp)
+    tool = await mcp.get_tool("generate_image")
+    assert tool is not None
+
+    ctx = MagicMock()
+    ctx.report_progress = AsyncMock()
+    ctx.info = AsyncMock()
+    ctx.session.check_client_capability.return_value = False
+    cfg = MagicMock()
+    cfg.paid_providers = frozenset()
+    cfg.base_url = None
+
+    # Patch the inline wait timeout to a short value for testing
+    with patch(
+        "image_generation_mcp._server_tools._INLINE_WAIT_S", 0.1
+    ):
+        result = await tool.fn(
+            prompt="timeout fallback test",
+            provider="placeholder",
+            service=svc,
+            config=cfg,
+            ctx=ctx,
+        )
+
+    text_items = [c for c in result.content if isinstance(c, TextContent)]
+    assert len(text_items) == 1
+    metadata = json.loads(text_items[0].text)
     assert metadata["status"] == "generating"
     assert "image_id" in metadata
+
+    # No inline image for pending generation
+    image_items = [c for c in result.content if isinstance(c, ImageContent)]
+    assert image_items == []
+
+    # Clean up: cancel the lingering background task
+    for task in list(_BACKGROUND_TASKS):
+        task.cancel()
+    await asyncio.sleep(0.1)
 
 
 async def test_background_tasks_set_holds_reference(tmp_path: Path) -> None:
@@ -82,7 +146,7 @@ async def test_background_tasks_set_holds_reference(tmp_path: Path) -> None:
     original_generate = original_provider.generate
 
     async def slow_generate(*args: object, **kwargs: object) -> object:
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.5)
         return await original_generate(*args, **kwargs)  # type: ignore[arg-type]
 
     original_provider.generate = slow_generate  # type: ignore[assignment]
@@ -99,26 +163,32 @@ async def test_background_tasks_set_holds_reference(tmp_path: Path) -> None:
     ctx.session.check_client_capability.return_value = False
     cfg = MagicMock()
     cfg.paid_providers = frozenset()
+    cfg.base_url = None
 
     size_before = len(_BACKGROUND_TASKS)
-    await tool.fn(
-        prompt="background tasks test",
-        provider="placeholder",
-        service=svc,
-        config=cfg,
-        ctx=ctx,
-    )
+
+    # Use a short inline wait so we return while background task is still running
+    with patch(
+        "image_generation_mcp._server_tools._INLINE_WAIT_S", 0.1
+    ):
+        await tool.fn(
+            prompt="background tasks test",
+            provider="placeholder",
+            service=svc,
+            config=cfg,
+            ctx=ctx,
+        )
     # Task was added to _BACKGROUND_TASKS while still running
     assert len(_BACKGROUND_TASKS) > size_before
 
     # Wait for the background task to finish
-    await asyncio.sleep(0.3)
+    await asyncio.sleep(0.6)
     # Task removed itself on completion
     assert len(_BACKGROUND_TASKS) == size_before
 
 
-async def test_background_task_completes_after_return(tmp_path: Path) -> None:
-    """Background task registers the image after generate_image returns."""
+async def test_completed_image_available_via_show_image(tmp_path: Path) -> None:
+    """After generate_image completes inline, show_image returns the image."""
     svc = ImageService(scratch_dir=tmp_path)
     svc.register_provider("placeholder", PlaceholderImageProvider())
 
@@ -133,6 +203,7 @@ async def test_background_task_completes_after_return(tmp_path: Path) -> None:
     ctx.session.check_client_capability.return_value = False
     cfg = MagicMock()
     cfg.paid_providers = frozenset()
+    cfg.base_url = None
 
     result = await tool.fn(
         prompt="completion test",
@@ -145,9 +216,6 @@ async def test_background_task_completes_after_return(tmp_path: Path) -> None:
     text_items = [c for c in result.content if isinstance(c, TextContent)]
     image_id = json.loads(text_items[0].text)["image_id"]
 
-    # Placeholder is near-instant; after a brief wait the image is registered
-    await asyncio.sleep(0.1)
-
     show_tool = await mcp.get_tool("show_image")
     assert show_tool is not None
     show_cfg = MagicMock()
@@ -159,8 +227,6 @@ async def test_background_task_completes_after_return(tmp_path: Path) -> None:
     )
     show_text = [c for c in show_result.content if isinstance(c, TextContent)]
     show_meta = json.loads(show_text[0].text)
-    # After completion the pending entry is cleaned up and show_image returns
-    # the normal image thumbnail (status key absent or not 'generating'/'failed')
     assert show_meta.get("status") not in ("generating", "failed")
 
 
@@ -194,14 +260,19 @@ async def test_show_image_returns_generating_for_in_progress(
     ctx.session.check_client_capability.return_value = False
     cfg = MagicMock()
     cfg.paid_providers = frozenset()
+    cfg.base_url = None
 
-    result = await gen_tool.fn(
-        prompt="slow generation test",
-        provider="placeholder",
-        service=svc,
-        config=cfg,
-        ctx=ctx,
-    )
+    # Short inline wait so generate_image returns while still generating
+    with patch(
+        "image_generation_mcp._server_tools._INLINE_WAIT_S", 0.1
+    ):
+        result = await gen_tool.fn(
+            prompt="slow generation test",
+            provider="placeholder",
+            service=svc,
+            config=cfg,
+            ctx=ctx,
+        )
     text_items = [c for c in result.content if isinstance(c, TextContent)]
     image_id = json.loads(text_items[0].text)["image_id"]
 
@@ -235,39 +306,44 @@ async def test_image_list_includes_pending_generation(
 
     config = ServerConfig(scratch_dir=tmp_path, read_only=False)
 
-    # Patch PlaceholderImageProvider to be slow so generation stays pending
-    original_provider = PlaceholderImageProvider()
-    original_generate = original_provider.generate
+    # Monkeypatch PlaceholderImageProvider.generate at the class level so
+    # the lifespan-created service uses the slow version.
+    _original_generate = PlaceholderImageProvider.generate
 
-    async def slow_generate(*args: object, **kwargs: object) -> object:
-        await asyncio.sleep(0.5)
-        return await original_generate(*args, **kwargs)  # type: ignore[arg-type]
-
-    original_provider.generate = slow_generate  # type: ignore[assignment]
+    async def slow_generate(self: object, *args: object, **kwargs: object) -> object:
+        await asyncio.sleep(5.0)
+        return await _original_generate(self, *args, **kwargs)  # type: ignore[arg-type]
 
     mcp = FastMCP("test-list-pending", lifespan=make_service_lifespan(config))
     register_tools(mcp)
     register_resources(mcp)
 
-    async with Client(mcp) as client:
-        gen_result = await client.call_tool(
-            "generate_image",
-            {"prompt": "list pending test", "provider": "placeholder"},
-        )
-        text = next(c for c in gen_result.content if c.type == "text")
-        image_id = json.loads(text.text)["image_id"]
+    # Short inline wait so call_tool returns while generation is pending
+    with (
+        patch.object(PlaceholderImageProvider, "generate", slow_generate),
+        patch("image_generation_mcp._server_tools._INLINE_WAIT_S", 0.1),
+    ):
+        async with Client(mcp) as client:
+            gen_result = await client.call_tool(
+                "generate_image",
+                {"prompt": "list pending test", "provider": "placeholder"},
+            )
+            text = next(c for c in gen_result.content if c.type == "text")
+            image_id = json.loads(text.text)["image_id"]
 
-        # Read image://list while generation is still pending
-        list_result = await client.read_resource("image://list")
-        items = json.loads(list_result[0].text)  # type: ignore[union-attr]
-        pending_items = [i for i in items if i.get("status") == "generating"]
-        assert len(pending_items) >= 1
-        pending_match = [i for i in pending_items if i["image_id"] == image_id]
-        assert len(pending_match) == 1
-        assert pending_match[0]["provider"] == "placeholder"
-        assert pending_match[0]["prompt"] == "list pending test"
-        assert "progress" in pending_match[0]
-        assert "progress_message" in pending_match[0]
+            # Read image://list while generation is still pending
+            list_result = await client.read_resource("image://list")
+            items = json.loads(list_result[0].text)  # type: ignore[union-attr]
+            pending_items = [i for i in items if i.get("status") == "generating"]
+            assert len(pending_items) >= 1
+            pending_match = [i for i in pending_items if i["image_id"] == image_id]
+            assert len(pending_match) == 1
+            assert pending_match[0]["provider"] == "placeholder"
+            assert pending_match[0]["prompt"] == "list pending test"
+            assert "progress" in pending_match[0]
+            assert "progress_message" in pending_match[0]
 
-        # Wait for background task to finish to avoid warnings
-        await asyncio.sleep(0.6)
+    # Clean up: cancel lingering background tasks
+    for t in list(_BACKGROUND_TASKS):
+        t.cancel()
+    await asyncio.sleep(0.1)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -856,10 +856,10 @@ class TestGenerateImageErrorHandling:
         text_items = [c for c in result.content if isinstance(c, TextContent)]
         return json.loads(text_items[0].text)["image_id"]
 
-    async def test_content_policy_error_surfaces_in_show_image(
+    async def test_content_policy_error_redirects_in_show_image(
         self, service: ImageService
     ) -> None:
-        """ImageContentPolicyError in background task surfaces as 'failed' in show_image."""
+        """ImageContentPolicyError: show_image redirects to check_generation_status."""
         from image_generation_mcp.providers.types import ImageContentPolicyError
 
         image_id = await self._call_generate_failing(
@@ -883,12 +883,12 @@ class TestGenerateImageErrorHandling:
         show_text = [c for c in show_result.content if isinstance(c, TextContent)]
         meta = json.loads(show_text[0].text)
         assert meta["status"] == "failed"
-        assert "error" in meta
+        assert "check_generation_status" in meta["error"]
 
-    async def test_connection_error_surfaces_in_show_image(
+    async def test_connection_error_redirects_in_show_image(
         self, service: ImageService
     ) -> None:
-        """ImageProviderConnectionError in background task surfaces as 'failed' in show_image."""
+        """ImageProviderConnectionError: show_image redirects to check_generation_status."""
         from image_generation_mcp.providers.types import ImageProviderConnectionError
 
         image_id = await self._call_generate_failing(
@@ -913,7 +913,7 @@ class TestGenerateImageErrorHandling:
         show_text = [c for c in show_result.content if isinstance(c, TextContent)]
         meta = json.loads(show_text[0].text)
         assert meta["status"] == "failed"
-        assert "error" in meta
+        assert "check_generation_status" in meta["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -81,7 +81,7 @@ def large_registered_image(service: ImageService) -> tuple[ImageService, str]:
 
 
 class TestGenerateImageReturnShape:
-    """generate_image must return TextContent + ResourceLink, no ImageContent."""
+    """generate_image waits for completion and returns image inline."""
 
     async def _call_generate(self, service: ImageService) -> ToolResult:
         mcp = FastMCP("test")
@@ -94,6 +94,7 @@ class TestGenerateImageReturnShape:
         ctx.info = AsyncMock()
         cfg = MagicMock()
         cfg.paid_providers = frozenset()
+        cfg.base_url = None
 
         return await tool.fn(
             prompt="test image",
@@ -110,21 +111,21 @@ class TestGenerateImageReturnShape:
         metadata = json.loads(text_items[0].text)
         assert "image_id" in metadata
         assert "original_uri" in metadata
-        assert metadata["status"] == "generating"
-        assert "dimensions" not in metadata
-        assert "original_size_bytes" not in metadata
+        assert metadata["status"] == "completed"
+        assert "dimensions" in metadata
+        assert "original_size_bytes" in metadata
 
     async def test_returns_resource_link(self, service: ImageService) -> None:
         result = await self._call_generate(service)
         link_items = [c for c in result.content if isinstance(c, ResourceLink)]
         assert len(link_items) == 1
         assert str(link_items[0].uri).startswith("image://")
-        assert link_items[0].name == "Generated image (generating)"
+        assert link_items[0].name == "Generated image"
 
-    async def test_no_image_content_in_result(self, service: ImageService) -> None:
+    async def test_returns_image_content(self, service: ImageService) -> None:
         result = await self._call_generate(service)
         image_items = [c for c in result.content if isinstance(c, ImageContent)]
-        assert image_items == [], "generate_image must not return ImageContent"
+        assert len(image_items) == 1, "generate_image should return ImageContent inline"
 
     async def test_no_thumbnail_size_bytes_in_metadata(
         self, service: ImageService
@@ -526,6 +527,7 @@ class TestElicitationPaidProviders:
 
         cfg = MagicMock()
         cfg.paid_providers = paid_providers
+        cfg.base_url = None
 
         return await tool.fn(
             prompt="test image",
@@ -817,15 +819,15 @@ class TestGenerateImageParameterValidation:
 
 
 class TestGenerateImageErrorHandling:
-    """generate_image errors surface through show_image in fire-and-forget mode."""
+    """generate_image errors are returned directly (inline wait catches them)."""
 
     async def _call_generate_failing(
         self, service: ImageService, side_effect: Exception
-    ) -> str:
-        """Call generate_image with a provider that raises, wait for failure.
+    ) -> ToolResult:
+        """Call generate_image with a provider that raises.
 
-        Permanently replaces service.generate with a raising coroutine so the
-        patch stays active when the background task runs.  Returns image_id.
+        Permanently replaces service.generate with a raising coroutine.
+        Returns the ToolResult directly (errors surface inline).
         """
 
         async def _always_raise(*_args: object, **_kwargs: object) -> None:
@@ -844,8 +846,9 @@ class TestGenerateImageErrorHandling:
         ctx.session.check_client_capability.return_value = False
         cfg = MagicMock()
         cfg.paid_providers = frozenset()
+        cfg.base_url = None
 
-        result = await tool.fn(
+        return await tool.fn(
             prompt="test image",
             provider="placeholder",
             service=service,
@@ -853,67 +856,38 @@ class TestGenerateImageErrorHandling:
             ctx=ctx,
         )
 
-        text_items = [c for c in result.content if isinstance(c, TextContent)]
-        return json.loads(text_items[0].text)["image_id"]
-
-    async def test_content_policy_error_surfaces_in_show_image(
+    async def test_content_policy_error_surfaces_directly(
         self, service: ImageService
     ) -> None:
-        """ImageContentPolicyError in background task surfaces as 'failed' in show_image."""
+        """ImageContentPolicyError surfaces as 'failed' directly from generate_image."""
         from image_generation_mcp.providers.types import ImageContentPolicyError
 
-        image_id = await self._call_generate_failing(
+        result = await self._call_generate_failing(
             service, ImageContentPolicyError("placeholder", "blocked")
         )
 
-        # Let the background task run and fail
-        await asyncio.sleep(0.1)
-
-        mcp = FastMCP("test")
-        register_tools(mcp)
-        show_tool = await mcp.get_tool("show_image")
-        assert show_tool is not None
-        show_cfg = MagicMock()
-        show_cfg.base_url = None
-        show_result = await show_tool.fn(
-            uri=f"image://{image_id}/view",
-            service=service,
-            config=show_cfg,
-        )
-        show_text = [c for c in show_result.content if isinstance(c, TextContent)]
-        meta = json.loads(show_text[0].text)
+        text_items = [c for c in result.content if isinstance(c, TextContent)]
+        meta = json.loads(text_items[0].text)
         assert meta["status"] == "failed"
         assert "error" in meta
+        assert meta["status"] == "failed"  # error surfaced inline
 
-    async def test_connection_error_surfaces_in_show_image(
+    async def test_connection_error_surfaces_directly(
         self, service: ImageService
     ) -> None:
-        """ImageProviderConnectionError in background task surfaces as 'failed' in show_image."""
+        """ImageProviderConnectionError surfaces as 'failed' directly from generate_image."""
         from image_generation_mcp.providers.types import ImageProviderConnectionError
 
-        image_id = await self._call_generate_failing(
+        result = await self._call_generate_failing(
             service,
             ImageProviderConnectionError("placeholder", "connection refused"),
         )
 
-        # Let the background task run and fail
-        await asyncio.sleep(0.1)
-
-        mcp = FastMCP("test")
-        register_tools(mcp)
-        show_tool = await mcp.get_tool("show_image")
-        assert show_tool is not None
-        show_cfg = MagicMock()
-        show_cfg.base_url = None
-        show_result = await show_tool.fn(
-            uri=f"image://{image_id}/view",
-            service=service,
-            config=show_cfg,
-        )
-        show_text = [c for c in show_result.content if isinstance(c, TextContent)]
-        meta = json.loads(show_text[0].text)
+        text_items = [c for c in result.content if isinstance(c, TextContent)]
+        meta = json.loads(text_items[0].text)
         assert meta["status"] == "failed"
         assert "error" in meta
+        assert meta["status"] == "failed"  # error surfaced inline
 
 
 # ---------------------------------------------------------------------------
@@ -942,6 +916,7 @@ class TestElicitationCapabilityCheckFailure:
         cfg = MagicMock()
         # placeholder is in paid_providers to trigger elicitation path
         cfg.paid_providers = frozenset({"placeholder"})
+        cfg.base_url = None
 
         result = await tool.fn(
             prompt="test image",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -81,7 +81,7 @@ def large_registered_image(service: ImageService) -> tuple[ImageService, str]:
 
 
 class TestGenerateImageReturnShape:
-    """generate_image waits for completion and returns image inline."""
+    """generate_image must return TextContent + ResourceLink, no ImageContent."""
 
     async def _call_generate(self, service: ImageService) -> ToolResult:
         mcp = FastMCP("test")
@@ -94,7 +94,6 @@ class TestGenerateImageReturnShape:
         ctx.info = AsyncMock()
         cfg = MagicMock()
         cfg.paid_providers = frozenset()
-        cfg.base_url = None
 
         return await tool.fn(
             prompt="test image",
@@ -111,21 +110,21 @@ class TestGenerateImageReturnShape:
         metadata = json.loads(text_items[0].text)
         assert "image_id" in metadata
         assert "original_uri" in metadata
-        assert metadata["status"] == "completed"
-        assert "dimensions" in metadata
-        assert "original_size_bytes" in metadata
+        assert metadata["status"] == "generating"
+        assert "dimensions" not in metadata
+        assert "original_size_bytes" not in metadata
 
     async def test_returns_resource_link(self, service: ImageService) -> None:
         result = await self._call_generate(service)
         link_items = [c for c in result.content if isinstance(c, ResourceLink)]
         assert len(link_items) == 1
         assert str(link_items[0].uri).startswith("image://")
-        assert link_items[0].name == "Generated image"
+        assert link_items[0].name == "Generated image (generating)"
 
-    async def test_returns_image_content(self, service: ImageService) -> None:
+    async def test_no_image_content_in_result(self, service: ImageService) -> None:
         result = await self._call_generate(service)
         image_items = [c for c in result.content if isinstance(c, ImageContent)]
-        assert len(image_items) == 1, "generate_image should return ImageContent inline"
+        assert image_items == [], "generate_image must not return ImageContent"
 
     async def test_no_thumbnail_size_bytes_in_metadata(
         self, service: ImageService
@@ -527,7 +526,6 @@ class TestElicitationPaidProviders:
 
         cfg = MagicMock()
         cfg.paid_providers = paid_providers
-        cfg.base_url = None
 
         return await tool.fn(
             prompt="test image",
@@ -819,15 +817,15 @@ class TestGenerateImageParameterValidation:
 
 
 class TestGenerateImageErrorHandling:
-    """generate_image errors are returned directly (inline wait catches them)."""
+    """generate_image errors surface through show_image in fire-and-forget mode."""
 
     async def _call_generate_failing(
         self, service: ImageService, side_effect: Exception
-    ) -> ToolResult:
-        """Call generate_image with a provider that raises.
+    ) -> str:
+        """Call generate_image with a provider that raises, wait for failure.
 
-        Permanently replaces service.generate with a raising coroutine.
-        Returns the ToolResult directly (errors surface inline).
+        Permanently replaces service.generate with a raising coroutine so the
+        patch stays active when the background task runs.  Returns image_id.
         """
 
         async def _always_raise(*_args: object, **_kwargs: object) -> None:
@@ -846,9 +844,8 @@ class TestGenerateImageErrorHandling:
         ctx.session.check_client_capability.return_value = False
         cfg = MagicMock()
         cfg.paid_providers = frozenset()
-        cfg.base_url = None
 
-        return await tool.fn(
+        result = await tool.fn(
             prompt="test image",
             provider="placeholder",
             service=service,
@@ -856,38 +853,67 @@ class TestGenerateImageErrorHandling:
             ctx=ctx,
         )
 
-    async def test_content_policy_error_surfaces_directly(
+        text_items = [c for c in result.content if isinstance(c, TextContent)]
+        return json.loads(text_items[0].text)["image_id"]
+
+    async def test_content_policy_error_surfaces_in_show_image(
         self, service: ImageService
     ) -> None:
-        """ImageContentPolicyError surfaces as 'failed' directly from generate_image."""
+        """ImageContentPolicyError in background task surfaces as 'failed' in show_image."""
         from image_generation_mcp.providers.types import ImageContentPolicyError
 
-        result = await self._call_generate_failing(
+        image_id = await self._call_generate_failing(
             service, ImageContentPolicyError("placeholder", "blocked")
         )
 
-        text_items = [c for c in result.content if isinstance(c, TextContent)]
-        meta = json.loads(text_items[0].text)
+        # Let the background task run and fail
+        await asyncio.sleep(0.1)
+
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        show_tool = await mcp.get_tool("show_image")
+        assert show_tool is not None
+        show_cfg = MagicMock()
+        show_cfg.base_url = None
+        show_result = await show_tool.fn(
+            uri=f"image://{image_id}/view",
+            service=service,
+            config=show_cfg,
+        )
+        show_text = [c for c in show_result.content if isinstance(c, TextContent)]
+        meta = json.loads(show_text[0].text)
         assert meta["status"] == "failed"
         assert "error" in meta
-        assert meta["status"] == "failed"  # error surfaced inline
 
-    async def test_connection_error_surfaces_directly(
+    async def test_connection_error_surfaces_in_show_image(
         self, service: ImageService
     ) -> None:
-        """ImageProviderConnectionError surfaces as 'failed' directly from generate_image."""
+        """ImageProviderConnectionError in background task surfaces as 'failed' in show_image."""
         from image_generation_mcp.providers.types import ImageProviderConnectionError
 
-        result = await self._call_generate_failing(
+        image_id = await self._call_generate_failing(
             service,
             ImageProviderConnectionError("placeholder", "connection refused"),
         )
 
-        text_items = [c for c in result.content if isinstance(c, TextContent)]
-        meta = json.loads(text_items[0].text)
+        # Let the background task run and fail
+        await asyncio.sleep(0.1)
+
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        show_tool = await mcp.get_tool("show_image")
+        assert show_tool is not None
+        show_cfg = MagicMock()
+        show_cfg.base_url = None
+        show_result = await show_tool.fn(
+            uri=f"image://{image_id}/view",
+            service=service,
+            config=show_cfg,
+        )
+        show_text = [c for c in show_result.content if isinstance(c, TextContent)]
+        meta = json.loads(show_text[0].text)
         assert meta["status"] == "failed"
         assert "error" in meta
-        assert meta["status"] == "failed"  # error surfaced inline
 
 
 # ---------------------------------------------------------------------------
@@ -916,7 +942,6 @@ class TestElicitationCapabilityCheckFailure:
         cfg = MagicMock()
         # placeholder is in paid_providers to trigger elicitation path
         cfg.paid_providers = frozenset({"placeholder"})
-        cfg.base_url = None
 
         result = await tool.fn(
             prompt="test image",

--- a/uv.lock
+++ b/uv.lock
@@ -781,45 +781,6 @@ wheels = [
 ]
 
 [[package]]
-name = "google-auth"
-version = "2.49.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
-]
-
-[package.optional-dependencies]
-requests = [
-    { name = "requests" },
-]
-
-[[package]]
-name = "google-genai"
-version = "1.69.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "google-auth", extra = ["requests"] },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "sniffio" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/5e/c0a5e6ff60d18d3f19819a9b1fbd6a1ef2162d025696d8660550739168dc/google_genai-1.69.0.tar.gz", hash = "sha256:5f1a6a478e0c5851506a3d337534bab27b3c33120e27bf9174507ea79dfb8673", size = 519538, upload-time = "2026-03-28T15:33:27.308Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/58/ef0586019f54b2ebb36deed7608ccb5efe1377564d2aaea6b1e295d1fadc/google_genai-1.69.0-py3-none-any.whl", hash = "sha256:252e714d724aba74949647b9de511a6a6f7804b3b317ab39ddee9cc2f001cacc", size = 760551, upload-time = "2026-03-28T15:33:24.957Z" },
-]
-
-[[package]]
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -895,14 +856,12 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "fastmcp", extra = ["tasks"] },
-    { name = "google-genai" },
     { name = "openai" },
     { name = "uvicorn" },
 ]
 dev = [
     { name = "diff-cover" },
     { name = "fastmcp", extra = ["tasks"] },
-    { name = "google-genai" },
     { name = "mypy" },
     { name = "openai" },
     { name = "pip-audit" },
@@ -917,9 +876,6 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
-google-genai = [
-    { name = "google-genai" },
-]
 mcp = [
     { name = "fastmcp", extra = ["tasks"] },
     { name = "uvicorn" },
@@ -933,8 +889,6 @@ requires-dist = [
     { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=9.0" },
     { name = "fastmcp", extras = ["tasks"], marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", extras = ["tasks"], marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
-    { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0" },
-    { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "image-generation-mcp", extras = ["all"], marker = "extra == 'dev'" },
     { name = "mkdocs-llmstxt", marker = "extra == 'docs'", specifier = ">=0.2" },
@@ -952,7 +906,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.20" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.20" },
 ]
-provides-extras = ["mcp", "openai", "google-genai", "all", "dev", "docs"]
+provides-extras = ["mcp", "openai", "all", "dev", "docs"]
 
 [[package]]
 name = "importlib-metadata"
@@ -2052,27 +2006,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2749,15 +2682,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
-]
-
-[[package]]
-name = "tenacity"
-version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -781,6 +781,45 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.49.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.69.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/5e/c0a5e6ff60d18d3f19819a9b1fbd6a1ef2162d025696d8660550739168dc/google_genai-1.69.0.tar.gz", hash = "sha256:5f1a6a478e0c5851506a3d337534bab27b3c33120e27bf9174507ea79dfb8673", size = 519538, upload-time = "2026-03-28T15:33:27.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/58/ef0586019f54b2ebb36deed7608ccb5efe1377564d2aaea6b1e295d1fadc/google_genai-1.69.0-py3-none-any.whl", hash = "sha256:252e714d724aba74949647b9de511a6a6f7804b3b317ab39ddee9cc2f001cacc", size = 760551, upload-time = "2026-03-28T15:33:24.957Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -856,12 +895,14 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "fastmcp", extra = ["tasks"] },
+    { name = "google-genai" },
     { name = "openai" },
     { name = "uvicorn" },
 ]
 dev = [
     { name = "diff-cover" },
     { name = "fastmcp", extra = ["tasks"] },
+    { name = "google-genai" },
     { name = "mypy" },
     { name = "openai" },
     { name = "pip-audit" },
@@ -876,6 +917,9 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+google-genai = [
+    { name = "google-genai" },
+]
 mcp = [
     { name = "fastmcp", extra = ["tasks"] },
     { name = "uvicorn" },
@@ -889,6 +933,8 @@ requires-dist = [
     { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=9.0" },
     { name = "fastmcp", extras = ["tasks"], marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", extras = ["tasks"], marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
+    { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0" },
+    { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "image-generation-mcp", extras = ["all"], marker = "extra == 'dev'" },
     { name = "mkdocs-llmstxt", marker = "extra == 'docs'", specifier = ">=0.2" },
@@ -906,7 +952,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.20" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.20" },
 ]
-provides-extras = ["mcp", "openai", "all", "dev", "docs"]
+provides-extras = ["mcp", "openai", "google-genai", "all", "dev", "docs"]
 
 [[package]]
 name = "importlib-metadata"
@@ -2006,6 +2052,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2682,6 +2749,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The LLM was calling `show_image` repeatedly to poll for generation progress, creating a distracting stack of heavy "Image Generation" cards (with AppConfig viewer, icons, spinners) in the conversation UI.

- Add a lightweight `check_generation_status` tool that returns minimal JSON status text — no image data, no AppConfig, no icons
- Update `generate_image` docstring to direct the LLM to the new polling flow: `generate_image` → `check_generation_status` → `show_image`
- `show_image` now redirects to `check_generation_status` when called on in-progress/failed images instead of rendering a full card
- Update ADR-0005 and tools docs to reflect the three-step workflow

## Test plan

- [x] `check_generation_status` returns `"generating"` while task is running
- [x] `check_generation_status` returns `"completed"` for finished images (both via file check and via pending entry)
- [x] `check_generation_status` returns `"failed"` with error for failed generations
- [x] `check_generation_status` returns `"unknown"` for non-existent IDs
- [x] `show_image` redirects to `check_generation_status` for in-progress/failed images
- [x] All 799 tests pass, `ruff format --check` clean

https://claude.ai/code/session_019jTxyHvw5KHShyQSRHyoju