### PR TITLE
fix(ci): docs concurrency collision on release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,10 @@ name: Documentation
 on:
   push:
     branches: [main]
+    # Tag-push is a SMOKE TEST: it runs `build` only (confirms docs still
+    # compile against a release tag) — the `upload-artifact` and `deploy`
+    # steps below are gated on `github.event_name == 'release'`, so actual
+    # GitHub Pages deployment still only happens via the release event.
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -13,8 +17,13 @@ on:
 permissions:
   contents: read
 
+# Include github.event_name so tag-push and release runs don't share a
+# concurrency key — without this, the tag-push run fired by ``git push``
+# and the release run fired by ``release:published`` collide on the same
+# ref+workflow key and `cancel-in-progress: true` cancels whichever
+# arrived first (usually the one carrying the deployment).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Follow-up to #185. claude-review on the template-side mirror (pvliesdonk/fastmcp-server-template#16) caught that my previous fix can *worsen* the exact failure mode it targets:

When PSR publishes a release, GitHub fires BOTH \`push\` (for the tag) AND \`release:published\`. Both resolved to the same \`\${workflow}-\${ref}\` concurrency key, so \`cancel-in-progress: true\` cancelled whichever enqueued first — typically the release run that carries the deployment.

Fix: include \`\${github.event_name}\` in the concurrency group.

Also add a comment documenting that tag-push is intentionally build-only (smoke test) — per design note from user.

## Urgency

Before Phase E stable release (\`v1.7.0\`): without this, deployment likely gets cancelled again on the next tag-pushing release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)