### PR TITLE
chore(template): apply copier template v2.3.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.2.0
+_commit: v2.2.1
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: MCP server for AI image generation via OpenAI, Google GenAI, or

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.2.1
+_commit: v2.3.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: MCP server for AI image generation via OpenAI, Google GenAI, or

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -1,15 +1,16 @@
-// Pure config-output generators. No DOM, no spec knowledge beyond the emit map.
+// Pure config-output generators. No DOM. All per-project data comes from
+// spec.meta; Docker path behaviour comes from per-question dockerVolume /
+// dockerPath. This file is template-owned and identical across all consumers.
 
-const IMAGE = "ghcr.io/pvliesdonk/image-generation-mcp:latest";
+const FASTMCP_HOME = "/data/state/fastmcp";
+// The named state volume, mounted in every Docker/Compose artifact.
+const STATE_VOLUME = "state-data:/data/state";
 
-// Vars whose value is fixed to a container path in Docker/Compose output.
-const CONTAINER_PATHS = {
-  // PROJECT-WIZARD-CONTAINER-PATHS-START — add container paths below; kept across copier update
-  IMAGE_GENERATION_MCP_SCRATCH_DIR: "/data/state/images",
-  // PROJECT-WIZARD-CONTAINER-PATHS-END
+const secretPlaceholder = (key, envPrefix) => {
+  const prefix = `${envPrefix}_`;
+  const short = key.startsWith(prefix) ? key.slice(prefix.length) : key;
+  return `<YOUR_${short}>`;
 };
-
-const SECRET_PLACEHOLDER = (key) => `<YOUR_${key.replace(/^IMAGE_GENERATION_MCP_/, "")}>`;
 
 // Single-quote a value for a POSIX shell `-e KEY=value` argument, but only when
 // it contains characters outside the shell-safe set (keeps clean output tidy).
@@ -18,11 +19,22 @@ const shellQuote = (v) => {
   return /^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${s.replace(/'/g, "'\\''")}'`;
 };
 
-// Quote a YAML scalar only when it contains characters that would otherwise
-// break parsing (or has surrounding whitespace, or is empty).
+// Bare tokens that YAML 1.1 parsers (used by Docker Compose) coerce to
+// bool/null/number. Env values are always strings, so these must be quoted to
+// stay strings — `KEY: true` would otherwise load as a boolean, `KEY: 8080` as
+// an int. Case-insensitive; covers bool, null, decimal/hex/octal ints, floats
+// (incl. exponent and ±.inf/.nan).
+const YAML_TYPED =
+  /^(?:y|n|yes|no|on|off|true|false|null|~|[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?|0x[0-9a-fA-F]+|0o[0-7]+|[-+]?\.(?:inf|nan))$/i;
+
+// Quote a YAML scalar when it contains characters that would otherwise break
+// parsing (or has surrounding whitespace, or is empty), or when it is a bare
+// token a YAML 1.1 parser would type-coerce.
 const yamlScalar = (v) => {
   const s = String(v);
-  return /[\n:#[\]{}&*?|<>=!%@,`"']|^\s|\s$|^$/.test(s) ? JSON.stringify(s) : s;
+  return YAML_TYPED.test(s) || /[\n:#[\]{}&*?|<>=!%@,`"']|^\s|\s$|^$/.test(s)
+    ? JSON.stringify(s)
+    : s;
 };
 
 // A systemd `Environment=` line. systemd does NOT expand `$` in Environment=
@@ -42,7 +54,8 @@ const systemdLine = (k, v) => {
 // dropped; a visible secret left empty becomes a placeholder so the artifact is
 // still complete and signals "replace me".
 export function buildEnvMap(spec, answers) {
-  const secrets = new Set(spec.secretKeys);
+  const secrets = new Set(spec.secretKeys ?? []);
+  const envPrefix = spec.meta.envPrefix;
   const map = {};
   for (const q of spec.questions) {
     if (!isVisible(q, answers)) continue;
@@ -53,7 +66,7 @@ export function buildEnvMap(spec, answers) {
     if (q.var) {
       const raw = answers[q.id];
       if (raw !== undefined && raw !== "") map[q.var] = raw;
-      else if (secrets.has(q.var)) map[q.var] = SECRET_PLACEHOLDER(q.var);
+      else if (secrets.has(q.var)) map[q.var] = secretPlaceholder(q.var, envPrefix);
     }
   }
   return map;
@@ -64,18 +77,41 @@ export function isVisible(q, answers) {
   return Object.entries(q.showIf).every(([k, allowed]) => allowed.includes(answers[k]));
 }
 
-function dockerEnvMap(map) {
-  const out = { ...map };
-  for (const [k, v] of Object.entries(CONTAINER_PATHS)) {
-    if (k in out) out[k] = v;
+// Bind mounts for visible dockerVolume questions: [[hostPath, containerPath]].
+// An empty answer yields a `/path/to/<id>` placeholder so the artifact still
+// reads as "replace me".
+export function dockerVolumes(spec, answers) {
+  const vols = [];
+  for (const q of spec.questions) {
+    if (!q.dockerVolume || !isVisible(q, answers)) continue;
+    const host = answers[q.id] || `/path/to/${q.id}`;
+    vols.push([host, q.dockerVolume]);
   }
-  out.FASTMCP_HOME = "/data/state/fastmcp";
+  return vols;
+}
+
+// Rewrite the env map for Docker/Compose output. A dockerVolume question's var
+// is always fixed to its container path (the bind mount makes that path real).
+// A dockerPath question's var is fixed only when already present (the user
+// opted into the value); dockerPath never adds a mount. FASTMCP_HOME is injected.
+function dockerEnvMap(spec, answers, map) {
+  const out = { ...map };
+  for (const q of spec.questions) {
+    if (!isVisible(q, answers) || !q.var) continue;
+    if (q.dockerVolume) {
+      out[q.var] = q.dockerVolume;
+    } else if (q.dockerPath && q.var in out) {
+      out[q.var] = q.dockerPath;
+    }
+  }
+  out.FASTMCP_HOME = FASTMCP_HOME;
   return out;
 }
 
 // Quote a .env value when it contains characters that common dotenv parsers
 // treat specially (notably `#`, which starts an inline comment in an unquoted
-// value and would silently truncate the value on load).
+// value and would silently truncate the value on load, and `$`, which triggers
+// variable expansion when the file is shell-sourced).
 const dotenvQuote = (v) => {
   const s = String(v);
   if (!/[#"'\\\s$]/.test(s)) return s;
@@ -86,36 +122,43 @@ export function generateDotenv(map) {
   return Object.entries(map).map(([k, v]) => `${k}=${dotenvQuote(v)}`).join("\n") + "\n";
 }
 
-export function generateClaudeJson(map) {
+export function generateClaudeJson(meta, map) {
   return JSON.stringify(
-    { mcpServers: { "image-generation-mcp": { command: "image-generation-mcp", args: ["serve"], env: map } } },
+    { mcpServers: { [meta.projectName]: { command: meta.projectName, args: ["serve"], env: map } } },
     null, 2,
   );
 }
 
-export function generateDockerRun(map) {
-  const env = dockerEnvMap(map);
+export function generateDockerRun(spec, answers, map) {
+  const env = dockerEnvMap(spec, answers, map);
   const lines = [
-    "docker run -d --name image-generation-mcp",
+    `docker run -d --name ${spec.meta.projectName}`,
     "  -p 8000:8000",
-    "  -v state-data:/data/state",
+    `  -v ${STATE_VOLUME}`,
   ];
+  for (const [host, container] of dockerVolumes(spec, answers)) {
+    lines.push(`  -v ${shellQuote(host)}:${container}`);
+  }
   for (const [k, v] of Object.entries(env)) lines.push(`  -e ${k}=${shellQuote(v)}`);
-  lines.push(`  ${IMAGE}`);
+  lines.push(`  ${spec.meta.dockerImage}`);
   return lines.join(" \\\n");
 }
 
-export function generateCompose(map) {
-  const env = dockerEnvMap(map);
+export function generateCompose(spec, answers, map) {
+  const env = dockerEnvMap(spec, answers, map);
+  const volLines = [`      - ${STATE_VOLUME}`];
+  for (const [host, container] of dockerVolumes(spec, answers)) {
+    volLines.push(`      - ${yamlScalar(`${host}:${container}`)}`);
+  }
   const envLines = Object.entries(env).map(([k, v]) => `      ${k}: ${yamlScalar(v)}`).join("\n");
   return [
     "services:",
-    "  image-generation-mcp:",
-    `    image: ${IMAGE}`,
+    `  ${spec.meta.projectName}:`,
+    `    image: ${spec.meta.dockerImage}`,
     "    ports:",
     '      - "8000:8000"',
     "    volumes:",
-    "      - state-data:/data/state",
+    ...volLines,
     "    environment:",
     envLines,
     "volumes:",
@@ -123,18 +166,19 @@ export function generateCompose(map) {
   ].join("\n");
 }
 
-export function generateSystemd(map) {
+export function generateSystemd(meta, map) {
+  const name = meta.projectName;
   const envLines = Object.entries(map).map(([k, v]) => systemdLine(k, v)).join("\n");
   return [
     "[Unit]",
-    "Description=image-generation-mcp",
+    `Description=${name}`,
     "After=network.target",
     "",
     "[Service]",
     "Type=simple",
-    "# Create this user first: sudo useradd --system --no-create-home image-generation-mcp",
-    "User=image-generation-mcp",
-    "ExecStart=/opt/image-generation-mcp/venv/bin/image-generation-mcp serve --transport http",
+    `# Create this user first: sudo useradd --system --no-create-home ${name}`,
+    `User=${name}`,
+    `ExecStart=/opt/${name}/venv/bin/${name} serve --transport http`,
     envLines,
     "Restart=on-failure",
     "",

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -78,7 +78,7 @@ function dockerEnvMap(map) {
 // value and would silently truncate the value on load).
 const dotenvQuote = (v) => {
   const s = String(v);
-  if (!/[#"'\\\s]/.test(s)) return s;
+  if (!/[#"'\\\s$]/.test(s)) return s;
   return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, '\\$')}"`;
 };
 

--- a/docs/javascripts/config-wizard/wizard-spec-schema.json
+++ b/docs/javascripts/config-wizard/wizard-spec-schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pvliesdonk.github.io/fastmcp-server-template/wizard-spec-schema.json",
+  "title": "fastmcp config-wizard spec",
+  "$comment": "Runtime convention not expressible here: wizard.js keys local-vs-server output off a question with id 'deployment' whose 'server' value selects the HTTP/Docker/systemd tabs. A spec omitting it degrades to local-only output.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "meta", "questions"],
+  "properties": {
+    "version": { "const": 1 },
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["projectName", "dockerImage", "envPrefix"],
+      "properties": {
+        "projectName": { "type": "string", "minLength": 1 },
+        "dockerImage": { "type": "string", "minLength": 1 },
+        "envPrefix": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]*[A-Z0-9]$",
+          "description": "Mirrors the copier.yml env_prefix validator: uppercase/digits/underscore, ≥2 chars, no trailing underscore."
+        }
+      }
+    },
+    "secretKeys": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "questions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/question" }
+    },
+    "guards": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/guard" }
+    }
+  },
+  "$defs": {
+    "question": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "type"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+        "label": { "type": "string", "minLength": 1 },
+        "help": { "type": "string", "minLength": 1 },
+        "type": { "enum": ["text", "select", "bool", "number"] },
+        "var": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" },
+        "advancedGroup": { "type": "string", "minLength": 1 },
+        "showIf": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/option" }
+        },
+        "dockerVolume": { "type": "string", "pattern": "^/" },
+        "dockerPath": { "type": "string", "pattern": "^/" }
+      },
+      "allOf": [
+        {
+          "if": { "required": ["type"], "properties": { "type": { "const": "select" } } },
+          "then": { "required": ["options"] }
+        }
+      ],
+      "not": { "required": ["dockerVolume", "dockerPath"] }
+    },
+    "option": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "label"],
+      "properties": {
+        "value": { "type": "string" },
+        "label": { "type": "string", "minLength": 1 },
+        "emit": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "guard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "message", "when"],
+      "properties": {
+        "level": { "enum": ["warning", "info", "error"] },
+        "message": { "type": "string", "minLength": 1 },
+        "when": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -1,5 +1,10 @@
 {
   "version": 1,
+  "meta": {
+    "projectName": "image-generation-mcp",
+    "dockerImage": "ghcr.io/pvliesdonk/image-generation-mcp:latest",
+    "envPrefix": "IMAGE_GENERATION_MCP"
+  },
   "secretKeys": [
     "IMAGE_GENERATION_MCP_BEARER_TOKEN",
     "IMAGE_GENERATION_MCP_OPENAI_API_KEY",
@@ -67,6 +72,7 @@
       "help": "Directory where generated images are saved. Defaults to ~/.image-generation-mcp/.",
       "type": "text",
       "var": "IMAGE_GENERATION_MCP_SCRATCH_DIR",
+      "dockerPath": "/data/state/images",
       "advancedGroup": "Behaviour"
     },
     {

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -124,14 +124,15 @@ function render() {
     els.forEach((e) => drawer.appendChild(e));
   }
 
+  const meta = spec.meta;
   const map = buildEnvMap(spec, answers);
   const local = answers.deployment !== "server";
   const tabs = local
-    ? [["Claude config", generateClaudeJson(map)], [".env", generateDotenv(map)]]
+    ? [["Claude config", generateClaudeJson(meta, map)], [".env", generateDotenv(map)]]
     : [
-        ["docker run", generateDockerRun(map)],
-        ["compose", generateCompose(map)],
-        ["systemd", generateSystemd(map)],
+        ["docker run", generateDockerRun(spec, answers, map)],
+        ["compose", generateCompose(spec, answers, map)],
+        ["systemd", generateSystemd(meta, map)],
         [".env", generateDotenv(map)],
       ];
   const out = document.createElement("div");
@@ -219,6 +220,12 @@ async function init() {
     const spec = await resp.json();
     if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
       throw new Error("wizard-spec.json is malformed (missing questions array)");
+    }
+    if (!spec.meta || typeof spec.meta !== "object") {
+      // The generators read project identity from spec.meta; a spec missing it
+      // (e.g. mid-migration) must fail loudly here rather than throw an
+      // uncaught TypeError deep inside render().
+      throw new Error("wizard-spec.json is malformed (missing meta block)");
     }
     SPEC = spec;
   } catch (e) {

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -82,6 +82,7 @@ function field(q, secrets) {
 
 let SPEC = null;
 let ROOT = null;
+let _writeTimer = null;
 
 function render() {
   const spec = SPEC;
@@ -170,7 +171,7 @@ function render() {
 
   const warnings = document.createElement("div");
   warnings.className = "cfg-warnings";
-  for (const g of spec.guards) {
+  for (const g of (spec.guards ?? [])) {
     if (Object.entries(g.when).every(([k, vals]) => vals.includes(answers[k]))) {
       const w = document.createElement("div");
       w.className = `cfg-${g.level}`;
@@ -184,7 +185,10 @@ function render() {
   } else {
     ROOT.replaceChildren(core, warnings, out);
   }
-  writeUrlState(spec);
+  // Debounce URL writes: browsers throttle history.replaceState to ~100
+  // calls/10 s, and URL sync is a "share" feature, not live feedback.
+  clearTimeout(_writeTimer);
+  _writeTimer = setTimeout(() => writeUrlState(spec), 300);
 
   // Restore focus + caret to the field the user was editing.
   if (activeQid) {
@@ -212,12 +216,20 @@ async function init() {
   try {
     const resp = await fetch(specUrl);
     if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
-    SPEC = await resp.json();
+    const spec = await resp.json();
+    if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
+      throw new Error("wizard-spec.json is malformed (missing questions array)");
+    }
+    SPEC = spec;
   } catch (e) {
     ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;
     return;
   }
   readUrlState(SPEC);
+  // Initialize all answers so guards that match [""] fire on the first render.
+  // Secrets are excluded from URL hydration (readUrlState skips them) so they
+  // also need this default, ensuring guards referencing secret question IDs
+  // evaluate correctly before the user has typed anything.
   for (const q of SPEC.questions) {
     if (answers[q.id] !== undefined) continue;
     if (q.type === "select" && q.options?.length) {

--- a/docs/stylesheets/config-wizard.css
+++ b/docs/stylesheets/config-wizard.css
@@ -16,4 +16,6 @@
 .cfg-pre { background: var(--md-code-bg-color); padding: 0.75rem; border-radius: 6px; overflow-x: auto; white-space: pre; }
 .cfg-warning { color: #b26a00; }
 [data-md-color-scheme="slate"] .cfg-warning { color: #e0a83a; }
+.cfg-error { color: #c0392b; }
+[data-md-color-scheme="slate"] .cfg-error { color: #e74c3c; }
 .cfg-info { color: var(--md-default-fg-color--light); }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "ruff>=0.6",
     "mypy>=1.0",
     "pip-audit>=2.7",
+    "jsonschema>=4.18",
 ]
 docs = [
     "mike>=2",
@@ -164,6 +165,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["playwright", "playwright.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["jsonschema", "jsonschema.*"]
 ignore_missing_imports = true
 
 # Tests use FastMCP private surfaces (e.g. ``tool.fn``) and pytest fixtures

--- a/tests/test_config_wizard_domain.py
+++ b/tests/test_config_wizard_domain.py
@@ -1,0 +1,25 @@
+"""Domain-specific config-wizard tests for Image Generation MCP.
+
+This file is owned by the generated project (kept across ``copier update`` via
+``_skip_if_exists``). The template seeds it once with a single skipped
+placeholder test; add browser assertions here that depend on *this project's*
+``wizard-spec.json`` — e.g. that a specific field renders, that a chosen option
+emits the expected env var, or that a guard message appears. The generic
+framework tests live in ``test_config_wizard_smoke.py`` (template-owned) and
+must not be edited here.
+
+See ``test_config_wizard_smoke.py`` for the page/browser fixtures to import.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_domain_placeholder() -> None:
+    # Placeholder: the template seeds this file with one skipped test so the
+    # path exists and is kept across copier updates, while neither failing CI
+    # on an empty file nor reporting a hollow "passing" test. Replace this skip
+    # with real domain assertions (field renders, option emits the expected env
+    # var, guard message appears).
+    pytest.skip("No domain-specific wizard tests yet -- add them here.")

--- a/tests/test_config_wizard_smoke.py
+++ b/tests/test_config_wizard_smoke.py
@@ -1,8 +1,19 @@
-"""Browser smoke test for the built config-wizard page.
+"""Browser smoke tests for the built config-wizard page.
 
 Marked ``browser``; requires the ``browser`` dependency group and
 ``playwright install chromium``. Runs against the built ``site/`` directory, so
 ``mkdocs build`` must have run first.
+
+Two kinds of tests live here, both template-owned and spec-agnostic:
+
+* Framework tests drive the actual rendered page and assert only on invariants
+  every spec shares (the ``deployment`` question exists; output carries the
+  project identity from ``meta``).
+* Generator unit tests import ``generators.js`` directly and feed it synthetic
+  specs, so they exercise ``dockerVolume`` / ``dockerPath`` behaviour without
+  depending on this project's questions.
+
+Domain-specific assertions belong in ``test_config_wizard_domain.py``.
 """
 
 from __future__ import annotations
@@ -67,15 +78,156 @@ def page(browser: Browser, site_url: str) -> typing.Iterator[Page]:
     pg.close()
 
 
-def test_local_path_emits_claude_json(page: Page) -> None:
+# --- Framework tests: drive the real page, assert only on universal invariants.
+
+
+def test_local_emits_claude_config_with_project_name(page: Page) -> None:
     page.select_option('[data-qid="deployment"] select', "local")
     text = page.inner_text(".cfg-output")
+    # meta.projectName renders into the Claude config server key + command.
     assert "image-generation-mcp" in text
 
 
-def test_server_docker_path_emits_image(page: Page) -> None:
+def test_server_emits_docker_image_from_meta(page: Page) -> None:
     page.select_option('[data-qid="deployment"] select', "server")
-    page.fill('[data-qid="bearer_token"] input', "secret-token")
     text = page.inner_text("#cfg-wizard")
     assert "ghcr.io/pvliesdonk/image-generation-mcp:latest" in text
-    assert "IMAGE_GENERATION_MCP_BEARER_TOKEN" in text
+
+
+# --- Generator unit tests: import generators.js with synthetic specs.
+
+_GEN_IMPORT = "/javascripts/config-wizard/generators.js"
+
+
+def _eval_generators(page: Page, body: str) -> typing.Any:
+    """Run `body` (an arrow function source) with generators.js imported.
+
+    `body` is JS source of the form `(g) => { ...; return ...; }`; it receives
+    the imported generators module as `g`.
+    """
+    script = (
+        "async () => { const g = await import('"
+        + _GEN_IMPORT
+        + "'); return ("
+        + body
+        + ")(g); }"
+    )
+    return page.evaluate(script)
+
+
+def test_docker_volume_adds_mount_and_fixes_container_path(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'data_dir', label: 'D', type: 'text', var: 'DEMO_DATA_DIR', dockerVolume: '/data/app' }],
+            guards: [] };
+          const answers = { deployment: 'server', data_dir: '/host/data' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateDockerRun(spec, answers, map);
+        }""",
+    )
+    assert "-v /host/data:/data/app" in result
+    # env var is fixed to the container path, NOT the host path.
+    assert "DEMO_DATA_DIR=/data/app" in result
+    assert "DEMO_DATA_DIR=/host/data" not in result
+
+
+def test_docker_volume_empty_answer_uses_placeholder(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'data_dir', label: 'D', type: 'text', var: 'DEMO_DATA_DIR', dockerVolume: '/data/app' }],
+            guards: [] };
+          const answers = { deployment: 'server' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateDockerRun(spec, answers, map);
+        }""",
+    )
+    assert "-v /path/to/data_dir:/data/app" in result
+
+
+def test_docker_path_fixes_present_var_without_mount(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'index_path', label: 'I', type: 'text', var: 'DEMO_INDEX_PATH', dockerPath: '/data/state/index.db' }],
+            guards: [] };
+          const answers = { deployment: 'server', index_path: '/host/index.db' };
+          const map = g.buildEnvMap(spec, answers);
+          return { docker: g.generateDockerRun(spec, answers, map) };
+        }""",
+    )
+    assert "DEMO_INDEX_PATH=/data/state/index.db" in result["docker"]
+    # dockerPath never adds a -v mount.
+    assert "/data/state/index.db:" not in result["docker"]
+    assert "-v /host/index.db" not in result["docker"]
+
+
+def test_docker_path_absent_var_stays_absent(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'index_path', label: 'I', type: 'text', var: 'DEMO_INDEX_PATH', dockerPath: '/data/state/index.db' }],
+            guards: [] };
+          const answers = { deployment: 'server' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateDockerRun(spec, answers, map);
+        }""",
+    )
+    # User left it blank → dockerPath does not inject it (persistence not opted in).
+    assert "DEMO_INDEX_PATH" not in result
+
+
+def test_systemd_uses_raw_host_path_not_container(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'data_dir', label: 'D', type: 'text', var: 'DEMO_DATA_DIR', dockerVolume: '/data/app' }],
+            guards: [] };
+          const answers = { deployment: 'server', data_dir: '/host/data' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateSystemd(spec.meta, map);
+        }""",
+    )
+    # systemd is a host-path context: no container-path rewrite.
+    assert "DEMO_DATA_DIR=/host/data" in result
+    assert "/data/app" not in result
+
+
+def test_compose_quotes_yaml_typed_env_values(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [
+              { id: 'flag', label: 'F', type: 'text', var: 'DEMO_FLAG' },
+              { id: 'port', label: 'P', type: 'text', var: 'DEMO_PORT' },
+            ],
+            guards: [] };
+          const answers = { deployment: 'server', flag: 'true', port: '8080' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateCompose(spec, answers, map);
+        }""",
+    )
+    # YAML 1.1 parsers coerce bare true/8080 to bool/int; env values are
+    # strings, so compose must emit them quoted.
+    assert 'DEMO_FLAG: "true"' in result
+    assert "DEMO_FLAG: true\n" not in result
+    assert 'DEMO_PORT: "8080"' in result

--- a/tests/test_config_wizard_spec_schema.py
+++ b/tests/test_config_wizard_spec_schema.py
@@ -1,0 +1,155 @@
+"""Validate the shipped wizard-spec.json against the canonical JSON Schema.
+
+Template-owned and generic: loads whatever ``wizard-spec.json`` this project
+ships and checks it against ``wizard-spec-schema.json`` plus the cross-reference
+rules JSON Schema cannot express (unique ids, dangling references, secret keys
+declared by a question). Runs in the main test lane (no browser required), so it
+is the gate that catches spec drift — e.g. a guard ``level`` outside {warning,
+info, error} or a ``meta`` block that a stale spec never added.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import jsonschema
+import pytest
+
+_WIZARD_DIR = (
+    Path(__file__).resolve().parent.parent / "docs" / "javascripts" / "config-wizard"
+)
+_SPEC_PATH = _WIZARD_DIR / "wizard-spec.json"
+_SCHEMA_PATH = _WIZARD_DIR / "wizard-spec-schema.json"
+
+
+@pytest.fixture(scope="module")
+def spec() -> dict[str, Any]:
+    return cast("dict[str, Any]", json.loads(_SPEC_PATH.read_text(encoding="utf-8")))
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    return cast("dict[str, Any]", json.loads(_SCHEMA_PATH.read_text(encoding="utf-8")))
+
+
+def _minimal_valid_spec() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "meta": {
+            "projectName": "demo",
+            "dockerImage": "ghcr.io/acme/demo:latest",
+            "envPrefix": "DEMO",
+        },
+        "secretKeys": [],
+        "questions": [
+            {
+                "id": "deployment",
+                "label": "Where?",
+                "type": "select",
+                "options": [
+                    {"value": "local", "label": "Local"},
+                    {"value": "server", "label": "Server"},
+                ],
+            }
+        ],
+        "guards": [],
+    }
+
+
+def test_schema_itself_is_valid(schema: dict[str, Any]) -> None:
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_shipped_spec_matches_schema(
+    spec: dict[str, Any], schema: dict[str, Any]
+) -> None:
+    jsonschema.validate(spec, schema)
+
+
+def test_question_ids_are_unique(spec: dict[str, Any]) -> None:
+    ids = [q["id"] for q in spec["questions"]]
+    assert len(ids) == len(set(ids)), f"duplicate question id(s): {ids}"
+
+
+def test_showif_references_existing_ids(spec: dict[str, Any]) -> None:
+    ids = {q["id"] for q in spec["questions"]}
+    for q in spec["questions"]:
+        for key in q.get("showIf") or {}:
+            assert key in ids, f"showIf references unknown question id: {key}"
+
+
+def test_guard_when_references_existing_ids(spec: dict[str, Any]) -> None:
+    ids = {q["id"] for q in spec["questions"]}
+    for guard in spec.get("guards", []):
+        for key in guard["when"]:
+            assert key in ids, f"guard.when references unknown question id: {key}"
+
+
+def test_secret_keys_are_declared_vars(spec: dict[str, Any]) -> None:
+    declared = {q.get("var") for q in spec["questions"]}
+    for key in spec.get("secretKeys", []):
+        assert key in declared, f"secretKey not declared by any question var: {key}"
+
+
+def test_schema_rejects_unknown_guard_level(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    bad["guards"] = [
+        {"level": "warn", "message": "x", "when": {"deployment": ["server"]}}
+    ]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_schema_rejects_missing_meta(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    del bad["meta"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_schema_rejects_dockervolume_and_dockerpath_together(
+    schema: dict[str, Any],
+) -> None:
+    bad = _minimal_valid_spec()
+    bad["questions"].append(
+        {
+            "id": "data_dir",
+            "label": "Data",
+            "type": "text",
+            "var": "DEMO_DATA_DIR",
+            "dockerVolume": "/data/app",
+            "dockerPath": "/data/state/app",
+        }
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_schema_accepts_dockervolume_alone(schema: dict[str, Any]) -> None:
+    spec = _minimal_valid_spec()
+    spec["questions"].append(
+        {
+            "id": "data_dir",
+            "label": "Data",
+            "type": "text",
+            "var": "DEMO_DATA_DIR",
+            "dockerVolume": "/data/app",
+        }
+    )
+    jsonschema.validate(spec, schema)
+
+
+def test_schema_accepts_dockerpath_alone(schema: dict[str, Any]) -> None:
+    spec = _minimal_valid_spec()
+    spec["questions"].append(
+        {
+            "id": "index_path",
+            "label": "Index",
+            "type": "text",
+            "var": "DEMO_INDEX_PATH",
+            "dockerPath": "/data/state/index.db",
+        }
+    )
+    jsonschema.validate(spec, schema)

--- a/uv.lock
+++ b/uv.lock
@@ -1114,6 +1114,7 @@ browser = [
 dev = [
     { name = "diff-cover" },
     { name = "image-generation-mcp", extra = ["all"] },
+    { name = "jsonschema" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pytest" },
@@ -1148,6 +1149,7 @@ browser = [{ name = "pytest-playwright", specifier = ">=0.5" }]
 dev = [
     { name = "diff-cover", specifier = ">=9.0" },
     { name = "image-generation-mcp", extras = ["all"] },
+    { name = "jsonschema", specifier = ">=4.18" },
     { name = "mypy", specifier = ">=1.0" },
     { name = "pip-audit", specifier = ">=2.7" },
     { name = "pytest", specifier = ">=7.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1080,7 +1080,7 @@ wheels = [
 
 [[package]]
 name = "image-generation-mcp"
-version = "1.10.0rc1"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary

Applies copier template v2.3.0 — the config-wizard ownership redesign that makes wizard runtime files byte-identical across all consumers, eliminating copier-update conflicts permanently.

**Root cause being fixed:** `wizard.js`, `generators.js`, and `config-wizard.css` were template-owned but downstream projects (including this one) had to edit them to express domain behavior (container paths, project identity). Those edits re-conflicted on every subsequent `copier update`.

**Resolution:** domain knowledge moves 100% into `wizard-spec.json` (which is `_skip_if_exists`). Runtime files become plain, generic, and unconflictable.

## Changes

### Runtime files (template-owned, conflict-free from here)
- `generators.js` — rewired to read `meta`/`dockerVolume`/`dockerPath` from spec; `CONTAINER_PATHS` sentinel removed; new `secretPlaceholder(key, envPrefix)` replaces hardcoded prefix
- `wizard.js` — updated generator call signatures: `generateDockerRun/Compose(spec, answers, map)`, `generateClaudeJson/generateSystemd(meta, map)`
- `wizard-spec-schema.json` — new; validates the spec on every CI run
- `test_config_wizard_spec_schema.py` — new; 11 schema tests including `test_shipped_spec_matches_schema`
- `test_config_wizard_domain.py` — new placeholder (`_skip_if_exists`) for domain browser assertions

### Domain migration (`wizard-spec.json`)
- Added `meta` block: `projectName`, `dockerImage`, `envPrefix`
- `scratch_dir` question: added `dockerPath: "/data/state/images"` (was in `CONTAINER_PATHS` sentinel)
- Guard `level: "warning"` was already correct

### Conflict resolutions (2)
- `generators.js`: dropped `CONTAINER_PATHS` sentinel → took template's `secretPlaceholder`
- `pyproject.toml`: kept `tests.*` mypy overrides + added template's new `jsonschema` override

## Test plan

- [x] `uv run pytest -x -q` — 892 passed, 1 skipped (domain placeholder)
- [x] `test_config_wizard_spec_schema.py` — all 11 pass including schema validation against our spec
- [x] `uv run ruff check --fix . && uv run ruff format .` — clean
- [x] `uv run mypy src/ tests/` — no errors

Closes #251

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._