### PR TITLE
fix(packaging): add mcpb bundle files (unblocks rc)

### DIFF
--- a/packaging/mcpb/.gitignore
+++ b/packaging/mcpb/.gitignore
@@ -1,0 +1,3 @@
+# Artifacts produced by build.sh (not in _skip_if_exists — maintained by the template).
+build/
+dist/

--- a/packaging/mcpb/build.sh
+++ b/packaging/mcpb/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Build an image-generation-mcp .mcpb bundle locally.
+#
+# Usage:
+#   VERSION=1.6.0 ./packaging/mcpb/build.sh
+#
+# With no VERSION set, builds a "dev" bundle for validation only.
+set -euo pipefail
+
+VERSION="${VERSION:-dev}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/packaging/mcpb/build"
+DIST_DIR="${REPO_ROOT}/packaging/mcpb/dist"
+
+command -v mcpb >/dev/null 2>&1 || {
+  echo "error: mcpb CLI not found. Install with:" >&2
+  echo "  npm install -g @anthropic-ai/mcpb@2.1.2" >&2
+  exit 1
+}
+
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}/src" "${DIST_DIR}"
+
+# Restrict substitution to ${VERSION} only — other ${...} tokens in the template
+# (e.g. ${DOCUMENTS}, ${user_config.*}) are runtime placeholders for the host.
+VERSION="${VERSION}" envsubst '${VERSION}' < "${SCRIPT_DIR}/manifest.json.in" \
+  > "${BUILD_DIR}/manifest.json"
+VERSION="${VERSION}" envsubst '${VERSION}' < "${SCRIPT_DIR}/pyproject.toml.in" \
+  > "${BUILD_DIR}/pyproject.toml"
+cp "${SCRIPT_DIR}/src/server.py" "${BUILD_DIR}/src/server.py"
+
+mcpb validate "${BUILD_DIR}/manifest.json"
+mcpb pack "${BUILD_DIR}" "${DIST_DIR}/image-generation-mcp-${VERSION}.mcpb"
+
+echo "built ${DIST_DIR}/image-generation-mcp-${VERSION}.mcpb"

--- a/packaging/mcpb/build.sh
+++ b/packaging/mcpb/build.sh
@@ -28,6 +28,12 @@ command -v mcpb >/dev/null 2>&1 || {
   echo "  npm install -g @anthropic-ai/mcpb@${MCPB_VERSION}" >&2
   exit 1
 }
+command -v envsubst >/dev/null 2>&1 || {
+  echo "error: envsubst not found (part of gettext). Install with:" >&2
+  echo "  brew install gettext     # macOS" >&2
+  echo "  apt install gettext-base # Debian/Ubuntu" >&2
+  exit 1
+}
 
 rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}/src" "${DIST_DIR}"

--- a/packaging/mcpb/build.sh
+++ b/packaging/mcpb/build.sh
@@ -5,6 +5,13 @@
 #   VERSION=1.6.0 ./packaging/mcpb/build.sh
 #
 # With no VERSION set, builds a "dev" bundle for validation only.
+#
+# Note on scaffold drift:
+#   packaging/mcpb/{manifest.json.in,pyproject.toml.in,src/server.py,build.sh}
+#   are in the template's _skip_if_exists list, so future ``copier update``
+#   runs will NOT re-render them.  When mcpb bumps manifest_version, when
+#   the project changes license, or when the mcpb CLI version is bumped
+#   upstream, update these files manually.
 set -euo pipefail
 
 VERSION="${VERSION:-dev}"
@@ -13,9 +20,12 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 BUILD_DIR="${REPO_ROOT}/packaging/mcpb/build"
 DIST_DIR="${REPO_ROOT}/packaging/mcpb/dist"
 
+# renovate: datasource=npm depName=@anthropic-ai/mcpb
+MCPB_VERSION="2.1.2"
+
 command -v mcpb >/dev/null 2>&1 || {
   echo "error: mcpb CLI not found. Install with:" >&2
-  echo "  npm install -g @anthropic-ai/mcpb@2.1.2" >&2
+  echo "  npm install -g @anthropic-ai/mcpb@${MCPB_VERSION}" >&2
   exit 1
 }
 

