### PR TITLE
fix(ci): docs deploy on v* tag push (not just release event)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,10 +3,12 @@ name: Documentation
 on:
   push:
     branches: [main]
-    # Tag-push is a SMOKE TEST: it runs `build` only (confirms docs still
-    # compile against a release tag) — the `upload-artifact` and `deploy`
-    # steps below are gated on `github.event_name == 'release'`, so actual
-    # GitHub Pages deployment still only happens via the release event.
+    # Tag-push also deploys: whichever event fires first (tag-push or
+    # release:published) wins the concurrency group below and performs
+    # the full build+upload+deploy.  The release-event path can race
+    # against tag availability (deploy-pages fetch fails), so tag-push
+    # gives a deterministic second path.  Gates on the `upload-artifact`
+    # step and `deploy` job below accept either event.
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -54,13 +56,13 @@ jobs:
         run: uv run mkdocs build --strict
 
       - name: Upload artifact
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
   deploy:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

v1.8.0 docs deploy failed on the release-event path (deploy-pages step races against tag availability — scholar v1.8.0-rc.1 hit the same).  Tag-push path already ran the workflow but only did \`build\` because upload + deploy were gated on \`event_name == 'release'\`.

Extend both gates to also accept tag-push on v*:

\`\`\`yaml
if: github.event_name == 'release'
    || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
\`\`\`

Mirrors upstream template PR pvliesdonk/fastmcp-server-template#20 and scholar-mcp#154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)