### PR TITLE
chore(copier): update to v1.1.4

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.1.3
+_commit: v1.1.4
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: MCP server for AI image generation via OpenAI, Google GenAI, or

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -113,12 +113,14 @@ jobs:
 
       - name: Commit and push to copier/update branch
         if: steps.changes.outputs.changed == 'true'
+        env:
+          REF: ${{ steps.meta.outputs.ref }}
         run: |
           set -euo pipefail
           branch="copier/update"
           git checkout -B "${branch}"
           git add -A
-          git commit -m "chore(copier): update to ${{ steps.meta.outputs.ref }}" \
+          git commit -m "chore(copier): update to ${REF}" \
             -m "Automated \`copier update\` run — review the diff and merge if CI is green."
           git push --force-with-lease origin "${branch}"
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from image_generation_mcp.server import make_server
+
 
 def test_make_server_constructs() -> None:
     """make_server() returns a FastMCP instance without raising."""
-    from image_generation_mcp.server import make_server
-
     server = make_server()
     assert server is not None


### PR DESCRIPTION
## Summary

Catches IG up from template v1.1.3 → **v1.1.4**. Small fleet-sync PR.

- `.copier-answers.yml`: `_commit` bumped.
- `.github/workflows/copier-update.yml`: refreshed — commit step now passes `REF` via `env:` instead of direct shell interpolation (template PR #26).
- `tests/test_smoke.py`: manually adopted the top-level-import form. The file is `_skip_if_exists`-protected, so copier preserved IG's existing v1.1.3 lazy-import version — matching the fleet by hand instead.

## Test plan

- [x] `uv run ruff check .` → clean
- [x] `uv run pytest -x -q` → 807 passed
- [x] `uv run mypy src/` → clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)