--- a/packaging/mcpb/manifest.json.in
+++ b/packaging/mcpb/manifest.json.in
@@ -1,0 +1,125 @@
+{
+  "manifest_version": "0.4",
+  "name": "image-generation-mcp",
+  "display_name": "Image Generation MCP",
+  "version": "${VERSION}",
+  "description": "AI image generation via OpenAI, Google Gemini, Stable Diffusion WebUI, or placeholders.",
+  "long_description": "MCP server exposing tools for AI image generation across multiple providers: OpenAI (gpt-image-1, dall-e-3), Google Gemini, Stable Diffusion WebUI (A1111/Forge/reForge), and a zero-cost placeholder. Images are saved to a local scratch directory; a gallery viewer MCP App surfaces results to clients that support iframe sandboxes.",
+  "author": {
+    "name": "Peter van Liesdonk",
+    "url": "https://github.com/pvliesdonk"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pvliesdonk/image-generation-mcp.git"
+  },
+  "homepage": "https://pvliesdonk.github.io/image-generation-mcp/",
+  "documentation": "https://pvliesdonk.github.io/image-generation-mcp/",
+  "support": "https://github.com/pvliesdonk/image-generation-mcp/issues",
+  "license": "MIT",
+  "keywords": ["image-generation", "openai", "gemini", "stable-diffusion", "dall-e", "ai-art", "mcp"],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/server.py",
+    "mcp_config": {
+      "command": "uvx",
+      "args": ["--from", "image-generation-mcp[all]==${VERSION}", "image-generation-mcp", "serve"],
+      "env": {
+        "IMAGE_GENERATION_MCP_SCRATCH_DIR":       "${user_config.scratch_dir}",
+        "IMAGE_GENERATION_MCP_STYLES_DIR":        "${user_config.styles_dir}",
+        "IMAGE_GENERATION_MCP_READ_ONLY":         "${user_config.read_only}",
+        "IMAGE_GENERATION_MCP_SERVER_NAME":       "${user_config.server_name}",
+        "IMAGE_GENERATION_MCP_DEFAULT_PROVIDER":  "${user_config.default_provider}",
+        "IMAGE_GENERATION_MCP_PAID_PROVIDERS":    "${user_config.paid_providers}",
+        "IMAGE_GENERATION_MCP_OPENAI_API_KEY":    "${user_config.openai_api_key}",
+        "IMAGE_GENERATION_MCP_GOOGLE_API_KEY":    "${user_config.google_api_key}",
+        "IMAGE_GENERATION_MCP_SD_WEBUI_HOST":     "${user_config.sd_webui_host}",
+        "IMAGE_GENERATION_MCP_SD_WEBUI_MODEL":    "${user_config.sd_webui_model}",
+        "FASTMCP_LOG_LEVEL":                      "${user_config.log_level}"
+      }
+    }
+  },
+  "user_config": {
+    "scratch_dir": {
+      "type": "directory",
+      "title": "Scratch directory",
+      "description": "Where generated images are saved. Blank uses ~/.image-generation-mcp/images.",
+      "required": false,
+      "default": "${DOCUMENTS}/Image Generation MCP"
+    },
+    "styles_dir": {
+      "type": "directory",
+      "title": "Styles directory",
+      "description": "Where style preset files live. Blank uses ~/.image-generation-mcp/styles.",
+      "required": false
+    },
+    "read_only": {
+      "type": "boolean",
+      "title": "Read-only mode",
+      "description": "When true, image-generation tools are hidden (only list_providers / show_image remain).",
+      "required": false,
+      "default": false
+    },
+    "server_name": {
+      "type": "string",
+      "title": "Server name",
+      "description": "Name shown in the Claude tool list.",
+      "required": false,
+      "default": "image-generation-mcp"
+    },
+    "default_provider": {
+      "type": "string",
+      "title": "Default provider",
+      "description": "One of: auto, openai, gemini, sd_webui, placeholder.",
+      "required": false,
+      "default": "auto"
+    },
+    "paid_providers": {
+      "type": "string",
+      "title": "Paid providers",
+      "description": "Comma-separated providers that cost money (used for elicitation prompts).",
+      "required": false,
+      "default": "openai"
+    },
+    "openai_api_key": {
+      "type": "string",
+      "title": "OpenAI API key",
+      "description": "Enables gpt-image-1 / dall-e-3. Stored in the OS keychain.",
+      "required": false,
+      "sensitive": true
+    },
+    "google_api_key": {
+      "type": "string",
+      "title": "Google API key",
+      "description": "Enables Gemini image generation. Stored in the OS keychain.",
+      "required": false,
+      "sensitive": true
+    },
+    "sd_webui_host": {
+      "type": "string",
+      "title": "SD WebUI host",
+      "description": "Base URL of an A1111/Forge/reForge instance (e.g. http://localhost:7860).",
+      "required": false
+    },
+    "sd_webui_model": {
+      "type": "string",
+      "title": "SD WebUI model",
+      "description": "Checkpoint name used for preset detection (optional).",
+      "required": false
+    },
+    "log_level": {
+      "type": "string",
+      "title": "Log level",
+      "description": "One of: DEBUG, INFO, WARNING, ERROR.",
+      "required": false,
+      "default": "INFO"
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "python": ">=3.11,<4.0"
+    }
+  }
+}

