### PR TITLE
chore(template): apply copier template v2.1.1 → v2.2.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.1.1
+_commit: v2.2.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: MCP server for AI image generation via OpenAI, Google GenAI, or

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -18,6 +19,12 @@ jobs:
         uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-${{ runner.os }}
 
       - name: Set up Python
         run: uv python install 3.12
@@ -34,6 +41,7 @@ jobs:
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -41,6 +49,12 @@ jobs:
         uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-${{ runner.os }}
 
       - name: Set up Python
         run: uv python install 3.12
@@ -54,6 +68,10 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # Prevent a stalled `uv python install` from blocking the PR for hours.
+    # 20 min covers the full test matrix with headroom; cold interpreter
+    # downloads from python-build-standalone are the most likely stall source.
+    timeout-minutes: 20
     continue-on-error: ${{ matrix.experimental || false }}
     permissions:
       contents: read
@@ -77,6 +95,16 @@ jobs:
         uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v4
+        with:
+          # `uv python install` writes to UV_PYTHON_INSTALL_DIR, which is
+          # separate from the uv package cache and not covered by setup-uv's
+          # enable-cache. Caching by version + OS avoids re-downloading the
+          # python-build-standalone tarball on every run.
+          path: ~/.local/share/uv/python
+          key: uv-python-${{ matrix.python-version }}-${{ runner.os }}
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -179,6 +207,7 @@ jobs:
   audit:
     name: Dependency Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -188,6 +217,12 @@ jobs:
         uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-${{ runner.os }}
 
       - name: Set up Python
         run: uv python install 3.12
@@ -202,7 +237,13 @@ jobs:
         run: uv export --all-extras --no-default-groups --frozen --no-emit-project --no-hashes -o ${{ runner.temp }}/requirements.txt
 
       - name: Run pip-audit
-        run: uvx pip-audit --strict --progress-spinner off -r ${{ runner.temp }}/requirements.txt
+        run: |
+          uvx pip-audit --strict --progress-spinner off \
+            --ignore-vuln CVE-2026-42561 \
+            -r ${{ runner.temp }}/requirements.txt
+          # CVE-2026-42561: python-multipart <0.0.27, pulled in transitively by
+          # fastmcp/starlette. Ignored until the upstream pin chain propagates
+          # the fix to 0.0.27. Remove once `uv lock` resolves >=0.0.27.
 
   secrets:
     name: Secret Detection

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -171,6 +171,7 @@ jobs:
         continue-on-error: true
         env:
           PREVIOUS_COMMIT: ${{ steps.meta.outputs.previous_commit }}
+          NEW_REF: ${{ steps.meta.outputs.new_ref }}
           TEMPLATE_REPO: ${{ steps.meta.outputs.template_repo }}
         run: |
           set -euo pipefail
@@ -182,10 +183,14 @@ jobs:
           git clone --filter=blob:none \
             "https://github.com/${TEMPLATE_REPO}.git" \
             /tmp/template
-          # Verify both refs are reachable
+          # Verify both refs are reachable before declaring the clone usable.
           git -C /tmp/template fetch --tags
           if [ -n "${PREVIOUS_COMMIT}" ]; then
             git -C /tmp/template rev-parse "${PREVIOUS_COMMIT}^{commit}" >/dev/null
+          fi
+          if [ -n "${NEW_REF}" ]; then
+            git -C /tmp/template rev-parse "${NEW_REF}^{commit}" >/dev/null \
+              || { echo "::error::NEW_REF not reachable in template clone: ${NEW_REF}"; exit 1; }
           fi
           echo "template_clone_ok=true" >> "$GITHUB_OUTPUT"
 
@@ -275,7 +280,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prepare-prompt-a.outputs.prompt }}
           claude_args: |
-            --allowed-tools "Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git rev-parse:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git config user.name:*),Bash(git config user.email:*),Bash(git commit:*),Bash(git rev-parse:*),Bash(git -C /tmp/template:*)"
 
       - name: Pre-render Job B prompt
         id: prepare-prompt-b
@@ -368,6 +373,11 @@ jobs:
           REF: ${{ steps.meta.outputs.ref }}
         run: |
           set -euo pipefail
+          # claude-code-action overwrites local git config (user.name/email) to
+          # claude[bot] during the agent step; reset here so this commit is
+          # attributed to github-actions[bot], not the agent identity.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           branch="copier/update"
           # `git add -A` runs BEFORE `git checkout -B` because copier's
           # `--conflict=inline` mode leaves conflict-marker files in the
@@ -406,7 +416,7 @@ jobs:
             echo "DIFF_STAT_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build #49 body content
+      - name: Build PR body content
         id: build-body
         if: steps.changes.outputs.changed == 'true'
         env:
@@ -483,10 +493,10 @@ jobs:
 
       - name: Compose PR body via aggregator
         id: compose
-        # Reads the existing #49-shaped body data + three /tmp/agent-job-*.json
+        # Reads the existing PR body data + three /tmp/agent-job-*.json
         # files (any may be missing/errored) and writes the composed PR body.
         # Failure-tolerant: if aggregator crashes, PR still opens with the
-        # existing #49 body (no agent sections).
+        # existing body (no agent sections).
         if: steps.changes.outputs.changed == 'true'
         continue-on-error: true
         env:
@@ -529,8 +539,8 @@ jobs:
           branch="copier/update"
           title="chore(copier): update to ${REF}"
 
-          # Prefer the aggregator's composed body; fall back to the plain
-          # #49 body if the aggregator step failed (continue-on-error: true).
+          # Prefer the aggregator's composed body; fall back to the plain body
+          # if the aggregator step failed (continue-on-error: true).
           if [ -f /tmp/aggregator/composed-body.md ]; then
             body_file=/tmp/aggregator/composed-body.md
           else

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,15 @@ jobs:
       - name: Build documentation
         run: uv run mkdocs build --strict
 
+      - name: Install browser test deps
+        run: uv sync --no-default-groups --all-extras --group docs --group browser --frozen
+
+      - name: Install Chromium
+        run: uv run playwright install --with-deps chromium
+
+      - name: Run config-wizard smoke test
+        run: uv run pytest tests/test_config_wizard_smoke.py -v -m browser
+
   deploy:
     # Publish versioned docs with mike, serving from the gh-pages branch:
     #   stable release (prerelease=false) -> version <major.minor> + `latest` alias (default)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Force version bump (empty = auto; "prerelease" advances the rc revision e.g. rc.1 → rc.2 — keep the pre-release box below checked)'
+        description: 'Force version bump type (empty = auto from commits). patch/minor/major override commit analysis. Ignored when pre-release box is checked and an rc series is already active — the revision is advanced automatically.'
         type: choice
         default: ''
         options:
           - ''
-          - prerelease
           - patch
           - minor
           - major
@@ -33,18 +32,48 @@ jobs:
       id-token: write
 
     steps:
-      - name: Reject contradictory dispatch inputs
-        if: inputs.force == 'prerelease' && inputs.prerelease == false
-        run: |
-          echo "::error::force=prerelease advances the rc revision and requires the pre-release box to stay checked"
-          exit 1
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
           token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Detect active pre-release series
