### PR TITLE
docs(styles): refresh provider list + clarify style_profile vs style library

### DIFF
--- a/docs/guides/styles.md
+++ b/docs/guides/styles.md
@@ -6,11 +6,20 @@ Styles are reusable presets that capture a visual direction — palette, composi
 
 A style is a **creative brief**, not a prompt template. When you apply a style, the LLM reads the brief and adapts it to the target provider's prompt format:
 
-- **OpenAI** — natural language description incorporating the style's direction
-- **SD WebUI (SD 1.5/SDXL)** — comma-separated CLIP tags with negative prompts
-- **SD WebUI (Flux)** — natural language, similar to OpenAI
+- **OpenAI** (gpt-image-1.5 / gpt-image-1 / gpt-image-2) — natural language description incorporating the style's direction.
+- **Gemini** (Flash Image / Pro Image preview) — natural language, similar to OpenAI; can also incorporate the style brief into multi-image compositing or conversational refinement.
+- **SD WebUI (SD 1.5 / SDXL / RealVisXL / Juggernaut)** — comma-separated CLIP tags with a separate negative prompt.
+- **SD WebUI (Flux 1 / Flux Schnell / FLUX.2 / SD 3.5)** — natural language, similar to OpenAI; no native negative prompts on the Flux family.
+- **SD WebUI (Pony Diffusion XL / Illustrious-XL / NoobAI-XL)** — Booru-style tag grammar with a mandatory `score_*` prefix on Pony.
 
-The style text is never copied verbatim into the generation prompt.
+The style text is never copied verbatim into the generation prompt — the LLM rewrites it in the right grammar for the chosen model. The per-model registry (`list_providers` → `style_profile.style_hints` / `incompatible_styles`) is the canonical source for what each model wants; cross-reference it from your style brief when you need provider-specific guidance.
+
+> **`style_profile` vs style library.** The two are deliberately separate concerns:
+>
+> - **Style library** (this guide) — a *user-saved creative brief* applied to a generation request. Describes *the brief*.
+> - **`style_profile`** (set by the registry, surfaced via `list_providers`) — *per-model metadata* describing what each model is best at. Describes *the model*.
+>
+> Both can use the word "style" in their everyday English sense — they don't interact. See [ADR-0009](https://github.com/pvliesdonk/image-generation-mcp/blob/main/docs/decisions/0009-model-style-metadata.md) for the disambiguation.
 
 ## Style File Format
 

--- a/docs/guides/styles.md
+++ b/docs/guides/styles.md
@@ -6,7 +6,7 @@ Styles are reusable presets that capture a visual direction — palette, composi
 
 A style is a **creative brief**, not a prompt template. When you apply a style, the LLM reads the brief and adapts it to the target provider's prompt format:
 
-- **OpenAI** (gpt-image-1.5 / gpt-image-1 / gpt-image-1-mini) — natural language description incorporating the style's direction. (`gpt-image-2` joins the lineup once OpenAI ships it; tracked as a separate change.)
+- **OpenAI** (gpt-image-1.5 / gpt-image-1 / gpt-image-1-mini) — natural language description incorporating the style's direction.
 - **Gemini** (gemini-2.5-flash-image / gemini-3.1-flash-image-preview / gemini-3-pro-image-preview) — natural language, similar to OpenAI; can also incorporate the style brief into multi-image compositing or conversational refinement.
 - **SD WebUI (SD 1.5 / SDXL / RealVisXL / Juggernaut)** — comma-separated CLIP tags with a separate negative prompt.
 - **SD WebUI (Flux 1 / Flux Schnell / FLUX.2)** — natural language, similar to OpenAI; **no** native negative prompts (CFG=1 distilled).

--- a/docs/guides/styles.md
+++ b/docs/guides/styles.md
@@ -13,7 +13,9 @@ A style is a **creative brief**, not a prompt template. When you apply a style, 
 - **SD WebUI (SD 3 / 3.5)** — natural language, similar to Flux, but **with** native negative prompts (unlike Flux). Skip SDXL-style `(weight:1.2)` parens.
 - **SD WebUI (Pony Diffusion XL / Illustrious-XL / NoobAI-XL)** — Booru-style tag grammar with a mandatory `score_*` prefix on Pony.
 
