### PR TITLE
refactor(claude-md): add DOMAIN + TEMPLATE-OWNED sentinel structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,13 @@
 
 FastMCP server scaffold. See [TEMPLATE.md](TEMPLATE.md) for customisation guide.
 
+## Design
+<!-- DOMAIN-START -->
+<!-- Add image-generation-mcp design notes here. Kept across copier update. -->
+<!-- DOMAIN-END -->
+
 ## Project Structure
+<!-- DOMAIN-START -->
 
 ```
 src/image_generation_mcp/
@@ -14,6 +20,10 @@ src/image_generation_mcp/
   _server_resources.py -- MCP resources; add domain resources here
   _server_prompts.py   -- MCP prompts; add domain prompts here
 ```
+<!-- DOMAIN-END -->
+
+<!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
+
 
 ## Conventions
 
@@ -24,15 +34,87 @@ src/image_generation_mcp/
 - Google-style docstrings on all public functions
 - `logging.getLogger(__name__)` throughout, no `print()`
 - Type hints everywhere
+- Tests: `pytest` with fixtures in `tests/fixtures/`
+
+## Hard PR Acceptance Gates
+
+Every PR must pass **all** of the following before merge. Do not open or push a PR until these are green locally:
+
+1. **CI passes** — `uv run pytest -x -q` all tests pass
+2. **Lint passes** — run in this exact order: `uv run ruff check --fix .` then `uv run ruff format .` then verify with `uv run ruff format --check .`. Always run format *after* check --fix because check --fix can leave files needing reformatting.
+3. **Type-check passes** — `uv run mypy src/` reports no errors
+4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
+5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
+6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
+
+## GitHub Review Types
+
+GitHub has two distinct review mechanisms — **both must be read and addressed**:
+
+- **Inline review comments** (`get_review_comments`): attached to specific lines of the diff. Appear in the "Files changed" tab. Use `get_review_comments` to fetch these.
+- **PR-level comments** (`get_comments`): posted on the Conversation tab, not tied to a line. Review summary posts, bot analysis, and blocking issues are often posted here. Use `get_comments` to fetch these.
+
+Always fetch both before declaring a review round complete.
+
+## Documentation Discipline
+
+Every issue, PR, and code change must consider documentation impact. Before closing any issue or creating any PR, check whether the following need updating:
+
+- **`docs/design.md`** — the authoritative spec. Any new feature, changed behavior, or architectural decision must be reflected here.
+- **`README.md`** — user-facing documentation. New env vars, tools, resources, prompts, CLI flags, or configuration options must be documented here.
+- **`docs/` site pages** — the published documentation site. New or changed MCP tools/resources/prompts, new env vars, new installation methods or deployment options.
+- **`CHANGELOG.md`** — managed by semantic-release from conventional commits.
+- **Inline docstrings** — new or changed public API methods need accurate Google-style docstrings.
+
+**Rule: code without matching docs is incomplete.**
+
+## Logging Standard
+
+### Framework
+- Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.
+- No `print()` for operational output. No third-party logging libraries.
+- FastMCP middleware handles tool invocation, timing, and error logging automatically.
+- All logging goes through FastMCP's `configure_logging()` for uniform output. `FASTMCP_LOG_LEVEL` is the single log level control; the `-v` CLI flag sets it to `DEBUG`. `FASTMCP_ENABLE_RICH_LOGGING=false` switches to plain/JSON output.
+
+### Log Levels
+| Level | Use for |
+|-------|---------|
+| `DEBUG` | Detailed internals: cache hits, parameter values, config resolution |
+| `INFO` | Significant operations: service startup, configuration decisions (tool calls logged by middleware) |
+| `WARNING` | Degraded but continuing: API errors with fallback, missing optional config, unexpected data |
+| `ERROR` | Failures affecting the primary result. Use `logger.error(..., exc_info=True)` when traceback is needed |
+
+### Exception Handling
+- All exceptions must be caught and handled. No bare `except:`. Always specify the exception type.
+- Expected errors (HTTP 4xx, missing data): catch, log, return user-facing error string.
+- Optional enrichment failures: catch, log at `DEBUG` with `exc_info=True`, continue.
+- Primary result errors: catch, log at `WARNING` or `ERROR`, return error string.
+- `ErrorHandlingMiddleware` is a safety net. If it catches something, that's a bug to fix.
+
+### Message Format
+- Pseudo-structured: `logger.info("event_name key=%s", value)`
+- Event name as first token (snake_case), then key=value pairs via `%s` formatting.
+- Never use f-strings in log calls (defeats lazy evaluation).
+
+## Config & Customization Contract
+
+Domain configuration composes :class:`fastmcp_pvl_core.ServerConfig` inside :class:`ProjectConfig` (see `src/image_generation_mcp/config.py`).  Add domain fields between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels and populate them in `from_env` between the `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels.  Never inherit from `ServerConfig`; always compose.
+
+Env var prefix is `IMAGE_GENERATION_MCP_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
+
+<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 
 ## Key Patterns
+<!-- DOMAIN-START -->
 
 - Library is sync; MCP layer uses `asyncio.to_thread()` for blocking calls
 - Write tools tagged `tags={"write"}`, hidden via `mcp.disable(tags={"write"})` in read-only mode
 - Auth: composed via `fastmcp_pvl_core.build_auth()` inside `make_server()`; MultiAuth assembled automatically when both bearer + OIDC are configured
 - `_ENV_PREFIX` in `config.py` controls all env var names — change once, affects everything
+<!-- DOMAIN-END -->
 
 ## Documentation
+<!-- DOMAIN-START -->
 
 Every PR that changes user-facing behavior must update the corresponding documentation:
 
@@ -44,3 +126,4 @@ Every PR that changes user-facing behavior must update the corresponding documen
 The architect-reviewer conformance check includes documentation currency. A PR that adds a tool without documenting it is incomplete.
 
 Internal design docs (`docs/design/`, `docs/decisions/`) are developer reference — they are NOT part of the mkdocs site. ADRs are created/updated as part of implementation issues, not documentation issues.
+<!-- DOMAIN-END -->


### PR DESCRIPTION
Structural move.  No functional changes.  Prepares for clean copier-update diffs from template v1.1.5.

See spec in fastmcp-server-template repo: `docs/superpowers/specs/2026-04-22-copier-sync-and-claude-md-parity-design.md` §3.2.