--- a/packaging/mcpb/manifest.json.in
+++ b/packaging/mcpb/manifest.json.in
@@ -56,7 +56,7 @@
     "read_only": {
       "type": "boolean",
       "title": "Read-only mode",
-      "description": "When true, image-generation tools are hidden (only list_providers / show_image remain).",
+      "description": "When true, image-generation tools are hidden (only list_providers / show_image remain). Defaults to FALSE for MCPB bundles (desktop/local use → interactive generation is the primary use case), in contrast to the stdio/uvx/Docker default which is TRUE (servers are read-only unless explicitly opted in).",
       "required": false,
       "default": false
     },

--- a/packaging/mcpb/pyproject.toml.in
+++ b/packaging/mcpb/pyproject.toml.in
@@ -1,0 +1,8 @@
+# Rendered at build time by envsubst. ${VERSION} matches the package release.
+[project]
+name = "image-generation-mcp-mcpb"
+version = "${VERSION}"
+requires-python = ">=3.11"
+dependencies = [
+  "image-generation-mcp[all]==${VERSION}",
+]

--- a/packaging/mcpb/pyproject.toml.in
+++ b/packaging/mcpb/pyproject.toml.in
@@ -1,4 +1,8 @@
 # Rendered at build time by envsubst. ${VERSION} matches the package release.
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "image-generation-mcp-mcpb"
 version = "${VERSION}"

--- a/packaging/mcpb/src/server.py
+++ b/packaging/mcpb/src/server.py
@@ -1,0 +1,17 @@
+"""Entry shim for the image-generation-mcp .mcpb bundle.
+
+This file is only executed when the host uses the ``uv run src/server.py``
+code path (``server.type: "uv"`` + ``entry_point``).  The primary launch path
+is ``mcp_config.command: "uvx"`` which fetches image-generation-mcp directly
+from PyPI and bypasses this shim entirely.
+
+The shim injects ``serve`` into ``sys.argv`` because ``cli.main()`` delegates
+to argparse which reads ``sys.argv``; the bundle host does not pass subcommands.
+"""
+
+import sys
+
+from image_generation_mcp.cli import main
+
+sys.argv = [sys.argv[0], "serve"]
+main()

--- a/packaging/mcpb/src/server.py
+++ b/packaging/mcpb/src/server.py
@@ -5,13 +5,16 @@ code path (``server.type: "uv"`` + ``entry_point``).  The primary launch path
 is ``mcp_config.command: "uvx"`` which fetches image-generation-mcp directly
 from PyPI and bypasses this shim entirely.
 
-The shim injects ``serve`` into ``sys.argv`` because ``cli.main()`` delegates
-to argparse which reads ``sys.argv``; the bundle host does not pass subcommands.
+The shim appends ``serve`` to ``sys.argv`` (unless already present) because
+``cli.main()`` delegates to argparse and requires a subcommand.  Existing
+argv entries (e.g. ``-v`` for verbose logging) are preserved so the bundle
+remains debuggable when invoked directly.
 """
 
 import sys
 
 from image_generation_mcp.cli import main
 
-sys.argv = [sys.argv[0], "serve"]
+if "serve" not in sys.argv[1:]:
+    sys.argv.append("serve")
 main()


### PR DESCRIPTION
## Summary

Template ships a \`build-mcpb\` job expecting \`packaging/mcpb/manifest.json.in\`, \`pyproject.toml.in\`, and \`src/server.py\`, but IG never had those files. \`v1.6.0-rc.1\` (first rc after copier retrofit) surfaced this — Docker succeeded, build-mcpb failed with \`No such file or directory\`.

## What this adds

- \`packaging/mcpb/manifest.json.in\` — IG-shaped MCPB manifest (display name, long_description, keywords around image-gen, user_config for scratch/styles dirs, provider API keys, SD WebUI host/model, server_name, default_provider, paid_providers, log_level).
- \`packaging/mcpb/pyproject.toml.in\` — thin wrapper: \`image-generation-mcp[all]==${VERSION}\`.
- \`packaging/mcpb/src/server.py\` — entry shim (only used by \`server.type: \"uv\"\` code path; primary launch is \`uvx\`).
- \`packaging/mcpb/build.sh\` — local bundle build (envsubst + mcpb validate/pack).

## Upstream follow-up

The template should ship starter versions of these so every copier consumer inherits them. Filed as a separate PR on \`pvliesdonk/fastmcp-server-template\`.

## Test plan

- [x] Local envsubst + JSON parse validates the manifest renders correctly
- [ ] CI green on PR
- [ ] After merge: re-trigger \`v1.6.0-rc.2\` release — build-mcpb job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)