### PR TITLE
chore(pyproject): rename ruff TCH → TC in select for consistency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
     "diff-cover>=9.0",
-    "ruff>=0.1",
+    "ruff>=0.6",
     "mypy>=1.0",
     "pip-audit>=2.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = [
-    "E", "W", "F", "I", "B", "C4", "UP", "ARG", "SIM", "TCH", "PTH", "RUF",
+    "E", "W", "F", "I", "B", "C4", "UP", "ARG", "SIM", "TC", "PTH", "RUF",
 ]
 ignore = ["E501"]
 


### PR DESCRIPTION
## Summary

`pyproject.toml:75` `select` listed the old \`TCH\` prefix while `per-file-ignores` (introduced via the v1.2.0 copier-update in #201) uses the renamed \`TC001/TC002/TC003\` codes. Functionally fine — ruff accepts \`TCH\` as a backwards-compatible alias and reports under the new codes — but inconsistent within the file.

Closes #208.

## Why this is a follow-up to #201

claude-review on the resolution commit flagged this as a minor finding:

> **Minor inconsistency** — \`select\` still uses old \`\"TCH\"\` prefix while \`per-file-ignores\` uses renamed \`TC0xx\` codes... updating \`\"TCH\"\` → \`\"TC\"\` in \`select\` would make the config self-consistent.

The review body posted at 11:10 UTC; #201 was merged at 11:11 UTC, so the feedback didn't get processed in-PR. Addressing here in a follow-up per the user's instruction.

## Test plan

- [x] \`uv run ruff check .\` clean
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run mypy src/ tests/\` clean
- [x] \`uv run pytest -q\` 874 passing
- [ ] Bot reviewers (claude-review, gemini-code-assist) green on the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)