### PR TITLE
fix(release): auto-bump server.json via PSR build_command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,15 @@ pythonVersion = "3.11"
 version_toml = ["pyproject.toml:project.version"]
 commit_parser = "angular"
 tag_format = "v{version}"
+# Bump the versioned server.json manifest inside the release commit rather
+# than in a follow-up commit + force-retag.
+build_command = "python scripts/bump_manifests.py"
+# PSR stages and commits files listed in `assets` together with pyproject.toml
+# and CHANGELOG.md, so the release tag points at a single commit containing
+# all version-coupled files.
+assets = [
+    "server.json",
+]
 
 [tool.semantic_release.changelog]
 changelog_file = "CHANGELOG.md"

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -47,15 +47,30 @@ def main() -> int:
     # Replace only the ``:v<old>`` suffix of the OCI identifier so forks/renames
     # keep their own ``ghcr.io/<owner>/<image>`` base.
     server_path = Path("server.json")
+    if not server_path.exists():
+        print(
+            f"server.json not found in {Path.cwd()} — run from repo root",
+            file=sys.stderr,
+        )
+        return 1
     server = _load(server_path)
     server["version"] = version
     for pkg in server.get("packages", []):
         if pkg.get("registryType") == "pypi":
             pkg["version"] = version
         elif pkg.get("registryType") == "oci":
-            pkg["identifier"] = re.sub(r":v[^:]+$", f":v{version}", pkg["identifier"])
+            identifier = pkg.get("identifier", "")
+            new_id, n = re.subn(r":v[^:]+$", f":v{version}", identifier)
+            if n == 0:
+                print(
+                    f"WARNING: OCI identifier {identifier!r} has no ':v<tag>' "
+                    "suffix to bump — left unchanged",
+                    file=sys.stderr,
+                )
+            pkg["identifier"] = new_id
     _dump(server_path, server)
 
+    print(f"bump_manifests: server.json → {version}")
     return 0
 
 

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Bump versioned manifests to match the semantic-release version.
+
+Invoked by python-semantic-release via ``[tool.semantic_release] build_command``.
+PSR sets ``NEW_VERSION`` in the environment and, because ``server.json`` is
+listed in ``[tool.semantic_release] assets``, PSR stages and commits it
+together with ``pyproject.toml`` + ``CHANGELOG.md`` as the single release
+commit — which is the commit it then tags.
+
+The script runs inside PSR's Docker action container (python:3.14-slim), which
+has Python but no ``jq`` — hence Python rather than a shell+jq wrapper.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _dump(path: Path, data: Any) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        # ensure_ascii=False preserves UTF-8 characters literally, matching
+        # jq's default behavior and how a human editor would save the file.
+        json.dump(data, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+def main() -> int:
+    version = os.environ.get("NEW_VERSION")
+    if not version:
+        print(
+            "NEW_VERSION must be set (python-semantic-release build_command env)",
+            file=sys.stderr,
+        )
+        return 1
+
+    # server.json: top-level version, PyPI package version, OCI tag suffix.
+    # Replace only the ``:v<old>`` suffix of the OCI identifier so forks/renames
+    # keep their own ``ghcr.io/<owner>/<image>`` base.
+    server_path = Path("server.json")
+    server = _load(server_path)
+    server["version"] = version
+    for pkg in server.get("packages", []):
+        if pkg.get("registryType") == "pypi":
+            pkg["version"] = version
+        elif pkg.get("registryType") == "oci":
+            pkg["identifier"] = re.sub(r":v[^:]+$", f":v{version}", pkg["identifier"])
+    _dump(server_path, server)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Root cause of the v1.7.0 → v1.5.1 surprise + publish-registry failure: IG's PSR config is missing \`build_command\` + \`assets\`, so the release commit doesn't touch server.json. v1.5.1 shipped with \`server.json.version = "1.5.0"\` → mcp-publisher tried to re-publish v1.5.0 → \`"cannot publish duplicate version"\`.

## Adoption pattern

Mirrors MV (\`markdown-vault-mcp/scripts/bump_manifests.py\`). IG's version is smaller — MV bumps server.json + plugin.json + .mcp.json; IG only needs server.json because it has no \`.claude-plugin/\` scaffold.

## Test

- [x] Smoke: \`NEW_VERSION=99.0.0 python scripts/bump_manifests.py\` correctly rewrites all three fields in server.json (top-level version, pypi package version, OCI :v tag)
- [ ] CI green
- [ ] Post-merge: next release (likely \`v1.5.2\` via commit-driven patch from this fix: commit) will have correct server.json + all 6 publish targets including MCP Registry

## Upstream follow-up

Template needs this too — filing \`pvliesdonk/fastmcp-server-template\` PR separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)