+        id: detect-rc
+        run: |
+          latest_rc=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$' | head -1 || true)
+          if [ -n "$latest_rc" ]; then
+            rc_base="${latest_rc%-rc.*}"
+            if ! git tag --list | grep -qx "$rc_base"; then
+              echo "in_rc_series=true" >> "$GITHUB_OUTPUT"
+              echo "rc_series_target=$rc_base" >> "$GITHUB_OUTPUT"
+            else
+              echo "in_rc_series=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "in_rc_series=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute effective PSR force
+        id: compute-force
+        run: |
+          force="${{ inputs.force }}"
+          prerelease="${{ inputs.prerelease }}"
+          in_rc_series="${{ steps.detect-rc.outputs.in_rc_series }}"
+          if [[ "$prerelease" == "true" && "$force" == "" && "$in_rc_series" == "true" ]]; then
+            echo "effective_force=prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "effective_force=$force" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Reject force bump on active pre-release series
+        if: steps.detect-rc.outputs.in_rc_series == 'true' && inputs.prerelease == false && (inputs.force == 'patch' || inputs.force == 'minor' || inputs.force == 'major')
+        run: |
+          echo "::error::An active pre-release series is in progress targeting ${{ steps.detect-rc.outputs.rc_series_target }}."
+          echo "::error::force=patch/minor/major with prerelease=false applies an additional bump on top of the series target and will skip ${{ steps.detect-rc.outputs.rc_series_target }}."
+          echo "::error::To finalize the series as a stable release, dispatch with force='' and prerelease=false."
+          exit 1
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -61,7 +90,7 @@ jobs:
           github_token: ${{ secrets.RELEASE_TOKEN }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
-          force: ${{ inputs.force }}
+          force: ${{ steps.compute-force.outputs.effective_force }}
           prerelease: ${{ inputs.prerelease }}
           prerelease_token: rc
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ site/
 # --- Development / ecosystem ignores (don't ship)
 .mcpregistry_*
 .worktrees/
-.claude/worktrees/
-.claude/settings.local.json
+.claude/
+.mcp.json
+.repowise/
 docs/superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,11 +88,31 @@ Every issue, PR, and code change must consider documentation impact. Before clos
 
 ## Logging Standard
 
+### Scope
+
+This standard governs **first-party code only** — `src/image_generation_mcp/` and
+`tests/`. Two categories of log output are explicitly **out of scope**; do not
+try to make them conform:
+
+- **FastMCP middleware stack** (`fastmcp-pvl-core` timing / logging /
+  error-handling middleware): emits conforming, bare-event-name-first lines
+  automatically. Tool-call lines carry `tool=<name>`. Governed by
+  `fastmcp-pvl-core` itself (see pvliesdonk/fastmcp-pvl-core#90); no
+  first-party code needed.
+- **`uvicorn.access` and `mcp.server.lowlevel.server` log lines**: upstream
+  transport / SDK output. `configure_logging_from_env` raises their effective
+  level to `WARNING`, suppressing per-request `INFO` output at the default
+  level; at `DEBUG` they are reset to `NOTSET` so the root logger governs
+  their effective level via propagation (pvliesdonk/fastmcp-pvl-core#91).
+  `uvicorn.error` is intentionally not suppressed — it carries startup and
+  bind failures. Do not silence or reformat any of these — they are out of
+  scope by design.
+
 ### Framework
 - Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.
 - No `print()` for operational output. No third-party logging libraries.
 - FastMCP middleware handles tool invocation, timing, and error logging automatically.
-- All logging goes through FastMCP's `configure_logging()` for uniform output. `FASTMCP_LOG_LEVEL` is the single log level control; the `-v` CLI flag sets it to `DEBUG`. `FASTMCP_ENABLE_RICH_LOGGING=false` switches to plain/JSON output.
+- All first-party logging goes through FastMCP's `configure_logging_from_env()` for uniform output. `FASTMCP_LOG_LEVEL` is the single log level control; the `-v` CLI flag sets it to `DEBUG`. `FASTMCP_ENABLE_RICH_LOGGING=false` switches to plain/JSON output.
 
 ### Log Levels
 | Level | Use for |

--- a/docs/configuration-generator.md
+++ b/docs/configuration-generator.md
@@ -1,0 +1,11 @@
+# Configuration Generator
+
+Answer a few questions and copy a ready-to-use configuration for your exact
+deployment. Everything runs in your browser; nothing you type is sent anywhere.
+Secret fields (tokens, keys) are never included in the shareable link; replace
+the `<YOUR_...>` placeholders if you leave them blank.
+
+<!-- The relative path relies on MkDocs' default use_directory_urls: true -->
+<div id="cfg-wizard" data-spec-url="../javascripts/config-wizard/wizard-spec.json">
+  Loading the configuration generator…
+</div>

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -1,0 +1,144 @@
+// Pure config-output generators. No DOM, no spec knowledge beyond the emit map.
+
+const IMAGE = "ghcr.io/pvliesdonk/image-generation-mcp:latest";
+
+// Vars whose value is fixed to a container path in Docker/Compose output.
+const CONTAINER_PATHS = {
+  // PROJECT-WIZARD-CONTAINER-PATHS-START — add container paths below; kept across copier update
+  IMAGE_GENERATION_MCP_SCRATCH_DIR: "/data/state/images",
+  // PROJECT-WIZARD-CONTAINER-PATHS-END
+};
+
+const SECRET_PLACEHOLDER = (key) => `<YOUR_${key.replace(/^IMAGE_GENERATION_MCP_/, "")}>`;
+
+// Single-quote a value for a POSIX shell `-e KEY=value` argument, but only when
+// it contains characters outside the shell-safe set (keeps clean output tidy).
+const shellQuote = (v) => {
+  const s = String(v);
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${s.replace(/'/g, "'\\''")}'`;
+};
+
+// Quote a YAML scalar only when it contains characters that would otherwise
+// break parsing (or has surrounding whitespace, or is empty).
+const yamlScalar = (v) => {
+  const s = String(v);
+  return /[\n:#[\]{}&*?|<>=!%@,`"']|^\s|\s$|^$/.test(s) ? JSON.stringify(s) : s;
+};
+
+// A systemd `Environment=` line. systemd does NOT expand `$` in Environment=
+// values (expansion only happens in ExecXYZ= directives), so `$` is left
+// literal. It DOES resolve `%` specifiers (escaped as `%%`) and process
+// C-style `\`/`"` escapes (systemd/systemd#36488), so those are escaped, and
+// the assignment is wrapped in quotes when it contains whitespace, a quote, or
+// a backslash.
+const systemdLine = (k, v) => {
+  const s = String(v).replace(/%/g, "%%");
+  if (!/[\s"\\]/.test(s)) return `Environment=${k}=${s}`;
+  const escaped = s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `Environment="${k}=${escaped}"`;
+};
+
+// Build {VAR: value} from the spec + answers. Empty non-secret answers are
+// dropped; a visible secret left empty becomes a placeholder so the artifact is
+// still complete and signals "replace me".
+export function buildEnvMap(spec, answers) {
+  const secrets = new Set(spec.secretKeys);
+  const map = {};
+  for (const q of spec.questions) {
+    if (!isVisible(q, answers)) continue;
+    if (q.options) {
+      const chosen = q.options.find((o) => o.value === answers[q.id]);
+      if (chosen && chosen.emit) Object.assign(map, chosen.emit);
+    }
+    if (q.var) {
+      const raw = answers[q.id];
+      if (raw !== undefined && raw !== "") map[q.var] = raw;
+      else if (secrets.has(q.var)) map[q.var] = SECRET_PLACEHOLDER(q.var);
+    }
+  }
+  return map;
+}
+
+export function isVisible(q, answers) {
+  if (!q.showIf) return true;
+  return Object.entries(q.showIf).every(([k, allowed]) => allowed.includes(answers[k]));
+}
+
+function dockerEnvMap(map) {
+  const out = { ...map };
+  for (const [k, v] of Object.entries(CONTAINER_PATHS)) {
+    if (k in out) out[k] = v;
+  }
+  out.FASTMCP_HOME = "/data/state/fastmcp";
+  return out;
+}
+
+// Quote a .env value when it contains characters that common dotenv parsers
+// treat specially (notably `#`, which starts an inline comment in an unquoted
+// value and would silently truncate the value on load).
+const dotenvQuote = (v) => {
+  const s = String(v);
+  if (!/[#"'\\\s]/.test(s)) return s;
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, '\\$')}"`;
+};
+
+export function generateDotenv(map) {
+  return Object.entries(map).map(([k, v]) => `${k}=${dotenvQuote(v)}`).join("\n") + "\n";
+}
+
+export function generateClaudeJson(map) {
+  return JSON.stringify(
+    { mcpServers: { "image-generation-mcp": { command: "image-generation-mcp", args: ["serve"], env: map } } },
+    null, 2,
+  );
+}
+
+export function generateDockerRun(map) {
+  const env = dockerEnvMap(map);
+  const lines = [
+    "docker run -d --name image-generation-mcp",
+    "  -p 8000:8000",
+    "  -v state-data:/data/state",
+  ];
+  for (const [k, v] of Object.entries(env)) lines.push(`  -e ${k}=${shellQuote(v)}`);
+  lines.push(`  ${IMAGE}`);
+  return lines.join(" \\\n");
+}
+
+export function generateCompose(map) {
+  const env = dockerEnvMap(map);
+  const envLines = Object.entries(env).map(([k, v]) => `      ${k}: ${yamlScalar(v)}`).join("\n");
+  return [
+    "services:",
+    "  image-generation-mcp:",
+    `    image: ${IMAGE}`,
+    "    ports:",
+    '      - "8000:8000"',
+    "    volumes:",
+    "      - state-data:/data/state",
+    "    environment:",
+    envLines,
+    "volumes:",
+    "  state-data:",
+  ].join("\n");
+}
+
+export function generateSystemd(map) {
+  const envLines = Object.entries(map).map(([k, v]) => systemdLine(k, v)).join("\n");
+  return [
+    "[Unit]",
+    "Description=image-generation-mcp",
+    "After=network.target",
+    "",
+    "[Service]",
+    "Type=simple",
+    "# Create this user first: sudo useradd --system --no-create-home image-generation-mcp",
+    "User=image-generation-mcp",
+    "ExecStart=/opt/image-generation-mcp/venv/bin/image-generation-mcp serve --transport http",
+    envLines,
+    "Restart=on-failure",
+    "",
+    "[Install]",
+    "WantedBy=multi-user.target",
+  ].join("\n");
+}

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "secretKeys": [
+    "IMAGE_GENERATION_MCP_BEARER_TOKEN",
+    "IMAGE_GENERATION_MCP_OPENAI_API_KEY",
+    "IMAGE_GENERATION_MCP_GOOGLE_API_KEY"
+  ],
+  "questions": [
+    {
+      "id": "deployment",
+      "label": "Where will the server run?",
+      "help": "Local stdio for Claude Desktop/Code, or an HTTP server for Docker/systemd.",
+      "type": "select",
+      "options": [
+        { "value": "local", "label": "Local (Claude Desktop / Claude Code, stdio)" },
+        { "value": "server", "label": "Server (HTTP — Docker / Compose / systemd)" }
+      ]
+    },
+    {
+      "id": "bearer_token",
+      "label": "Bearer token",
+      "help": "Any non-empty string enables bearer auth. Leave blank for no authentication.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_BEARER_TOKEN",
+      "showIf": { "deployment": ["server"] }
+    },
+    {
+      "id": "openai_api_key",
+      "label": "OpenAI API key",
+      "help": "Required for the OpenAI provider (DALL-E 3, GPT-Image-1). Leave blank to skip OpenAI.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OPENAI_API_KEY"
+    },
+    {
+      "id": "google_api_key",
+      "label": "Google API key (Gemini)",
+      "help": "Required for the Gemini provider (Imagen 3). Leave blank to skip Gemini.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_GOOGLE_API_KEY"
+    },
+    {
+      "id": "sd_webui_host",
+      "label": "SD WebUI host URL",
+      "help": "Base URL of a running AUTOMATIC1111/Forge/reForge instance, e.g. http://localhost:7860. Leave blank to skip SD WebUI.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_SD_WEBUI_HOST"
+    },
+    {
+      "id": "default_provider",
+      "label": "Default provider",
+      "help": "Provider used when no keyword triggers auto-selection. \"auto\" picks the first configured provider.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_DEFAULT_PROVIDER",
+      "advancedGroup": "Providers"
+    },
+    {
+      "id": "read_only",
+      "label": "Read-only mode",
+      "help": "Disables write tools (generate, transform). Default: true.",
+      "type": "bool",
+      "var": "IMAGE_GENERATION_MCP_READ_ONLY",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "scratch_dir",
+      "label": "Scratch directory",
+      "help": "Directory where generated images are saved. Defaults to ~/.image-generation-mcp/.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_SCRATCH_DIR",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "log_level",
+      "label": "Log level",
+      "help": "One of DEBUG, INFO, WARNING, ERROR.",
+      "type": "text",
+      "var": "FASTMCP_LOG_LEVEL",
+      "advancedGroup": "Logging"
+    },
+    {
+      "id": "rich_logging",
+      "label": "Rich logging",
+      "help": "Enable pretty terminal output. Disable for JSON/plain logs in production.",
+      "type": "bool",
+      "var": "FASTMCP_ENABLE_RICH_LOGGING",
+      "advancedGroup": "Logging"
+    }
+  ],
+  "guards": []
+}

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -86,5 +86,15 @@
       "advancedGroup": "Logging"
     }
   ],
-  "guards": []
+  "guards": [
+    {
+      "level": "warning",
+      "message": "No provider is configured — the server will start but cannot generate images. Fill in at least one of: OpenAI API key, Google API key, or SD WebUI host.",
+      "when": {
+        "openai_api_key": [""],
+        "google_api_key": [""],
+        "sd_webui_host": [""]
+      }
+    }
+  ]
 }

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -1,0 +1,221 @@
+import {
+  buildEnvMap, isVisible, generateDotenv, generateClaudeJson,
+  generateDockerRun, generateCompose, generateSystemd,
+} from "./generators.js";
+
+const MOUNT_ID = "cfg-wizard";
+const answers = {};
+
+function readUrlState(spec) {
+  const hash = new URLSearchParams(location.hash.slice(1));
+  const secrets = new Set(spec.secretKeys);
+  for (const q of spec.questions) {
+    if (secrets.has(q.var)) continue; // never hydrate secrets from URL
+    const v = hash.get(q.id);
+    if (v !== null) answers[q.id] = v;
+  }
+}
+
+function writeUrlState(spec) {
+  const secrets = new Set(spec.secretKeys);
+  const params = new URLSearchParams();
+  for (const q of spec.questions) {
+    if (secrets.has(q.var)) continue;
+    if (answers[q.id] !== undefined && answers[q.id] !== "") params.set(q.id, answers[q.id]);
+  }
+  const qs = params.toString();
+  history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+}
+
+function field(q, secrets) {
+  const wrap = document.createElement("label");
+  wrap.className = "cfg-field";
+  wrap.dataset.qid = q.id;
+  const title = document.createElement("span");
+  title.className = "cfg-label";
+  title.textContent = q.label;
+  wrap.appendChild(title);
+  if (q.help) {
+    const help = document.createElement("small");
+    help.className = "cfg-help";
+    help.textContent = q.help;
+    wrap.appendChild(help);
+  }
+  let input;
+  if (q.type === "select") {
+    input = document.createElement("select");
+    for (const opt of q.options) {
+      const o = document.createElement("option");
+      o.value = opt.value;
+      o.textContent = opt.label;
+      input.appendChild(o);
+    }
+  } else if (q.type === "bool") {
+    input = document.createElement("select");
+    for (const v of ["", "true", "false"]) {
+      const o = document.createElement("option");
+      o.value = v;
+      o.textContent = v || "(default)";
+      input.appendChild(o);
+    }
+  } else {
+    input = document.createElement("input");
+    input.type = q.type === "number" ? "number" : "text";
+  }
+  if (secrets.has(q.var)) wrap.classList.add("cfg-secret");
+  if (answers[q.id] !== undefined) input.value = answers[q.id];
+  // One listener per control: selects/bools settle on "change"; text/number
+  // fields update live on "input". Avoids the double render + double
+  // history.replaceState that "input"+"change" both firing on <select> causes.
+  const evt = q.type === "select" || q.type === "bool" ? "change" : "input";
+  input.addEventListener(evt, () => {
+    answers[q.id] = input.value;
+    render();
+  });
+  wrap.appendChild(input);
+  return wrap;
+}
+
+let SPEC = null;
+let ROOT = null;
+
+function render() {
+  const spec = SPEC;
+  const secrets = new Set(spec.secretKeys);
+  // Capture focus + caret so a full re-render (replaceChildren) doesn't drop
+  // the user mid-keystroke in a text field.
+  const active = document.activeElement;
+  const activeQid =
+    active && active.closest ? active.closest(".cfg-field")?.dataset.qid : null;
+  let selStart = null;
+  let selEnd = null;
+  try {
+    selStart = active.selectionStart;
+    selEnd = active.selectionEnd;
+  } catch {
+    // selects / number inputs do not expose a text selection
+  }
+  const core = document.createElement("div");
+  core.className = "cfg-core";
+  const advanced = {};
+  for (const q of spec.questions) {
+    if (!isVisible(q, answers)) continue;
+    const el = field(q, secrets);
+    if (q.advancedGroup) {
+      (advanced[q.advancedGroup] ??= []).push(el);
+    } else {
+      core.appendChild(el);
+    }
+  }
+  const drawer = document.createElement("details");
+  drawer.className = "cfg-advanced";
+  const sum = document.createElement("summary");
+  sum.textContent = "Advanced tuning";
+  drawer.appendChild(sum);
+  for (const [group, els] of Object.entries(advanced)) {
+    const h = document.createElement("h4");
+    h.textContent = group;
+    drawer.appendChild(h);
+    els.forEach((e) => drawer.appendChild(e));
+  }
+
+  const map = buildEnvMap(spec, answers);
+  const local = answers.deployment !== "server";
+  const tabs = local
+    ? [["Claude config", generateClaudeJson(map)], [".env", generateDotenv(map)]]
+    : [
+        ["docker run", generateDockerRun(map)],
+        ["compose", generateCompose(map)],
+        ["systemd", generateSystemd(map)],
+        [".env", generateDotenv(map)],
+      ];
+  const out = document.createElement("div");
+  out.className = "cfg-output";
+  for (const [name, text] of tabs) {
+    const block = document.createElement("div");
+    block.className = "cfg-tab";
+    const head = document.createElement("div");
+    head.className = "cfg-tab-head";
+    head.textContent = name;
+    const pre = document.createElement("pre");
+    pre.className = "cfg-pre";
+    pre.textContent = text;
+    const copy = document.createElement("button");
+    copy.type = "button";
+    copy.className = "cfg-copy";
+    copy.textContent = "Copy";
+    copy.addEventListener("click", () => {
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).catch(() => {});
+      } else {
+        // Fallback for non-secure contexts: select the block so Ctrl/Cmd-C works.
+        const range = document.createRange();
+        range.selectNodeContents(pre);
+        const sel = window.getSelection();
+        if (sel) {
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
+      }
+    });
+    head.appendChild(copy);
+    block.appendChild(head);
+    block.appendChild(pre);
+    out.appendChild(block);
+  }
+
+  const warnings = document.createElement("div");
+  warnings.className = "cfg-warnings";
+  for (const g of spec.guards) {
+    if (Object.entries(g.when).every(([k, vals]) => vals.includes(answers[k]))) {
+      const w = document.createElement("div");
+      w.className = `cfg-${g.level}`;
+      w.textContent = g.message;
+      warnings.appendChild(w);
+    }
+  }
+
+  ROOT.replaceChildren(core, drawer, warnings, out);
+  writeUrlState(spec);
+
+  // Restore focus + caret to the field the user was editing.
+  if (activeQid) {
+    const restored = ROOT.querySelector(
+      `.cfg-field[data-qid="${activeQid}"] input, .cfg-field[data-qid="${activeQid}"] select`,
+    );
+    if (restored) {
+      restored.focus();
+      if (selStart !== null && restored.tagName === "INPUT" && restored.type !== "number") {
+        try {
+          restored.setSelectionRange(selStart, selEnd);
+        } catch {
+          // input type does not support text selection
+        }
+      }
+    }
+  }
+}
+
+async function init() {
+  ROOT = document.getElementById(MOUNT_ID);
+  if (!ROOT) return;
+  const specUrl = ROOT.dataset.specUrl;
+  try {
+    const resp = await fetch(specUrl);
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
+    SPEC = await resp.json();
+  } catch (e) {
+    ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;
+    return;
+  }
+  readUrlState(SPEC);
+  for (const q of SPEC.questions) {
+    if (answers[q.id] === undefined && q.type === "select" && q.options?.length) {
+      answers[q.id] = q.options[0].value;
+    }
+  }
+  render();
+}
+
+if (document.readyState !== "loading") init();
+else document.addEventListener("DOMContentLoaded", init);

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -24,7 +24,11 @@ function writeUrlState(spec) {
     if (answers[q.id] !== undefined && answers[q.id] !== "") params.set(q.id, answers[q.id]);
   }
   const qs = params.toString();
-  history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+  try {
+    history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+  } catch {
+    // history.replaceState throws in sandboxed iframes — safe to ignore.
+  }
 }
 
 function field(q, secrets) {
@@ -175,13 +179,18 @@ function render() {
     }
   }
 
-  ROOT.replaceChildren(core, drawer, warnings, out);
+  if (Object.keys(advanced).length > 0) {
+    ROOT.replaceChildren(core, drawer, warnings, out);
+  } else {
+    ROOT.replaceChildren(core, warnings, out);
+  }
   writeUrlState(spec);
 
   // Restore focus + caret to the field the user was editing.
   if (activeQid) {
+    const escaped = CSS.escape(activeQid);
     const restored = ROOT.querySelector(
-      `.cfg-field[data-qid="${activeQid}"] input, .cfg-field[data-qid="${activeQid}"] select`,
+      `.cfg-field[data-qid="${escaped}"] input, .cfg-field[data-qid="${escaped}"] select`,
     );
     if (restored) {
       restored.focus();

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -219,8 +219,11 @@ async function init() {
   }
   readUrlState(SPEC);
   for (const q of SPEC.questions) {
-    if (answers[q.id] === undefined && q.type === "select" && q.options?.length) {
+    if (answers[q.id] !== undefined) continue;
+    if (q.type === "select" && q.options?.length) {
       answers[q.id] = q.options[0].value;
+    } else {
+      answers[q.id] = "";
     }
   }
   render();

--- a/docs/stylesheets/config-wizard.css
+++ b/docs/stylesheets/config-wizard.css
@@ -1,0 +1,19 @@
+#cfg-wizard { display: flex; flex-direction: column; gap: 1rem; }
+.cfg-core { display: grid; gap: 0.75rem; }
+.cfg-field { display: flex; flex-direction: column; gap: 0.25rem; }
+.cfg-label { font-weight: 600; }
+.cfg-help { color: var(--md-default-fg-color--light); }
+.cfg-field input, .cfg-field select {
+  padding: 0.4rem 0.5rem; border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 4px; background: var(--md-default-bg-color); color: var(--md-default-fg-color);
+}
+.cfg-secret input { border-color: var(--md-accent-fg-color); }
+.cfg-advanced { border: 1px solid var(--md-default-fg-color--lightest); border-radius: 6px; padding: 0.5rem 1rem; }
+.cfg-advanced h4 { margin: 0.75rem 0 0.25rem; }
+.cfg-output { display: grid; gap: 1rem; }
+.cfg-tab-head { display: flex; justify-content: space-between; align-items: center; font-weight: 600; }
+.cfg-copy { cursor: pointer; padding: 0.2rem 0.6rem; border-radius: 4px; border: 1px solid var(--md-default-fg-color--lighter); background: var(--md-default-bg-color); }
+.cfg-pre { background: var(--md-code-bg-color); padding: 0.75rem; border-radius: 6px; overflow-x: auto; white-space: pre; }
+.cfg-warn { color: #b26a00; }
+[data-md-color-scheme="slate"] .cfg-warn { color: #e0a83a; }
+.cfg-info { color: var(--md-default-fg-color--light); }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,13 @@ extra:
     provider: mike
     default: latest
 
+extra_javascript:
+  - path: javascripts/config-wizard/wizard.js
+    type: module
+
+extra_css:
+  - stylesheets/config-wizard.css
+
 plugins:
   - search
   - llmstxt:
@@ -61,6 +68,7 @@ plugins:
           - getting-started/installation.md: Installation from PyPI, uv, source, or Docker
           - getting-started/claude-desktop.md: Claude Desktop MCP configuration
           - getting-started/claude-code.md: Claude Code MCP configuration
+          - configuration-generator.md: Interactive configuration wizard
         Providers:
           - providers/index.md: Provider comparison and selection guide
           - providers/gemini.md: Gemini provider setup and capabilities
@@ -123,6 +131,7 @@ nav:
       - Installation: getting-started/installation.md
       - Claude Desktop: getting-started/claude-desktop.md
       - Claude Code: getting-started/claude-code.md
+      - Configuration Generator: configuration-generator.md
   - Providers:
       - Overview: providers/index.md
       - Gemini: providers/gemini.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,10 @@ docs = [
     "mkdocs-llmstxt>=0.5",
 ]
 
+browser = [
+    "pytest-playwright>=0.5",
+]
+
 [project.scripts]
 image-generation-mcp = "image_generation_mcp.cli:main"
 
@@ -122,6 +126,9 @@ indent-style = "space"
 testpaths = ["tests"]
 addopts = ["--strict-markers", "-ra"]
 asyncio_mode = "auto"
+markers = [
+    "browser: end-to-end test that drives a headless browser (requires the 'browser' dependency group + 'playwright install chromium')",
+]
 
 [tool.coverage.run]
 source = ["src/image_generation_mcp"]
@@ -153,6 +160,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["google", "google.genai", "google.genai.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["playwright", "playwright.*"]
 ignore_missing_imports = true
 
 # Tests use FastMCP private surfaces (e.g. ``tool.fn``) and pytest fixtures

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -46,7 +46,7 @@ class AggregatorInputs:
     """
 
 
-def _read_job_json(path: Path | None) -> dict | None:
+def _read_job_json(path: Path | None) -> object | None:
     """Read and JSON-parse an agent output file.
 
     Absent paths (None or not a regular file) return None silently — expected

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -46,13 +46,32 @@ class AggregatorInputs:
     """
 
 
-def _read_job_json(path: Path | None) -> object:
-    """Read and JSON-parse an agent output file. Returns None if missing or unreadable."""
-    if path is None or not path.exists():
+def _read_job_json(path: Path | None) -> dict | None:
+    """Read and JSON-parse an agent output file.
+
+    Absent paths (None or not a regular file) return None silently — expected
+    when an agent was gated off. Parse, encoding, or I/O failures emit a
+    ::warning:: annotation so operators have a breadcrumb without aborting the
+    aggregator run. Note: UnicodeDecodeError requires its own except clause
+    because it is a ValueError subclass, not an OSError subclass.
+    """
+    if path is None or not path.is_file():
         return None
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError as e:
+        print(
+            f"::warning::agent output at {path} is not valid JSON: {e}", file=sys.stderr
+        )
+        return None
+    except UnicodeDecodeError as e:
+        print(
+            f"::warning::agent output at {path} is not valid UTF-8: {e}",
+            file=sys.stderr,
+        )
+        return None
+    except OSError as e:
+        print(f"::warning::could not read agent output at {path}: {e}", file=sys.stderr)
         return None
 
 
@@ -531,10 +550,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    if not args.existing_body.is_file():
+        print(
+            f"::error::--existing-body not found or not a regular file: {args.existing_body}",
+            file=sys.stderr,
+        )
+        return 1
     try:
         existing_body = args.existing_body.read_text(encoding="utf-8")
     except OSError as exc:
-        print(f"ERROR: cannot read existing body: {exc}", file=sys.stderr)
+        print(f"::error::cannot read existing body: {exc}", file=sys.stderr)
         return 1
     inputs = AggregatorInputs(
         existing_body=existing_body,

--- a/scripts/copier_update_prompts/job_a.md
+++ b/scripts/copier_update_prompts/job_a.md
@@ -69,7 +69,12 @@ git add <files-you-modified>
 # the PR branch under the auto-resolve commit.
 git diff --cached --name-only
 
-git commit -m "auto-resolve N trivial conflicts (claude-code)" --author="claude-code <claude-code@anthropic.com>"
+# Reset git identity so both author and committer are github-actions[bot].
+# claude-code-action overwrites user.name/email to claude[bot]; --author alone
+# would fix the author field but leave the committer as claude[bot].
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git commit -m "auto-resolve N trivial conflicts (claude-code)"
 ```
 
 Capture the commit SHA via `git rev-parse HEAD`.
@@ -113,7 +118,8 @@ deviation from the shapes above will cause the section to render as
 
 - Tool access: file read/write on the working tree, file read on `/tmp/template`,
   `git -C /tmp/template <subcommand>`, `git status`, `git diff`, `git add <path>`,
-  `git commit -m '<msg>'`. NO `git push`, NO branch operations, NO network calls.
+  `git config user.name`, `git config user.email`, `git commit -m '<msg>'`,
+  `git rev-parse`. NO `git push`, NO branch operations, NO network calls.
 - Do not modify files outside the conflict files listed above.
 - Sentinel-block awareness: lines inside `<!-- DOMAIN-*-START -->` ... `<!-- DOMAIN-*-END -->`,
   `<!-- PROJECT-*-START -->` ... `<!-- PROJECT-*-END -->`, `# CONFIG-*-START` ...

--- a/tests/test_config_wizard_smoke.py
+++ b/tests/test_config_wizard_smoke.py
@@ -1,0 +1,81 @@
+"""Browser smoke test for the built config-wizard page.
+
+Marked ``browser``; requires the ``browser`` dependency group and
+``playwright install chromium``. Runs against the built ``site/`` directory, so
+``mkdocs build`` must have run first.
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import socketserver
+import threading
+import typing
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+
+if typing.TYPE_CHECKING:
+    from playwright.sync_api import Browser, Page
+
+SITE = Path(__file__).resolve().parent.parent / "site"
+
+pytestmark = pytest.mark.browser
+
+
+@pytest.fixture(scope="module")
+def site_url() -> typing.Iterator[str]:
+    if not (SITE / "configuration-generator" / "index.html").exists():
+        pytest.skip("site/ not built -- run `uv run mkdocs build` first")
+    handler = functools.partial(
+        http.server.SimpleHTTPRequestHandler, directory=str(SITE)
+    )
+    with socketserver.TCPServer(("127.0.0.1", 0), handler) as httpd:
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield f"http://127.0.0.1:{port}"
+        finally:
+            httpd.shutdown()
+
+
+@pytest.fixture(scope="module")
+def browser(site_url: str) -> typing.Iterator[Browser]:  # noqa: ARG001 — depended on only for fixture ordering
+    # Depend on site_url so its "site not built" skip runs BEFORE we try to
+    # launch Chromium. In the main CI test lane (no built site, no installed
+    # browser) this makes the smoke tests skip cleanly instead of erroring.
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        b = p.chromium.launch()
+        yield b
+        b.close()
+
+
+@pytest.fixture
+def page(browser: Browser, site_url: str) -> typing.Iterator[Page]:
+    # Fresh page per test: the wizard keeps answer state in a module-level JS
+    # object, so each test must start from a clean load to stay order-independent.
+    pg = browser.new_page()
+    pg.goto(f"{site_url}/configuration-generator/")
+    pg.wait_for_selector("#cfg-wizard select")
+    yield pg
+    pg.close()
+
+
+def test_local_path_emits_claude_json(page: Page) -> None:
+    page.select_option('[data-qid="deployment"] select', "local")
+    text = page.inner_text(".cfg-output")
+    assert "image-generation-mcp" in text
+
+
+def test_server_docker_path_emits_image(page: Page) -> None:
+    page.select_option('[data-qid="deployment"] select', "server")
+    page.fill('[data-qid="bearer_token"] input', "secret-token")
+    text = page.inner_text("#cfg-wizard")
+    assert "ghcr.io/pvliesdonk/image-generation-mcp:latest" in text
+    assert "IMAGE_GENERATION_MCP_BEARER_TOKEN" in text

--- a/uv.lock
+++ b/uv.lock
@@ -938,6 +938,83 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/8b/befc3cb36965f397d87e86fb3b00e3ec0dc67c1ecb0986d7f54ee528f018/greenlet-3.5.2.tar.gz", hash = "sha256:c1b906220d83c140361cdd12eef970fb5881a168b98ee58a43786426173da14c", size = 199243, upload-time = "2026-06-17T20:19:01.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/68/371ee6dad168be3386c46030bedaa8e3e7e3cf3d203621d4529e78ff36ef/greenlet-3.5.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:d7792398872f89466c6671d5d193537eff163ecf7fac78d82e6ddc25017fb4f5", size = 286925, upload-time = "2026-06-17T17:33:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/26/16/ed5706c26b4d26f3fabceb79abca992654eac8b0fa435def2ac6dbd92122/greenlet-3.5.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:711028c953cd6ce5dc01bbb5a1747e3ad6bd8b2f7ded73778bb936e8dab9e3b6", size = 606036, upload-time = "2026-06-17T18:07:18.538Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/f9c77093af9f5f96615922b7e3fe3690a9faff02adb89f1d74e21578b147/greenlet-3.5.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5eba55076d79e8a5176e6925295cfb901ebc95dae493342ede22230f75d8bee2", size = 617821, upload-time = "2026-06-17T18:29:41.317Z" },
+    { url = "https://files.pythonhosted.org/packages/27/f5/a963a939039aa5acafc2f9535f6cc8958ad30afe1478e2e37ab5098af74d/greenlet-3.5.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1724499fc08388208408681c53c5062e9803c334e5a0bdaeb616228ba882aac8", size = 625675, upload-time = "2026-06-17T18:39:25.767Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d4/642833e778c17d32b5cabb793e14ce7364c55952462fc506fecdee55d485/greenlet-3.5.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1c1e5ad80f1f38ea479b83b39dccb20874cfe9ad5e52f87225fa294ba4d39a1", size = 616877, upload-time = "2026-06-17T17:39:26.564Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c8/995a898ebbf44e3da0b7ea6fbc1631518c185fb83467a5d6cf408d6d3ced/greenlet-3.5.2-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:e976f9f6941f57d87a194c91868622c8b22a142a741d2fde31655c319133ade6", size = 420572, upload-time = "2026-06-17T18:41:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/7120f83e78b8be3cf7acbe2306b3b7bd2cbf99f5ad12e85e2f05d7b31961/greenlet-3.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9e194b996aa1b89d933cfe136e5eb39b22a8b72ba59d376ef39a55bca4dbf47f", size = 1577274, upload-time = "2026-06-17T18:22:10.692Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/05a0074ee485dd51c320fd706fd7ed48006b9cad3443092d7df1a655f0d2/greenlet-3.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4e554809538bd4867f24421b43abde170f9c9b8192149b30df5e164bcac6124f", size = 1643566, upload-time = "2026-06-17T17:40:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/35/fe/9fe2060bdeece682e38d381184ae66045b48ed183c107ab3f88b9886a630/greenlet-3.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:e063263ce9047878480d7e536012fc8b7c8e1922989eb5f03b9ab998a2ee7b7e", size = 238643, upload-time = "2026-06-17T17:37:03.039Z" },
+    { url = "https://files.pythonhosted.org/packages/41/13/a9db72f5b6b700977ebd371d6a1f2984a08838357de924fcd5571607b1bf/greenlet-3.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:a3f76a94e2d6e1fee8f302265679d8cc47d71a203936dd03c6e2ace0f9cfd46d", size = 237135, upload-time = "2026-06-17T17:34:34.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/7a/6bc2a7835731387ed303b9390ce68a116ab053df05450a59181239200454/greenlet-3.5.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:76dae33e97b52743a19210931ee3e78a88fe1438bc2fc4ee5e7512d289bfad4f", size = 288351, upload-time = "2026-06-17T17:36:17.019Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1b/bd98062fcef6d0e9d0873ab6f2d029772e6ea342972ae43275bd6177900f/greenlet-3.5.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30252d191d6959df1d040b559a38fc017139606c5ecc2ad00416557c0355d742", size = 604273, upload-time = "2026-06-17T18:07:20.296Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e6/fe392c522bf45d976abe7db2793f6ef4e87b053ebb869deeaae46aeb54da/greenlet-3.5.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1adc23c50f22b0f5979521909a8360ab4a3d3bef8b641ce633a04cf1b1c967ea", size = 616536, upload-time = "2026-06-17T18:29:43.205Z" },
+    { url = "https://files.pythonhosted.org/packages/42/df/cdb1f75f07214f13110e7e3879531f11c26083bd480a56a9474c430ec44c/greenlet-3.5.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87359c23eb4e8f1b16da68faad29bf5aeb80e3628d7d8e4aa2e41c36879ddedd", size = 621843, upload-time = "2026-06-17T18:39:27.507Z" },
+    { url = "https://files.pythonhosted.org/packages/68/4a/399ff81fa93a19d6a9df394cef0355f082dbc19ad41aba9593cd0ad444e2/greenlet-3.5.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f052fff492c52fdfa99bd3b3c1389a53de37dae76a0562741417f0d018f02b3", size = 613749, upload-time = "2026-06-17T17:39:28.148Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/25/36a3628a7edcfeefddd3101dc88039c79721c5f8d688db7ebed1cbaaa789/greenlet-3.5.2-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:f4d67c1684db3f9782c37ee4bade3f86f5a23a8fcf3f8359224106018ca40728", size = 424889, upload-time = "2026-06-17T18:41:19.469Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/75/f519593f12ad43d08e28c03a95cfe2eeae011707dbc9dab0c4a263ce90f9/greenlet-3.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:120b77c2a18ebf629c3a7886f68c6d01e065654844ad468f15bb93ace66f2094", size = 1573725, upload-time = "2026-06-17T18:22:12.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/bc/bc1ea4b0754c6c51bbf9d94677b0b1f7fbda8cbb404e44a896854fc0a940/greenlet-3.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a850f6224088ef7dcc70f1a545cb6b3d119c35d6dca63b925b9f35da0635cdad", size = 1638132, upload-time = "2026-06-17T17:40:06.971Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c0/f0f5a34247df60de285f75f22e57f14027f4b3c43820981854b5b643ca6d/greenlet-3.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:89da99ee8345b458ea2f16831dad31c88ddcdec454b48704d569a0b8fb28f146", size = 239393, upload-time = "2026-06-17T17:33:47.09Z" },
+    { url = "https://files.pythonhosted.org/packages/09/17/a8544e165445f30aea67a8d9cf2786d2bb0eb1b0e0d224b4d9bd80e2d587/greenlet-3.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:ca92411942154023c65851e6077d8ca0d00f19de5fa80bb2c6f196ff6c920ba9", size = 237723, upload-time = "2026-06-17T17:36:47.776Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3c/bb37b9d40d65b0741a8b040ca5c307034d0a9822994dff5f825c88dd7a6b/greenlet-3.5.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:0629377725977252159de1ebd3c6e49c170a63856e585446797bb3d66d4d9c34", size = 287178, upload-time = "2026-06-17T17:35:25.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a6/0c5902393f492f8ceb19d0b5cf139284e3a11b333a049739643b1036b6f8/greenlet-3.5.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2ddf9eddc617681108dd071b3feabf3f4a4cd64846254aec4d4ceda098b639a", size = 606900, upload-time = "2026-06-17T18:07:21.692Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7c/42899c31d4b87148ae4e3f87f63e13398824be6241f4dde42ded95768a34/greenlet-3.5.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f41feb9f2b59e2e61ac9bea4e344ddd9396bf3cacb2583f73a3595ed7df6f8e7", size = 619265, upload-time = "2026-06-17T18:29:44.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/28f991affb413b232b1e7d768db24c37b3f4d5daecc3f19b455d40bd2dea/greenlet-3.5.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9dc23f0e5ad76415457212a4b947d22ebe4dc80baf02adf7dd5647a90f38bb4e", size = 625044, upload-time = "2026-06-17T18:39:29.046Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/52/4ff8c98d3cfe62b4515f8584ae14510a58f35c549cc5292b78d9b7a40b70/greenlet-3.5.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09201fa698768db245920b00fdc86ee3e73540f01ca6db162be9632642e1a473", size = 616187, upload-time = "2026-06-17T17:39:29.473Z" },
+    { url = "https://files.pythonhosted.org/packages/29/05/0cc9ec660e7acff85f93b0a048b6654371c822c884add44c02a465cf70e0/greenlet-3.5.2-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:423167363c510a75b649f5cd58d873c29498ea03598b9e4b1c3b73e0f899f3d5", size = 427322, upload-time = "2026-06-17T18:41:20.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a6/269c8bf9aefc13361ce1088f0e392b154cb21005de7862e42b5d782b81fd/greenlet-3.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a1759fa4f14c398508cf20dc8037de55cc23ae8bd14c185c2718257837195ca5", size = 1573778, upload-time = "2026-06-17T18:22:13.497Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/9b/391d015cbc6323e81b14c02cf825fdca7e0049c9bb489bf4ac72883118ba/greenlet-3.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9318cdeb9abdbfdd8bc8464ee4a06dffde2c7846e1def138365a6240ab2c9a5", size = 1638092, upload-time = "2026-06-17T17:40:08.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/53/5b4df711f4356c62e85d9f819d87966d526d1cfb32bae49a8f7d6fc36ea4/greenlet-3.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:2c3b3311af72b3d3b03cc0f1ffd11f072e834be5d0444105cf715fc44434e39c", size = 239352, upload-time = "2026-06-17T17:38:51.593Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/b6/18efc3a329ec035c3f344b8f2b60356451950ddf9b7b64ff00023778a1dd/greenlet-3.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:f9bbd6216c45a563c2a61e478e038b439d9f248bde44f775ea37d339da643af4", size = 237635, upload-time = "2026-06-17T17:35:36.632Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/89/aaafc8e14de4ac882e02ccb963225329b0e8578aba4365e71eb678e45722/greenlet-3.5.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:1c31219badba285858ba8ed117f403dea7fafee6bade9a1991875aae530c3ceb", size = 287676, upload-time = "2026-06-17T17:33:31.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/2308249206c12ac70de7b9a00970f84f07d10b3cd60e05d2fbcaa84124e8/greenlet-3.5.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f96ed6f4adc1066954ae95f45717657cb67468ef3b89e9a3632e14a625a8f39", size = 653552, upload-time = "2026-06-17T18:07:23.493Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/24/47730d1f8f1336b9b089237521ed7a26eee997065dcb4cab81cdca333abc/greenlet-3.5.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5795e883e915333c0d5648faaa691857fbc7180136883edc377f50f0d509c2a8", size = 665756, upload-time = "2026-06-17T18:29:46.616Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/2664d290cbd1fef9eb3f69b5d3bc5aa91b6fa907519298ca6af93a90c6cb/greenlet-3.5.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6e9e49d732ee92a189bb7035e293029244aeba648297a9b856dc733d17ca7f0d", size = 669989, upload-time = "2026-06-17T18:39:30.79Z" },
+    { url = "https://files.pythonhosted.org/packages/99/69/d6c99db15dc0b5e892ac3cc7b942c8b21f4a9cc3bd9ea0bc3b0f339ffbd4/greenlet-3.5.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26aed8d9503ca78889141a9739d71b383efea5f472a7c522b5410f7eb2a1b163", size = 663228, upload-time = "2026-06-17T17:39:31.073Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d4/fcb53fa9847d7fbd4723fbed9469c3869b9e3544c4e001d9d5aa2f66162d/greenlet-3.5.2-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:537c5c4f30395020bb9f48f53146070e3b997c3c75da14011ab732aaa19ce3ef", size = 472888, upload-time = "2026-06-17T18:41:22.511Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/88/9e603f448e2bc107c883e95817b980fb9b45ba6aea0299b2e9978124bea2/greenlet-3.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:dbebc038fcdda8f8f21cce985fd04e34e0f42007e7fc7ab7ad285caf77974b95", size = 1620723, upload-time = "2026-06-17T18:22:14.817Z" },
+    { url = "https://files.pythonhosted.org/packages/11/91/26da17e3777858c16fdb8d020a4c68f3a03cb92f238de8f5351d5d5186e9/greenlet-3.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a207023f1cf8695fd82580b8099c09c5809be18bc2282362cdfb965dd884a317", size = 1684227, upload-time = "2026-06-17T17:40:09.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/44/b3a11f7aa34cb38f1b7f3df8bcd9fcd09bac9d342c2a2c9b8686c804bcd2/greenlet-3.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:c674a1dd4fe41f6a93febe7ab366ceabf15080ea31a9307811c56dac5f435f73", size = 240257, upload-time = "2026-06-17T17:35:23.359Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e3/3b62145fe917311732041a258adb218248add00542e3131c48bd047fbed5/greenlet-3.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3c417cd6c593bbbef6f7aa31a79f37d3db7d18832fc56b694a2150130bde784e", size = 239038, upload-time = "2026-06-17T17:37:56.792Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ac/d3bad483e9f6cd1848604fdffa32cac25846dd6dfcec0e6f81c790185518/greenlet-3.5.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a96457a30384de52d9c5d2fd33abf6c1daae3db392cd556738f408b1a79a1cf0", size = 295668, upload-time = "2026-06-17T17:36:02.293Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e9/3a7e557b895fd0469b00cd0b2bd498ba950e8bfdf6d7adeecf2c5e4130a6/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4af5d4961818ab651d09c1448a03b1ba2a1726a076266ebb62330bab9f3238c", size = 652820, upload-time = "2026-06-17T18:07:24.95Z" },
+    { url = "https://files.pythonhosted.org/packages/78/67/6225d5c5e4afc04be0fd161eec82e4b72017e8a100d222f25d7b42b0140d/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a1789a6244ea1ba61fd4386c9a6a31873e9b0234762103364be98ef87dcb19f3", size = 658697, upload-time = "2026-06-17T18:29:48.365Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ad/9b3058f999b81750a9c6d9ec424f509462d232b58002086fe2ba63b66407/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2ee6288f1933d698b4f098127ed17bda2910a75d2807915bd16294a972055d6c", size = 658945, upload-time = "2026-06-17T18:39:32.509Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/99/6324b8ef916dcaddccb340b304c992ca3f947614ce0f2685d438187300b8/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3be00501fb4a8c37f6b4b3c4773808ceb26ea65c7ea64fd5735d0f330b3786de", size = 656436, upload-time = "2026-06-17T17:39:32.509Z" },
+    { url = "https://files.pythonhosted.org/packages/92/75/1b6ecd8c027b69ab1b6798a84094df79aab5e69ac7e249c78b9d361dd1fa/greenlet-3.5.2-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:b4cad42662c796334c2d24607c411e3ed82481c1fb4e1e8ec3a5a8416060092e", size = 490529, upload-time = "2026-06-17T18:41:23.954Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ee/f5bf9daac27c5e1b011965f64b5630a32b415daf7381b312943629e12c2a/greenlet-3.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1d554cd96841a68d464d75a3736f8e87408a7b02b1930a75fa32feb408ad62f8", size = 1617193, upload-time = "2026-06-17T18:22:16.252Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/b05d5b12715bda92ce27c118d64971d21e9b8f3563ed959a7d271e2d4223/greenlet-3.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3dff6cd3aac35f6cd3fc23460105acf576f5faf6c378de0bc088bf37c913864a", size = 1677512, upload-time = "2026-06-17T17:40:10.771Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/1b8f1314b868041b327dc1051603e8142b826480cb0ecb8a7b7632aee9c4/greenlet-3.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:36cfea2aa075d544617176b2e84450480f0797070ad8799a8c41ada2fe449d32", size = 243145, upload-time = "2026-06-17T17:34:37.502Z" },
+    { url = "https://files.pythonhosted.org/packages/36/07/1b5311775e04c718a118c504d7a3a312430e2a1bd1347226aff4774e4549/greenlet-3.5.2-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:a0314aa832c94633355dc6f3ee54f195159533355a323f26926fc63b98b2ccbb", size = 288315, upload-time = "2026-06-17T17:34:34.04Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/cc/6abcd2a486b58b9f77b7a93b690d59cb2c11a5906ed2ad4c63c7b9c1113d/greenlet-3.5.2-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24c59cb7db9d5c694cb8fd0c76eef8e456b2123afdfa7e4b8f2a67a0860d7682", size = 659130, upload-time = "2026-06-17T18:07:26.354Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/12/f4aaad6d3d383233f700ab322568a4f29f2c701a4861d85f4811d99689b2/greenlet-3.5.2-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7bb811753703739ad318112f16eccfaabdac050037b6d092debaa8b23566b4ce", size = 669724, upload-time = "2026-06-17T18:29:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e0/4ce3a046b51e53934eae93d7f9c13975a97285741e9e1fcadf8751314c37/greenlet-3.5.2-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2debcd0ef9455b7d4879589903efc8e497d4b8fb8c0ae772309e44d1ca5e957f", size = 673494, upload-time = "2026-06-17T18:39:34.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2a/a089811fc31c6bf8742f40a4e73470d6d401cef18e4314eb20dc399b377c/greenlet-3.5.2-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d78b5c1c178dad90447f1b8452262709d3eef4c98f825569e74c9d0b2260ac9", size = 668089, upload-time = "2026-06-17T17:39:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e0/9c18721e63445dce02ee67e4c81c0f281626604ff55ae6f7b7f4354d7129/greenlet-3.5.2-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:9558cae989faeab6fbb425cd98a0cfa4190a47fba6443973fbee0a1eb0b0b6c3", size = 479721, upload-time = "2026-06-17T18:41:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1c/2f47c7d5fcfa98a62b705bf9a0505d86f4563c0d81cab1f7159ff1e743b7/greenlet-3.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:0977af2df83136f81c1f76e76d4e2fe7d0dc56ea9c101a86af26a95190b9ca32", size = 1625684, upload-time = "2026-06-17T18:22:17.664Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/bf/661dd24624f70b7b32972d7693d0344ecde10278f647d7b828baf739899c/greenlet-3.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f9ed777c6891d8253e54468576f55e27f8fc1a662a664f946a191003574c0a74", size = 1688043, upload-time = "2026-06-17T17:40:12.403Z" },
+    { url = "https://files.pythonhosted.org/packages/60/49/d9bde1d15a21296b3b521fe083eb8aabd54ac05d15de9832918f3d639543/greenlet-3.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:c0ea4eb3de23f0bac1d75205e10ccfa9b418b17b01a2d7bf19e3b69dda08900a", size = 240531, upload-time = "2026-06-17T17:35:47.448Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/4d/86d7768bd53e9907de0333df215c2018cd01a593b3715cbd79aa82dd94b7/greenlet-3.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:7a7bfc200be40d04961d7e80e8337d726c0c1a50777e588123c3ed8ba731dcb9", size = 239579, upload-time = "2026-06-17T17:39:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/92/15/907be5e8900901039bae752fa9a31c03a3c1e064833f35a4e49449184581/greenlet-3.5.2-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:98a52d6a50d4deaba304331d83ee3e10ebbdc1517fcca40b2715d1de4534065c", size = 296697, upload-time = "2026-06-17T17:37:15.887Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/08c57be575c3d6a3c023bbf22144a1c7dc6ed4d134527bb36ded4dbf04a8/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1587ff8b58fdf806993ed1490a06ac19c22d47b219c68b30954380029045d8d4", size = 656710, upload-time = "2026-06-17T18:07:28.046Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d0/749f917bdc9fc90fceea4aa65fbf6556e617a50714d1496bdc8ad190bb36/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:feb721811d2754bfd16b48de151dd6b1f222c048e625151f2ca44cfdfd69f59c", size = 662629, upload-time = "2026-06-17T18:29:51.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/87/10776cd88df54d0f563e9e21e98363f2d6af94bedc553b1da0972fa87f80/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a9476cbead736dc48ce89e3cd97acff95ecc48cbf21273603a438f9870c4a014", size = 663191, upload-time = "2026-06-17T18:39:35.639Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a5/68cefae3a07f6d0093a490cf28ab604f14578f3e60205a2a2b2d5cd70af2/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7fe6062b1f35534e1e8fb28dfed406cf4eeff3e0bca3a0d9f8ff69f20a4abb00", size = 660147, upload-time = "2026-06-17T17:39:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/02/aa/26ddf92826a99d87bfb8fdb8f3a262a6f16495a5d8e579737baa92fb4543/greenlet-3.5.2-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:5930d3946ecae99fa7fc0e3f3ae515426ad85058ebd9bfc6c00cca8016e6206b", size = 498199, upload-time = "2026-06-17T18:41:27.464Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6b/b9156d8397e4750220f54c7c5c34650f1e740a8d2f66eab9cfd1b7b53b69/greenlet-3.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b4ac902af825cbac8e9b2fccab8122236fd2ba6c8b71a080116d2c2ec72671b1", size = 1621675, upload-time = "2026-06-17T18:22:18.873Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e3/d3250f4fa01c211a93d04e34fded63187e648dbec17b9b1a14d388040593/greenlet-3.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:6f1e473c06ae8be00c9034c2bb10fa277b08a93287e3111c395b839f01d27e1f", size = 1680577, upload-time = "2026-06-17T17:40:14.055Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eaee8bda4419770d7096b5a009ebff0ab20a2a28cdd83c4b591bfdf36fa9/greenlet-3.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:3c2315045f9983e2e50d7e89d95405c21bddb8745f2da4487bc080ab3525f904", size = 243482, upload-time = "2026-06-17T17:37:34.741Z" },
+    { url = "https://files.pythonhosted.org/packages/37/45/f794a81c91e9942c61f9110bd1f9a38a0ea565eab57f8b08cd53d3131e48/greenlet-3.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:db548d5ab6c2a8ead82c013f875090d79b5d7d2b67fc513934ce6cf66492ad7f", size = 242062, upload-time = "2026-06-17T17:35:39.814Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1031,6 +1108,9 @@ openai = [
 ]
 
 [package.dev-dependencies]
+browser = [
+    { name = "pytest-playwright" },
+]
 dev = [
     { name = "diff-cover" },
     { name = "image-generation-mcp", extra = ["all"] },
@@ -1064,6 +1144,7 @@ requires-dist = [
 provides-extras = ["mcp", "openai", "google-genai", "all", "debug"]
 
 [package.metadata.requires-dev]
+browser = [{ name = "pytest-playwright", specifier = ">=0.5" }]
 dev = [
     { name = "diff-cover", specifier = ">=9.0" },
     { name = "image-generation-mcp", extras = ["all"] },
@@ -2114,6 +2195,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2362,6 +2462,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2445,6 +2557,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2456,6 +2581,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/ef/172eb8e23c80491fc72f1401c72f9305663873649351306a38b18406b0c9/pytest_playwright-0.8.0.tar.gz", hash = "sha256:7888d4a2443160c82e0c506c437076679f86b36d1910427250d90fbf1843a981", size = 17132, upload-time = "2026-05-18T10:16:15.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl", hash = "sha256:856aae6efd4bc055f2ef229c647768760bcaad5cd3a5983c314ac260a974a933", size = 17143, upload-time = "2026-05-18T10:16:18.226Z" },
 ]
 
 [[package]]
@@ -2495,6 +2635,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -2915,6 +3067,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1003,7 +1003,7 @@ wheels = [
 
 [[package]]
 name = "image-generation-mcp"
-version = "1.9.0"
+version = "1.10.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary

- Ships the browser-based **configuration wizard** from template v2.2.0: users select deployment mode and fill in env vars; the wizard outputs a ready-to-use Claude JSON / Docker / Compose / systemd / .env config without anything leaving the browser.
- Populated `wizard-spec.json` with all domain env vars (OpenAI, Google/Gemini, SD WebUI, default provider, read-only mode, scratch dir, logging knobs).
- Added `IMAGE_GENERATION_MCP_SCRATCH_DIR → /data/state/images` Docker container-path override in `generators.js`.
- Absorbed template improvements to `ci.yml`, `release.yml`, `docs.yml`, `copier-update.yml`, aggregator error handling (`::error::` annotations + `is_file()` guards), and CLAUDE.md logging scope docs.
- Added `playwright` mypy `ignore_missing_imports` override so browser smoke tests don't break the typecheck gate in environments without Playwright installed.
- Added `.claude/`, `.mcp.json`, `.repowise/` to `.gitignore` (locally-required tooling, not project artefacts).

Closes #245

## Test plan

- [ ] `uv run pytest -x -q` — 881 tests pass
- [ ] `uv run ruff check --fix . && uv run ruff format .` — clean
- [ ] `uv run mypy src/ tests/` — no errors
- [ ] Docs CI builds without broken links (`docs/configuration-generator.md` added to `nav:` and `llmstxt` sections)
- [ ] Browser smoke tests (`pytest -m browser`) require `mkdocs build` + `playwright install chromium` — skip in standard CI, validated locally when browser deps are available

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._