### PR TITLE
chore(ci): pause copier-update cron during fleet-sync

### DIFF
--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -10,7 +10,7 @@ name: Copier Update
 
 on:
   schedule:
-    - cron: "0 6 * * 1"  # Monday 06:00 UTC
+#     - cron: "0 6 * * 1"  # TEMPORARILY PAUSED during copier-sync fleet-alignment (2026-04-22) — resumed in a follow-up PR  # Monday 06:00 UTC
   workflow_dispatch:
     inputs:
       vcs_ref:


### PR DESCRIPTION
Temporarily comment out the Monday 06:00 UTC cron so fleet-sync PRs don't race with bot runs.  Reverted once the fleet is aligned to template v1.1.5 — see copier-sync plan in fastmcp-server-template repo.