### PR TITLE
chore(copier): converge drifted template-owned files to v1.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,41 @@
+# Python bytecode
 __pycache__/
 *.py[cod]
 *$py.class
+*.so
+
+# Distribution / packaging
 *.egg-info/
+*.egg
 dist/
 build/
 .eggs/
-*.egg
+
+# Virtualenvs
 .venv/
 venv/
-.env
-*.so
+
+# Tooling caches
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
+
+# Test / coverage artifacts
 .coverage
 coverage.xml
+coverage.json
 htmlcov/
-*.npy
-*.npz
+
+# MkDocs build output
 site/
+
+# Local environment
+.env
+.env.local
+
+# --- Development / ecosystem ignores (don't ship)
 .mcpregistry_*
 .worktrees/
-docs/superpowers/
-
-# Claude Code local overrides (scope narrowly so project-shared assets
-# under .claude/ — hooks, custom commands, agents — stay committable)
 .claude/worktrees/
 .claude/settings.local.json
+docs/superpowers/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.12-slim
 
+# DOCKERFILE-APT-DEPS-START — add domain apt packages below; kept across copier update
 RUN apt-get update && apt-get install -y --no-install-recommends git gosu \
     && rm -rf /var/lib/apt/lists/*
+# DOCKERFILE-APT-DEPS-END
 
 COPY --from=ghcr.io/astral-sh/uv:0.6 /uv /uvx /bin/
 
@@ -10,6 +12,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 WORKDIR /app
 
+# DOCKERFILE-UV-EXTRAS-START — append `--extra <name>` flags below to pull domain-specific extras; kept across copier update
 # Install dependencies first (cache layer).
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
@@ -20,6 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra all
+# DOCKERFILE-UV-EXTRAS-END
 
 # Create non-root user with configurable UID/GID for bind-mount compatibility.
 ARG APP_UID=1000
@@ -41,4 +45,4 @@ EXPOSE 8000
 VOLUME ["/data/service", "/data/state"]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["image-generation-mcp", "serve", "--transport", "http"]
+CMD ["image-generation-mcp", "serve", "--transport", "http", "--host", "0.0.0.0"]

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,6 +23,7 @@ coverage:
 ignore:
   - "tests/**"
   - "docs/**"
+  - "src/image_generation_mcp/__main__.py"
 
 comment:
   layout: "reach,diff,flags,files"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,7 +25,7 @@ if [ "$(id -u)" = '0' ]; then
     # Ensure state subdirectories exist inside the volume.
     # Dockerfile seeds these on first use, but externally-created or
     # pre-existing volumes may be empty.
-    mkdir -p /data/state/embeddings /data/state/fastembed /data/state/fastmcp
+    mkdir -p /data/state/fastmcp
     # Always fix ownership of state subdirs — mkdir creates as root,
     # but the conditional chown loop below may skip /data/state if it
     # was already owned by appuser from a previous run.
@@ -33,7 +33,7 @@ if [ "$(id -u)" = '0' ]; then
 
     # Fix ownership — named volumes may arrive root-owned.
     # Only recurse into directories still owned by root, to avoid
-    # touching bind-mounted vault files on every restart.
+    # touching bind-mounted service files on every restart.
     chown appuser:appuser /data
     for _dir in /data/*; do
         if [ -d "$_dir" ] && [ "$(stat -c '%u' "$_dir")" = '0' ]; then

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -9,6 +9,11 @@ commit — which is the commit it then tags.
 
 The script runs inside PSR's Docker action container (python:3.14-slim), which
 has Python but no ``jq`` — hence Python rather than a shell+jq wrapper.
+
+Projects that ship additional versioned manifests (e.g. a Claude Code
+``plugin.json``, an ``.mcp.json``, or other lockstep JSON/TOML files) should
+add the extra paths to this script and list them in
+``pyproject.toml`` ``[tool.semantic_release] assets``.
 """
 
 from __future__ import annotations
@@ -56,16 +61,27 @@ def main() -> int:
     server = _load(server_path)
     if not isinstance(server, dict):
         print(
-            f"{server_path} must contain a JSON object (top-level)",
+            f"{server_path} must contain a JSON object (top-level), "
+            f"got {type(server).__name__}",
             file=sys.stderr,
         )
         return 1
     server["version"] = version
     packages = server.get("packages", [])
     if not isinstance(packages, list):
-        packages = []
-    for pkg in packages:
+        print(
+            f"{server_path}: 'packages' must be a JSON array, got "
+            f"{type(packages).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+    for i, pkg in enumerate(packages):
         if not isinstance(pkg, dict):
+            print(
+                f"WARNING: packages[{i}] is not a JSON object "
+                f"(got {type(pkg).__name__}) — skipped",
+                file=sys.stderr,
+            )
             continue
         if pkg.get("registryType") == "pypi":
             pkg["version"] = version


### PR DESCRIPTION
## Summary

Pre-emptive alignment before the Phase 4 copier-update bot PR lands template v1.1.5. Includes Dockerfile migration to the new `DOCKERFILE-APT-DEPS` / `DOCKERFILE-UV-EXTRAS` sentinel shape with image-gen's `--extra all` customization inside the UV-EXTRAS block.

### Files converged (pure drift)

- `codecov.yml` — add `src/image_generation_mcp/__main__.py` ignore
- `.gitignore` — adopt template grouped layout; drop stale `*.npy`/`*.npz` (no numpy usage)
- `docker-entrypoint.sh` — drop stale `mkdir` of `/data/state/embeddings` and `/data/state/fastembed` (no embeddings/fastembed runtime code); fix "vault" -> "service" comment
- `scripts/bump_manifests.py` — adopt v1.1.5 hardening (hard-fail on non-list `packages`, WARN-with-index on non-dict `pkg` entries, richer type name in top-level error). Verified IG has no `plugin.json`/`.mcp.json` assets; only `server.json` -> direct convergence safe.

### Files edited-into-sentinels (Dockerfile migration)

`Dockerfile` — wrap the `apt-get` install in `DOCKERFILE-APT-DEPS-{START,END}` and the `uv sync` + `COPY` lines in `DOCKERFILE-UV-EXTRAS-{START,END}`. IG customizations preserved inside sentinel blocks:

- APT-DEPS keeps IG's slim apt list (no `git-lfs`; IG has no LFS usage, no `.gitattributes` LFS tracks).
- UV-EXTRAS keeps `--extra all` on both `uv sync` invocations (IG ships provider-SDK extras).
- UV-EXTRAS keeps `COPY . .` (the `.dockerignore` narrows it appropriately).
- CMD converged to template v1.1.5's `--host 0.0.0.0` form.

### Files preserved (real domain content, not pure drift)

- `docs/deployment/docker.md` — IG-specific env vars (`OPENAI_API_KEY`, `SD_WEBUI_HOST`, `SCRATCH_DIR`, `EVENT_STORE_URL`).
- `docs/deployment/oidc.md` — IG's two-mode OIDC walkthrough (`remote` + `oidc-proxy`) with Authelia setup details.
- `docs/guides/authentication.md` — IG's fuller auth guide with OIDC-mode selection + OAuthProxy double-validation explainer.

## Gate

Local gate green on `chore/converge-template-drift`:

- `uv run ruff check .` - passed
- `uv run ruff format --check .` - 64 files already formatted
- `uv run mypy src/` - no issues (23 source files)
- `uv run pytest -x -q` - 807 passed, 1 warning

## Context

See spec in the `fastmcp-server-template` repo: `docs/superpowers/specs/2026-04-22-copier-sync-and-claude-md-parity-design.md` sections 2.4 and 3.3 Phase 1.5.

## Test plan

- [ ] CI green on this branch
- [ ] Do NOT merge yet — wait for Task 15 copier-update bot PRs