### PR TITLE
chore: add .gemini/config.yaml to scope gemini-code-assist as a one-pass gate

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -6,7 +6,10 @@
 # templates — `pr-review-toolkit:code-reviewer` + `superpowers:code-reviewer`)
 # before any push; by the time the PR opens we expect the hosted bot to have
 # nothing to flag. These settings narrow the bot's scope so it fires on
-# flip-to-ready (not on every draft push) and only surfaces real issues.
+# flip-to-ready (not on every draft push) and only surfaces real issues —
+# the HIGH severity floor and 20-comment cap match the local-circus contract:
+# anything LOW/MEDIUM should already be caught locally, so a quiet bot review
+# is the expected steady state, not a sign of a quota or auth failure.
 
 code_review:
   disable: false

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -2,11 +2,11 @@
 # Reference: https://developers.google.com/gemini-code-assist/docs/customize-repo-review
 #
 # Rationale: gemini-code-assist is a merge gate, not a pair reviewer. We run a
-# local review circus (`pr-review-toolkit:code-reviewer` subagent + the
-# `gemini-cli-extensions/code-review` extension) before any push; by the time
-# the PR opens we expect the hosted bot to have nothing to flag. These settings
-# narrow the bot's scope so it fires on flip-to-ready (not on every draft push)
-# and only surfaces real issues.
+# local review circus (two subagent code-reviewers with different prompt
+# templates — `pr-review-toolkit:code-reviewer` + `superpowers:code-reviewer`)
+# before any push; by the time the PR opens we expect the hosted bot to have
+# nothing to flag. These settings narrow the bot's scope so it fires on
+# flip-to-ready (not on every draft push) and only surfaces real issues.
 
 code_review:
   disable: false

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,19 @@
+# Gemini Code Assist — repo review config
+# Reference: https://developers.google.com/gemini-code-assist/docs/customize-repo-review
+#
+# Rationale: gemini-code-assist is a merge gate, not a pair reviewer. We run a
+# local review circus (`pr-review-toolkit:code-reviewer` subagent + the
+# `gemini-cli-extensions/code-review` extension) before any push; by the time
+# the PR opens we expect the hosted bot to have nothing to flag. These settings
+# narrow the bot's scope so it fires on flip-to-ready (not on every draft push)
+# and only surfaces real issues.
+
+code_review:
+  disable: false
+  comment_severity_threshold: HIGH
+  max_review_comments: 20
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true
+    include_drafts: false


### PR DESCRIPTION
Closes #217
Refs pvliesdonk/fastmcp-server-template#82

## Summary

Configures the `gemini-code-assist` GitHub App per its [repo-review docs](https://developers.google.com/gemini-code-assist/docs/customize-repo-review) so it behaves as a one-pass merge gate rather than an iterative pair reviewer:

- `include_drafts: false` — gemini reviews only on flip-to-ready, not on every draft push
- `summary: false` — no PR-summary write-up, just the review
- `comment_severity_threshold: HIGH` — local review handles MEDIUM/LOW; hosted bot only surfaces real issues
- `max_review_comments: 20` — bound noise on rare disagreements

## Why

Recent PRs (#212/#213/#214/#215) showed the failure mode: I treated the hosted bot as a pair reviewer, pushing tiny fixes and re-triggering `/gemini review` after each, which (a) burned through Gemini's daily quota mid-session and (b) produced a stream of "fix nit" commits that should have been part of the original change.

The corrected workflow (now in global agent guidance): run a **local** review circus — two subagent code-reviewers with different prompt templates (`pr-review-toolkit:code-reviewer` + `superpowers:code-reviewer`) — until the diff is clean, then push and let the hosted bot fire as a one-pass gate. This config makes that workflow tractable.

## Template ownership

This file would naturally live in the [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) and propagate via copier; tracked at upstream issue [#82](https://github.com/pvliesdonk/fastmcp-server-template/issues/82). Landing here ahead of the template release so the workflow change takes effect immediately. When the template adopts the same content, the next `copier update` should reconcile cleanly (identical content → no conflict marker).

## Test plan

- [x] Schema verified against the Google docs (top-level `code_review:` wrapper; `comment_severity_threshold` / `max_review_comments` / `disable` are direct children of `code_review`; `pull_request_opened` is a sub-block).
- [x] Local `pr-review-toolkit:code-reviewer` subagent: clean (round 3, after fixing a critical schema error in round 1).
- [x] Local `gemini` CLI second-opinion: **dropped from the workflow.** The `code-review` extension can't function in this environment — it tries to read its own skill files outside the gemini workspace and to call `run_shell_command` which is gated. Per [google-gemini/gemini-cli#5435](https://github.com/google-gemini/gemini-cli/issues/5435), slash commands work in non-interactive mode now, but the extension itself depends on tools the runtime denies. The CLAUDE.md update was revised to use a second subagent reviewer (`superpowers:code-reviewer`) for the second-opinion angle instead.
- [ ] Hosted gemini-code-assist behavior on this PR will exercise the config — with `include_drafts: false`, the bot should NOT auto-review while this PR is in draft, and should auto-review only on flip-to-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)