### PR TITLE
fix(ci): trigger docs workflow on v* tag pushes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Documentation
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
   release:


### PR DESCRIPTION
## Summary

Docs workflow failed on \`v1.7.0-rc.1\` release event (build succeeded, deploy-pages failed; logs already GC'd). Add tag-push as a second trigger so docs have a fallback path.

## Callout

Mirrored upstream at pvliesdonk/fastmcp-server-template#16. MV will inherit on next \`copier update\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)