### PR TITLE
fix(wizard): .cfg-warn → .cfg-warning CSS class; drop stale CVE suppression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,11 +239,7 @@ jobs:
       - name: Run pip-audit
         run: |
           uvx pip-audit --strict --progress-spinner off \
-            --ignore-vuln CVE-2026-42561 \
             -r ${{ runner.temp }}/requirements.txt
-          # CVE-2026-42561: python-multipart <0.0.27, pulled in transitively by
-          # fastmcp/starlette. Ignored until the upstream pin chain propagates
-          # the fix to 0.0.27. Remove once `uv lock` resolves >=0.0.27.
 
   secrets:
     name: Secret Detection

--- a/docs/stylesheets/config-wizard.css
+++ b/docs/stylesheets/config-wizard.css
@@ -14,6 +14,6 @@
 .cfg-tab-head { display: flex; justify-content: space-between; align-items: center; font-weight: 600; }
 .cfg-copy { cursor: pointer; padding: 0.2rem 0.6rem; border-radius: 4px; border: 1px solid var(--md-default-fg-color--lighter); background: var(--md-default-bg-color); }
 .cfg-pre { background: var(--md-code-bg-color); padding: 0.75rem; border-radius: 6px; overflow-x: auto; white-space: pre; }
-.cfg-warn { color: #b26a00; }
-[data-md-color-scheme="slate"] .cfg-warn { color: #e0a83a; }
+.cfg-warning { color: #b26a00; }
+[data-md-color-scheme="slate"] .cfg-warning { color: #e0a83a; }
 .cfg-info { color: var(--md-default-fg-color--light); }


### PR DESCRIPTION
## Summary

- **CSS class fix**: `config-wizard.css` had `.cfg-warn` but `wizard.js` applies `.cfg-warning` (via `` `cfg-${g.level}` `` with `level: "warning"`). The no-provider guard message was rendering unstyled — the orange emphasis never fired.
- **CVE suppression removed**: `--ignore-vuln CVE-2026-42561` in `ci.yml` guarded against python-multipart <0.0.27, but `uv.lock` already pins it at `0.0.32`. Suppression condition met; flag removed.

These were in commit `d65ada6` on the previous branch but missed the squash-merge of #246 (merged at `8b02231`).

Closes #247

## Test plan

- [ ] CI passes (no Python changes — patch coverage gate will skip)
- [ ] Dependency Audit passes without `--ignore-vuln` flag
- [ ] `grep "cfg-warn" docs/stylesheets/config-wizard.css` returns only `.cfg-warning` (no bare `.cfg-warn`)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._