-The style text is never copied verbatim into the generation prompt — the LLM rewrites it in the right grammar for the chosen model. The per-model registry (`list_providers` → `style_profile.style_hints` / `incompatible_styles`) is the canonical source for what each model wants; cross-reference it from your style brief when you need provider-specific guidance.
+The style text is never copied verbatim into the generation prompt — the LLM rewrites it in the right grammar for the chosen model.
+
+The per-model registry (`list_providers` → `style_profile.style_hints` / `incompatible_styles`) is the canonical source for what each model wants; cross-reference it from your style brief when you need provider-specific guidance.
 
 > **`style_profile` vs style library.** The two are deliberately separate concerns:
 >

--- a/docs/guides/styles.md
+++ b/docs/guides/styles.md
@@ -6,10 +6,11 @@ Styles are reusable presets that capture a visual direction — palette, composi
 
 A style is a **creative brief**, not a prompt template. When you apply a style, the LLM reads the brief and adapts it to the target provider's prompt format:
 
-- **OpenAI** (gpt-image-1.5 / gpt-image-1 / gpt-image-2) — natural language description incorporating the style's direction.
-- **Gemini** (Flash Image / Pro Image preview) — natural language, similar to OpenAI; can also incorporate the style brief into multi-image compositing or conversational refinement.
+- **OpenAI** (gpt-image-1.5 / gpt-image-1 / gpt-image-1-mini) — natural language description incorporating the style's direction. (`gpt-image-2` joins the lineup once OpenAI ships it; tracked as a separate change.)
+- **Gemini** (gemini-2.5-flash-image / gemini-3.1-flash-image-preview / gemini-3-pro-image-preview) — natural language, similar to OpenAI; can also incorporate the style brief into multi-image compositing or conversational refinement.
 - **SD WebUI (SD 1.5 / SDXL / RealVisXL / Juggernaut)** — comma-separated CLIP tags with a separate negative prompt.
-- **SD WebUI (Flux 1 / Flux Schnell / FLUX.2 / SD 3.5)** — natural language, similar to OpenAI; no native negative prompts on the Flux family.
+- **SD WebUI (Flux 1 / Flux Schnell / FLUX.2)** — natural language, similar to OpenAI; **no** native negative prompts (CFG=1 distilled).
+- **SD WebUI (SD 3 / 3.5)** — natural language, similar to Flux, but **with** native negative prompts (unlike Flux). Skip SDXL-style `(weight:1.2)` parens.
 - **SD WebUI (Pony Diffusion XL / Illustrious-XL / NoobAI-XL)** — Booru-style tag grammar with a mandatory `score_*` prefix on Pony.
 
 The style text is never copied verbatim into the generation prompt — the LLM rewrites it in the right grammar for the chosen model. The per-model registry (`list_providers` → `style_profile.style_hints` / `incompatible_styles`) is the canonical source for what each model wants; cross-reference it from your style brief when you need provider-specific guidance.


### PR DESCRIPTION
## Summary

The style library guide (\`docs/guides/styles.md\`) predated Gemini and the per-model \`style_profile\` registry from #207. Two updates:

1. **Expand provider coverage in 'How Styles Work'.** The original mentioned only OpenAI / SD WebUI (SD 1.5 / SDXL) / SD WebUI (Flux). Updated to cover Gemini, the full SD architecture lineup the registry surfaces (Flux 1 / Flux Schnell / FLUX.2 / SD 3.5), and the tag-grammar fine-tunes (Pony / Illustrious-XL / NoobAI-XL). The LLM needs to know which grammar each style brief gets adapted into.

2. **Disambiguate \"style library\" vs \"style_profile\".** Both use the word \"style\" in everyday English. They don't interact:
   - **Style library** (this guide) — user-saved creative briefs.
   - **\`style_profile\`** (set by the registry, surfaced via \`list_providers\`) — per-model metadata.

   Added a callout block linking to ADR-0009 for the full disambiguation. Link points at the GitHub blob URL because \`docs/decisions/\` is excluded from the mkdocs site.

Closes #59.

## Why this is small

The 7-point acceptance criteria in #59 were already met by earlier work (presumably one of the dependency PRs #56 / #57 / #58 that landed the style library code). The guide is comprehensive: file format documented, manual + tool creation, browsing via resources, applying via prompt, managing, configuration, JSON examples that match \`StyleEntry\` serialisation. mkdocs nav already lists it. This PR only adds the missing Gemini coverage and the new \`style_profile\` cross-reference.

## Test plan

- [x] \`uv run mkdocs build --strict\` — clean (no broken links / warnings)
- [x] \`uv run pytest -q\` — 874 passing (no test changes; docs-only PR)
- [x] \`uv run ruff check . && uv run ruff format --check .\` — clean (markdown isn't linted, but stay sure)
- [ ] Bot reviewers (claude-review, gemini-code-assist) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)