### PR TITLE
feat: OpenAI gpt-image image editing and composition (#258)

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -55,6 +55,7 @@ edit_image
 frontmatter
 gallery_full_image
 generate_image
+inpainting
 lightbox
 Lightbox
 list_providers

--- a/docs/design/2026-06-27-openai-image-edit-plan.md
+++ b/docs/design/2026-06-27-openai-image-edit-plan.md
@@ -1,0 +1,458 @@
+# OpenAI gpt-image image editing (Issue #258) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement reference-image input for the OpenAI provider via the `images.edit` endpoint, so `transform_image` can do image-to-image edits and multi-image composition (up to 16 references) on the gpt-image family.
+
+**Architecture:** The foundation (PR #263) already added `reference_images` to `ImageProvider.generate()`, the `transform_image` tool (capability-routed), and `InputImage`. The OpenAI provider currently *rejects* `reference_images` with `ImageInputUnsupported`. This issue replaces that rejection (for edit-capable gpt-image models) with a real `images.edit` call, and advertises `supports_image_input` / `max_input_images=16` so the tool routes correctly. No tool-layer changes are needed.
+
+**Tech Stack:** Python 3.11+, the `openai` AsyncOpenAI SDK (`client.images.edit`), pytest (SDK mocked via the `_mock_openai` conftest fixture), uv, ruff, mypy.
+
+## Global Constraints
+
+- Python 3.11+; full type hints; Google-style docstrings on public functions.
+- `logging.getLogger(__name__)`; no f-strings in log calls (lazy `%s`); no bare `except` (catch specific types — the provider funnels SDK errors through `_handle_error`).
+- Hard gates before any push: `uv run pytest -x -q`; `uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .`; `uv run mypy src/ tests/`; patch coverage ≥ 80%; docs updated.
+- TDD: failing test first, watch it fail, implement, watch it pass, commit.
+- Conventional commits ending with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Verified API facts** (OpenAI docs, 2026-06-27): `client.images.edit(model=, image=<FileTypes | list[FileTypes]>, prompt=, size=, quality=, n=, background=, output_format=)` returns `data[0].b64_json`. GPT image models accept **up to 16** reference images. `image` FileTypes accepts a `(filename, bytes, content_type)` tuple. `mask` and `input_fidelity` are OUT OF SCOPE (mask = #261; omit input_fidelity — gpt-image-2 disallows changing it). Only gpt-image-* support this no-mask reference edit; dall-e-3 has no edit, dall-e-2 edit is mask-only.
+
+## Scope decisions
+
+- OpenAI `max_input_images = 16` (API native), multi-image composition supported. (#260 remains Gemini-specific.)
+- Edit applies to gpt-image-2 / gpt-image-1.5 / gpt-image-1 / gpt-image-1-mini only. dall-e-3 and dall-e-2 keep `supports_image_input=False` → `ImageInputUnsupported`.
+- No `transform_image` tool changes (already capability-routed). No mask support.
+
+---
+
+## File Structure
+
+- **Modify** `src/image_generation_mcp/providers/openai.py` — add `_MAX_INPUT_IMAGES = 16`; advertise `supports_image_input` / `max_input_images` on the four gpt-image models; dispatch `generate()` to a new `_edit()` path when `reference_images` is non-empty; share request-param building between generate and edit; raise `TooManyInputImages` / `ImageInputUnsupported` appropriately.
+- **Modify** `tests/test_openai_provider.py` — update the now-incorrect `test_openai_rejects_reference_images` (gpt-image now *supports* edit); add edit-path tests.
+- **Modify** `tests/test_openai_discovery.py` — assert the new capability fields.
+- **Modify** `docs/providers/openai.md`, `docs/tools.md` — document OpenAI image input/composition.
+
+---
+
+## Task 1: OpenAI capability fields for image input
+
+**Files:**
+- Modify: `src/image_generation_mcp/providers/openai.py` (module constant + `discover_capabilities`)
+- Test: `tests/test_openai_discovery.py`
+
+**Interfaces:**
+- Produces: `_MAX_INPUT_IMAGES = 16` (module constant); the four gpt-image `ModelCapabilities` carry `supports_image_input=True, max_input_images=16`; dall-e-3/dall-e-2 keep the defaults (`False`/`0`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_openai_discovery.py` (match the file's existing discovery-test harness — it builds a provider with `models.list` mocked to return the known ids, then awaits `discover_capabilities()`; mirror an existing test's mock setup):
+
+```python
+async def test_gpt_image_models_advertise_image_input() -> None:
+    provider = _provider_with_models(  # reuse this file's existing helper/pattern
+        {"gpt-image-2", "gpt-image-1.5", "gpt-image-1", "gpt-image-1-mini", "dall-e-3"}
+    )
+    caps = await provider.discover_capabilities()
+    by_id = {m.model_id: m for m in caps.models}
+    for mid in ("gpt-image-2", "gpt-image-1.5", "gpt-image-1", "gpt-image-1-mini"):
+        assert by_id[mid].supports_image_input is True
+        assert by_id[mid].max_input_images == 16
+    # dall-e-3 has no edit support
+    assert by_id["dall-e-3"].supports_image_input is False
+    assert by_id["dall-e-3"].max_input_images == 0
+```
+
+> If `tests/test_openai_discovery.py` has no `_provider_with_models` helper, follow the actual pattern the file uses to mock `models.list()` (e.g. setting `provider._client.models.list = AsyncMock(return_value=...)` with objects exposing `.id`). The requirement is: discover with the gpt-image ids present and assert the four new capability values.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_openai_discovery.py -k image_input -v`
+Expected: FAIL — `supports_image_input` is `False`/`max_input_images` is `0` for the gpt-image models (foundation defaults).
+
+- [ ] **Step 3: Implement**
+
+In `openai.py`, add the module constant near the other constants (after `_NO_BACKGROUND_GPT_IMAGE`):
+
+```python
+# OpenAI's images.edit endpoint accepts up to 16 reference images for the
+# gpt-image family (multi-image composition). dall-e-3 has no edit endpoint;
+# dall-e-2 edit is mask-only (out of scope here).
+_MAX_INPUT_IMAGES = 16
+```
+
+In `discover_capabilities`, add to EACH of the four gpt-image `ModelCapabilities(...)` constructions (`gpt-image-1`, and the loop covering `gpt-image-1-mini` + `gpt-image-1.5`, and `gpt-image-2`):
+
+```python
+                    supports_image_input=True,
+                    max_input_images=_MAX_INPUT_IMAGES,
+```
+
+Do NOT add these to dall-e-3 or dall-e-2 (they keep the `False`/`0` defaults).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_openai_discovery.py -k image_input -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/image_generation_mcp/providers/openai.py tests/test_openai_discovery.py
+git commit -m "feat(openai): advertise image-input capability (max 16) on gpt-image models
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: OpenAI `images.edit` reference-image path
+
+**Files:**
+- Modify: `src/image_generation_mcp/providers/openai.py` (`generate` dispatch + new `_edit`; shared param helper)
+- Test: `tests/test_openai_provider.py`
+
+**Interfaces:**
+- Consumes: `_MAX_INPUT_IMAGES` (Task 1), `InputImage`, `TooManyInputImages`, `ImageInputUnsupported`, `ImageResult`.
+- Produces: `generate()` dispatches to an edit path when `reference_images` is non-empty; gpt-image models call `client.images.edit`; non-edit models raise `ImageInputUnsupported`; >16 refs raise `TooManyInputImages`.
+
+Behavior contract:
+1. `reference_images` empty/None → existing text-to-image behavior, unchanged.
+2. `reference_images` non-empty:
+   - `effective_model = model or self._model`. If not a gpt-image model → `ImageInputUnsupported("openai", effective_model)` (dall-e has no no-mask reference edit).
+   - `len(reference_images) > _MAX_INPUT_IMAGES` → `TooManyInputImages("openai", effective_model, _MAX_INPUT_IMAGES, len(reference_images))`.
+   - Build `image=[(filename, ref.data, ref.content_type) for ref in reference_images]` (filename = `f"reference_{i}{ext}"`, ext from content_type).
+   - Call `client.images.edit(model=, image=, prompt=<effective, with "Avoid:" negative>, n=1, size=, quality=<api_quality>, output_format=<format>, background=<if model supports>)` — same param mapping as the gpt-image generate path.
+   - Parse `response.data[0].b64_json` identically to generate; metadata `{"model","size","quality","api_quality","edited": True}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Update the existing module-level `test_openai_rejects_reference_images` in `tests/test_openai_provider.py` — gpt-image now *supports* edit, so the rejection must assert against a NON-edit model:
+
+```python
+async def test_openai_rejects_reference_images_for_non_edit_model() -> None:
+    """dall-e-3 has no edit endpoint -> reference_images raises ImageInputUnsupported."""
+    from image_generation_mcp.providers.openai import OpenAIImageProvider
+    from image_generation_mcp.providers.types import ImageInputUnsupported, InputImage
+
+    provider = OpenAIImageProvider(api_key="sk-test", model="dall-e-3")
+    with pytest.raises(ImageInputUnsupported):
+        await provider.generate(
+            "a cat",
+            reference_images=[InputImage(data=b"x", content_type="image/png")],
+        )
+```
+
+(Delete the old `test_openai_rejects_reference_images` that used the default gpt-image-1 model — it asserts behavior this issue intentionally changes. Replace, don't keep both.)
+
+Add edit-path tests (use the `_mock_openai` fixture + the file's mock pattern: set `provider._client.images.edit = AsyncMock(return_value=mock_response)`):
+
+```python
+@pytest.mark.usefixtures("_mock_openai")
+class TestOpenAIEdit:
+    def _mk_provider(self, model="gpt-image-1"):
+        from image_generation_mcp.providers.openai import OpenAIImageProvider
+        return OpenAIImageProvider(api_key="sk-test", model=model)
+
+    def _mk_response(self, b64="aGk="):
+        item = MagicMock()
+        item.b64_json = b64
+        resp = MagicMock()
+        resp.data = [item]
+        return resp
+
+    async def test_edit_with_single_reference_calls_images_edit(self) -> None:
+        from image_generation_mcp.providers.types import InputImage
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(return_value=self._mk_response())
+
+        ref = InputImage(data=b"png-bytes", content_type="image/png", source_id="a")
+        result = await provider.generate("make it blue", reference_images=[ref])
+
+        provider._client.images.edit.assert_awaited_once()
+        kwargs = provider._client.images.edit.call_args.kwargs
+        assert kwargs["model"] == "gpt-image-1"
+        assert isinstance(kwargs["image"], list) and len(kwargs["image"]) == 1
+        # file tuple: (filename, data, content_type)
+        fname, data, ctype = kwargs["image"][0]
+        assert data == b"png-bytes"
+        assert ctype == "image/png"
+        assert result.provider_metadata.get("edited") is True
+
+    async def test_edit_with_multiple_references(self) -> None:
+        from image_generation_mcp.providers.types import InputImage
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(return_value=self._mk_response())
+        refs = [InputImage(data=b"a", content_type="image/png"),
+                InputImage(data=b"b", content_type="image/jpeg")]
+        await provider.generate("compose", reference_images=refs)
+        assert len(provider._client.images.edit.call_args.kwargs["image"]) == 2
+
+    async def test_edit_too_many_references_raises(self) -> None:
+        from image_generation_mcp.providers.types import InputImage, TooManyInputImages
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        refs = [InputImage(data=b"x", content_type="image/png") for _ in range(17)]
+        with pytest.raises(TooManyInputImages):
+            await provider.generate("x", reference_images=refs)
+
+    async def test_edit_negative_prompt_appended(self) -> None:
+        from image_generation_mcp.providers.types import InputImage
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(return_value=self._mk_response())
+        await provider.generate(
+            "x", negative_prompt="dogs",
+            reference_images=[InputImage(data=b"a", content_type="image/png")],
+        )
+        assert "Avoid: dogs" in provider._client.images.edit.call_args.kwargs["prompt"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_openai_provider.py -k "edit or non_edit_model" -v`
+Expected: FAIL — `images.edit` is never called (current code raises `ImageInputUnsupported` for all reference_images), and the non-edit test imports/paths don't yet hold.
+
+- [ ] **Step 3: Implement the edit path**
+
+In `openai.py`, import `TooManyInputImages` (add to the `.types` import block alongside `ImageInputUnsupported`).
+
+Extract the shared gpt-image request kwargs into a helper so generate and edit don't duplicate it:
+
+```python
+    def _gpt_image_request(
+        self,
+        *,
+        effective_model: str,
+        prompt: str,
+        negative_prompt: str | None,
+        aspect_ratio: str,
+        quality: str,
+        background: str,
+    ) -> tuple[dict[str, Any], str]:
+        """Build the shared gpt-image request kwargs and resolved content type.
+
+        Returns ``(kwargs, content_type)`` where ``kwargs`` carries prompt, n,
+        size, quality, output_format and (when the model supports it)
+        background — everything common to ``images.generate`` and
+        ``images.edit`` for the gpt-image family. The caller adds ``model`` and,
+        for edits, ``image``.
+        """
+        size = _GPT_IMAGE_SIZES.get(aspect_ratio)
+        if size is None:
+            supported = ", ".join(sorted(_GPT_IMAGE_SIZES))
+            raise ImageProviderError(
+                "openai",
+                f"Unsupported aspect_ratio '{aspect_ratio}'. Supported: {supported}",
+            )
+        effective_prompt = prompt
+        if negative_prompt:
+            effective_prompt = f"{prompt}\n\nAvoid: {negative_prompt}"
+        api_quality = {"standard": "auto", "hd": "high"}.get(quality, quality)
+        kwargs: dict[str, Any] = {
+            "prompt": effective_prompt,
+            "n": 1,
+            "size": size,
+            "quality": api_quality,
+            "output_format": self._output_format,
+        }
+        if effective_model not in _NO_BACKGROUND_GPT_IMAGE:
+            kwargs["background"] = background
+        elif background == "transparent":
+            logger.debug(
+                "%s does not support background parameter, ignoring", effective_model
+            )
+        return kwargs, _FORMAT_TO_CONTENT_TYPE[self._output_format]
+```
+
+> Refactor the existing gpt-image branch of `generate()` to use `_gpt_image_request` too (so the kwargs/size/quality/background logic lives in one place); leave the dall-e branch as-is. Keep `generate()`'s response-parsing and metadata block. The goal is no duplicated request-building between generate and edit — a reviewer will flag duplication.
+
+Add the dispatch at the TOP of `generate()` (replace the current `if reference_images: raise ImageInputUnsupported(...)`):
+
+```python
+        if reference_images:
+            return await self._edit(
+                prompt,
+                reference_images=reference_images,
+                negative_prompt=negative_prompt,
+                aspect_ratio=aspect_ratio,
+                quality=quality,
+                background=background,
+                model=model,
+            )
+```
+
+Add the `_edit` method:
+
+```python
+    async def _edit(
+        self,
+        prompt: str,
+        *,
+        reference_images: Sequence[InputImage],
+        negative_prompt: str | None,
+        aspect_ratio: str,
+        quality: str,
+        background: str,
+        model: str | None,
+    ) -> ImageResult:
+        """Edit/compose using OpenAI ``images.edit`` (gpt-image family only).
+
+        Args:
+            prompt: Edit description.
+            reference_images: 1..16 input images (gpt-image composition).
+            negative_prompt: Appended as ``"Avoid: ..."``.
+            aspect_ratio / quality / background: Same mapping as generation.
+            model: Override model; must be a gpt-image model.
+
+        Raises:
+            ImageInputUnsupported: model has no no-mask edit endpoint (dall-e).
+            TooManyInputImages: more than 16 references supplied.
+            ImageProviderError / *ContentPolicy* / *Connection*: API failures.
+        """
+        effective_model = model or self._model
+        if not _is_gpt_image_model(effective_model):
+            raise ImageInputUnsupported("openai", effective_model)
+        if len(reference_images) > _MAX_INPUT_IMAGES:
+            raise TooManyInputImages(
+                "openai", effective_model, _MAX_INPUT_IMAGES, len(reference_images)
+            )
+
+        kwargs, content_type = self._gpt_image_request(
+            effective_model=effective_model,
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            aspect_ratio=aspect_ratio,
+            quality=quality,
+            background=background,
+        )
+        kwargs["model"] = effective_model
+        kwargs["image"] = [
+            (f"reference_{i}{_ext_for(ref.content_type)}", ref.data, ref.content_type)
+            for i, ref in enumerate(reference_images)
+        ]
+
+        logger.debug(
+            "OpenAI image edit: model=%s refs=%d size=%s",
+            effective_model,
+            len(reference_images),
+            kwargs["size"],
+        )
+        try:
+            response = await self._client.images.edit(**kwargs)
+        except ImageProviderError:
+            raise
+        except Exception as e:
+            self._handle_error(e)
+
+        if not response.data:
+            raise ImageProviderError("openai", "Empty response from image edit API")
+        b64_data = response.data[0].b64_json
+        if not b64_data:
+            raise ImageProviderError("openai", "No image data in edit response")
+        logger.info(
+            "OpenAI image edited: model=%s refs=%d",
+            effective_model,
+            len(reference_images),
+        )
+        return ImageResult.from_base64(
+            b64_data,
+            content_type=content_type,
+            model=effective_model,
+            size=kwargs["size"],
+            quality=quality,
+            api_quality=kwargs["quality"],
+            edited=True,
+        )
+```
+
+Add the small extension-map helper near the top-level constants:
+
+```python
+_CONTENT_TYPE_TO_EXT: dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+}
+
+
+def _ext_for(content_type: str) -> str:
+    """Return a filename extension for an input image content type."""
+    return _CONTENT_TYPE_TO_EXT.get(content_type, ".png")
+```
+
+Update the `generate()` docstring's `reference_images` line to describe the new behavior (image-to-image / composition via `images.edit` for gpt-image; raises `ImageInputUnsupported` for dall-e).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_openai_provider.py -v`
+Expected: PASS (existing generate tests unchanged + new edit tests + the rewritten non-edit rejection test).
+
+- [ ] **Step 5: Full gates**
+
+```bash
+uv run pytest -x -q
+uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .
+uv run mypy src/ tests/
+```
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/image_generation_mcp/providers/openai.py tests/test_openai_provider.py
+git commit -m "feat(openai): image-to-image and composition via images.edit
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Documentation
+
+**Files:**
+- Modify: `docs/providers/openai.md`, `docs/tools.md`
+
+**Interfaces:** none. Required by the docs hard gate.
+
+- [ ] **Step 1: Document OpenAI image input**
+
+In `docs/providers/openai.md`, add an "Image input (editing and composition)" section: the gpt-image family (gpt-image-2/1.5/1/1-mini) accepts reference images via `transform_image` — single-image edits and multi-image composition up to 16 references; dall-e-3/dall-e-2 do not (no-mask reference edit unsupported). Note `supports_image_input` / `max_input_images` appear in `list_providers`.
+
+In `docs/tools.md`, update the `transform_image` section to note OpenAI is now a supported image-input provider (in addition to Gemini), with up to 16 references for composition.
+
+**Keep the prose Vale-clean** (these are site docs): no em-dashes (use commas/parentheses), no "e.g."/"i.e." (write "for example"/"that is"), no "**Note:**" metacommentary, no three-parallel-verb lists. Run `vale sync` then `vale --minAlertLevel=error docs/providers/openai.md docs/tools.md` and fix any error on the lines you add (add genuine technical terms to `.vale/styles/config/vocabularies/Base/accept.txt` if needed).
+
+- [ ] **Step 2: Verify**
+
+Run: `uv run mkdocs build 2>&1 | tail -5` (no errors) and `vale --minAlertLevel=error docs/providers/openai.md docs/tools.md` (0 errors on added lines).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/providers/openai.md docs/tools.md
+git commit -m "docs: document OpenAI image input (editing + composition)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Pre-PR verification
+
+- [ ] `uv run pytest -x -q` — all pass.
+- [ ] ruff check/format clean; `uv run mypy src/ tests/` clean.
+- [ ] `uv run pytest --cov=image_generation_mcp.providers.openai --cov-report=term-missing` — patch coverage ≥ 80% (edit path, both error branches, capability fields covered).
+- [ ] Run `preflight-circus` against `BASE..HEAD` before `gh pr create`. Pre-emptively grep for any provider-name-hardcoded user-facing string and confirm messages stay provider-neutral where appropriate (lesson from #263).
+- [ ] PR body: `Closes #258`, `Refs #256`, agent-attribution signature; note Vale is the known-broken #244 gate (non-blocking) if it shows red on unrelated docs.
+
+## Self-Review notes (author)
+
+- Capability fields (T1) → edit implementation (T2) → docs (T3). The tool layer needs no change (capability-routed already).
+- `_gpt_image_request` is extracted to avoid duplicating request-building between `generate` and `_edit` (pre-empts the DRY finding pattern seen on #263).
+- The foundation's `test_openai_rejects_reference_images` is rewritten (not deleted) to assert the new state (rejection only for non-edit models) — removal/refactor discipline.
+- Type consistency: `_MAX_INPUT_IMAGES = 16`, `_edit(... reference_images: Sequence[InputImage] ...)`, file tuple `(filename, bytes, content_type)`, metadata `edited=True`.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -19,6 +19,7 @@ The provider registers automatically when this variable is set.
 | `gpt-image-1` | Current (default) | PNG, JPEG, WebP | Best quality, native format selection |
 | `gpt-image-1.5` | Preview | PNG, JPEG, WebP | Capabilities assumed to match gpt-image-1 |
 | `gpt-image-1-mini` | Preview | PNG, JPEG, WebP | Capabilities assumed to match gpt-image-1 |
+| `gpt-image-2` | Flagship (when listed) | PNG, JPEG, WebP | No transparent background; entry stays dormant until OpenAI's models.list returns the id |
 | `dall-e-3` | Legacy | PNG only | Deprecated May 2026 |
 
 ## Aspect ratios and sizes

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -138,7 +138,7 @@ The endpoint accepts PNG, JPEG, and WebP references. Each reference image is sen
 
 ### Masks
 
-Mask support (inpainting) is not yet implemented for the `images.edit` endpoint. All edits are applied globally using the reference images as compositional context; targeted region editing is a future enhancement.
+The `transform_image` tool does not send a mask, so edits apply globally using the reference images as compositional context. The underlying `images.edit` endpoint supports masks for region-targeted editing, which `list_providers` reports through `supports_mask`.
 
 ## Error handling
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -115,6 +115,31 @@ OpenAI charges per image generated. Pricing varies by model, size, and quality l
 
 `gpt-image-1` is generally more expensive than `dall-e-3` but produces higher quality output with more flexible format options.
 
+## Image input (editing and composition)
+
+The gpt-image family (`gpt-image-2`, `gpt-image-1.5`, `gpt-image-1`, `gpt-image-1-mini`) accepts reference images through the `transform_image` tool. The provider routes these requests through OpenAI's `images.edit` endpoint, supporting both single-image edits and multi-image composition with up to 16 reference images per call.
+
+`dall-e-3` and `dall-e-2` do not support reference-image input. Supplying reference images to either model raises an unsupported-input error (`ImageInputUnsupported`).
+
+### Capability fields
+
+The `list_providers` response includes two fields on each model entry that clients use to determine routing:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `supports_image_input` | bool | `true` for all gpt-image models; `false` for dall-e models |
+| `max_input_images` | int | `16` for gpt-image models; absent for dall-e models |
+
+Use these fields to decide which provider and model to pass to `transform_image`. When `supports_image_input` is `false`, pass the images to a Gemini provider instead.
+
+### Supported reference image formats
+
+The endpoint accepts PNG, JPEG, and WebP references. Each reference image is sent as a named file tuple using the source image's content type.
+
+### Masks
+
+Mask support (inpainting) is not yet implemented for the `images.edit` endpoint. All edits are applied globally using the reference images as compositional context; targeted region editing is a future enhancement.
+
 ## Error handling
 
 | Error | Cause | Resolution |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -110,8 +110,8 @@ Edit or transform an existing image using a model that accepts image input (imag
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | str | *(required)* | Description of the desired edit or transformation (natural language) |
-| `reference_images` | list[str] | *(required)* | One or more gallery `image_id` values, `image://` URIs, or (when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`) local file paths to use as source images; currently limited to one image per call (Gemini), check `max_input_images` in `list_providers` |
-| `provider` | str | `"auto"` | Provider to use, or `"auto"`. Use a Gemini provider for image-to-image tasks; check `supports_image_input` in `list_providers` |
+| `reference_images` | list[str] | *(required)* | One or more gallery `image_id` values, `image://` URIs, or (when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`) local file paths to use as source images; Gemini supports one reference image per call, OpenAI gpt-image models support up to 16 (multi-image composition); check `max_input_images` in `list_providers` |
+| `provider` | str | `"auto"` | Provider to use, or `"auto"`. Use a Gemini or OpenAI provider for image-to-image tasks; check `supports_image_input` in `list_providers` |
 | `negative_prompt` | str | `null` | Things to avoid in the result (provider support varies) |
 | `aspect_ratio` | str | `"1:1"` | Desired aspect ratio of the output image |
 | `quality` | str | `"standard"` | Quality level: `standard` or `hd` |
@@ -126,7 +126,7 @@ Each entry in `reference_images` is resolved in order:
 2. **`image://` URI**: a full resource URI, such as `"image://a1b2c3d4e5f6/view"`.
 3. **Local file path**: absolute path on the server host, such as `"/home/user/photo.png"`. Only accepted when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`; rejected with an error otherwise.
 
-Call `list_providers` and inspect `supports_image_input` and `max_input_images` on each model to confirm which provider can handle your input count. This release serves single-reference-image transformations via Gemini models.
+Call `list_providers` and inspect `supports_image_input` and `max_input_images` on each model to confirm which provider can handle your input count. Gemini supports one reference image per call. OpenAI gpt-image models (`gpt-image-1`, `gpt-image-1.5`, `gpt-image-1-mini`, `gpt-image-2`) support up to 16 reference images for multi-image composition. `dall-e-3` and `dall-e-2` do not accept reference images.
 
 ### Return value
 

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -567,7 +567,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             provider: Provider to use, or ``"auto"`` to select
                 automatically.  Image-to-image is served by providers that
                 report ``supports_image_input`` in ``list_providers``
-                (currently Gemini).
+                (Gemini, one reference image; OpenAI gpt-image, up to 16).
             negative_prompt: Things to avoid in the result (provider
                 support varies).
             aspect_ratio: Desired aspect ratio of the output image.

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -542,8 +542,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Supply one or more reference images (gallery ``image_id``, an
         ``image://`` URI, or — when enabled — a local file path) plus a
         prompt describing the change.  Served by providers that report
-        ``supports_image_input`` in ``list_providers`` (currently Gemini,
-        single reference image); check ``supports_image_input`` /
+        ``supports_image_input`` in ``list_providers`` (Gemini accepts one
+        reference image; OpenAI gpt-image models accept up to 16 for
+        multi-image composition); check ``supports_image_input`` /
         ``max_input_images`` there to route.
 
         Returns immediately; poll ``check_generation_status(image_id)``
@@ -633,23 +634,29 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         ) as exc:
             raise ValueError(str(exc)) from exc
 
-        # Resolve provider name. For "auto", restrict candidates to
-        # image-input-capable providers so auto-selection cannot pick a
-        # text-only provider and then reject a transform a capable provider
-        # could serve. The _any_provider_supports_image_input guard above
-        # guarantees at least one capable provider exists here.
+        # Resolve provider name. For "auto", restrict candidates to providers
+        # whose capabilities include a model that supports image input AND
+        # accepts at least len(resolved) references, so auto-selection cannot
+        # pick a provider that would then reject this request's reference count
+        # (Gemini caps at 1; OpenAI accepts up to 16). Prefer Gemini among the
+        # eligible providers (higher-quality edits); otherwise the first
+        # eligible provider alphabetically for determinism.
         if provider == "auto":
-            capable_providers = sorted(
+            eligible = sorted(
                 name
                 for name, caps in service.capabilities.items()
-                if any(m.supports_image_input for m in caps.models)
+                if any(
+                    m.supports_image_input and m.max_input_images >= len(resolved)
+                    for m in caps.models
+                )
             )
-            # Prefer Gemini (most capable image-input model) when available;
-            # otherwise pick the first capable provider alphabetically for determinism.
-            # A future explicit priority order can replace this once more providers gain image input.
-            chosen_provider = (
-                "gemini" if "gemini" in capable_providers else capable_providers[0]
-            )
+            if not eligible:
+                raise ValueError(
+                    f"No configured provider accepts {len(resolved)} reference "
+                    "image(s). See list_providers (max_input_images) for "
+                    "per-model limits."
+                )
+            chosen_provider = "gemini" if "gemini" in eligible else eligible[0]
         else:
             chosen_provider = provider
         resolved_name = await asyncio.to_thread(

--- a/src/image_generation_mcp/providers/openai.py
+++ b/src/image_generation_mcp/providers/openai.py
@@ -100,8 +100,20 @@ _CONTENT_TYPE_TO_EXT: dict[str, str] = {
 
 
 def _ext_for(content_type: str) -> str:
-    """Return a filename extension for an input image content type."""
-    return _CONTENT_TYPE_TO_EXT.get(content_type, ".png")
+    """Return the filename extension for a supported input image content type.
+
+    Raises:
+        ImageProviderError: If the content type is not a supported input format.
+    """
+    ext = _CONTENT_TYPE_TO_EXT.get(content_type)
+    if ext is None:
+        supported = ", ".join(sorted(_CONTENT_TYPE_TO_EXT))
+        raise ImageProviderError(
+            "openai",
+            f"Unsupported reference-image content type {content_type!r}. "
+            f"Supported: {supported}",
+        )
+    return ext
 
 
 class OpenAIImageProvider:
@@ -204,9 +216,7 @@ class OpenAIImageProvider:
         if effective_model not in _NO_BACKGROUND_GPT_IMAGE:
             kwargs["background"] = background
         elif background == "transparent":
-            logger.debug(
-                "%s does not support background parameter, ignoring", effective_model
-            )
+            logger.debug("background_param_skipped model=%s", effective_model)
         return kwargs, _FORMAT_TO_CONTENT_TYPE[self._output_format]
 
     async def generate(
@@ -230,7 +240,8 @@ class OpenAIImageProvider:
             quality: ``"standard"`` maps to ``"auto"`` for gpt-image-1
                 (lets OpenAI choose). ``"hd"`` maps to ``"high"``.
             background: Background transparency (``opaque``, ``transparent``).
-                Only supported for gpt-image-1; ignored for dall-e-3.
+                Supported for gpt-image-1, gpt-image-1.5, and gpt-image-1-mini;
+                not sent to gpt-image-2 (no alpha support) or dall-e.
             model: Specific model to use for this call (e.g., ``"dall-e-3"``).
                 Overrides the constructor model. Size table selection adjusts
                 automatically.
@@ -249,7 +260,7 @@ class OpenAIImageProvider:
             ImageContentPolicyError: On content policy rejection.
             ImageProviderConnectionError: On network errors.
             ImageInputUnsupported: When reference_images are supplied to a
-                dall-e model.
+                non-gpt-image model (dall-e or unknown).
             TooManyInputImages: When more than 16 reference_images are given.
         """
         if reference_images:

--- a/src/image_generation_mcp/providers/openai.py
+++ b/src/image_generation_mcp/providers/openai.py
@@ -86,6 +86,11 @@ def _is_gpt_image_model(model: str) -> bool:
 # ``discover_capabilities()`` for the same model_ids.
 _NO_BACKGROUND_GPT_IMAGE: frozenset[str] = frozenset({"gpt-image-2"})
 
+# OpenAI's images.edit endpoint accepts up to 16 reference images for the
+# gpt-image family (multi-image composition). dall-e-3 has no edit endpoint;
+# dall-e-2 edit is mask-only (out of scope here).
+_MAX_INPUT_IMAGES = 16
+
 
 class OpenAIImageProvider:
     """Image generation via OpenAI's Images API.
@@ -326,6 +331,8 @@ class OpenAIImageProvider:
                     supports_mask=True,
                     supports_background=True,
                     supports_negative_prompt=False,
+                    supports_image_input=True,
+                    max_input_images=_MAX_INPUT_IMAGES,
                     supported_aspect_ratios=tuple(_GPT_IMAGE_SIZES),
                     supported_formats=("png", "jpeg", "webp"),
                     supported_qualities=("standard", "hd"),
@@ -350,6 +357,8 @@ class OpenAIImageProvider:
                         supports_mask=True,
                         supports_background=True,
                         supports_negative_prompt=False,
+                        supports_image_input=True,
+                        max_input_images=_MAX_INPUT_IMAGES,
                         supported_aspect_ratios=tuple(_GPT_IMAGE_SIZES),
                         supported_formats=("png", "jpeg", "webp"),
                         supported_qualities=("standard", "hd"),
@@ -375,6 +384,8 @@ class OpenAIImageProvider:
                     supports_mask=True,
                     supports_background=False,
                     supports_negative_prompt=False,
+                    supports_image_input=True,
+                    max_input_images=_MAX_INPUT_IMAGES,
                     supported_aspect_ratios=tuple(_GPT_IMAGE_SIZES),
                     supported_formats=("png", "jpeg", "webp"),
                     supported_qualities=("standard", "hd"),

--- a/src/image_generation_mcp/providers/openai.py
+++ b/src/image_generation_mcp/providers/openai.py
@@ -29,6 +29,7 @@ from image_generation_mcp.providers.types import (
     ImageResult,
     InputImage,
     ProgressCallback,
+    TooManyInputImages,
 )
 
 if TYPE_CHECKING:
@@ -89,7 +90,18 @@ _NO_BACKGROUND_GPT_IMAGE: frozenset[str] = frozenset({"gpt-image-2"})
 # OpenAI's images.edit endpoint accepts up to 16 reference images for the
 # gpt-image family (multi-image composition). dall-e-3 has no edit endpoint;
 # dall-e-2 edit is mask-only (out of scope here).
-_MAX_INPUT_IMAGES = 16
+_MAX_INPUT_IMAGES: int = 16
+
+_CONTENT_TYPE_TO_EXT: dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+}
+
+
+def _ext_for(content_type: str) -> str:
+    """Return a filename extension for an input image content type."""
+    return _CONTENT_TYPE_TO_EXT.get(content_type, ".png")
 
 
 class OpenAIImageProvider:
@@ -139,6 +151,64 @@ class OpenAIImageProvider:
             ) from e
         return _AsyncOpenAI(api_key=api_key)
 
+    def _gpt_image_request(
+        self,
+        *,
+        effective_model: str,
+        prompt: str,
+        negative_prompt: str | None,
+        aspect_ratio: str,
+        quality: str,
+        background: str,
+    ) -> tuple[dict[str, Any], str]:
+        """Build the shared gpt-image request kwargs and resolved content type.
+
+        Returns ``(kwargs, content_type)`` where ``kwargs`` carries prompt, n,
+        size, quality, output_format and (when the model supports it)
+        background — everything common to ``images.generate`` and
+        ``images.edit`` for the gpt-image family. The caller adds ``model`` and,
+        for edits, ``image``.
+
+        Args:
+            effective_model: The resolved model name (post-override).
+            prompt: Positive text prompt.
+            negative_prompt: Appended as ``"Avoid: ..."`` when non-None.
+            aspect_ratio: Maps to OpenAI size parameter.
+            quality: ``"standard"`` or ``"hd"``; mapped to API values.
+            background: Background transparency (``opaque``, ``transparent``).
+
+        Returns:
+            Tuple of (kwargs dict, content_type string).
+
+        Raises:
+            ImageProviderError: When aspect_ratio is not supported.
+        """
+        size = _GPT_IMAGE_SIZES.get(aspect_ratio)
+        if size is None:
+            supported = ", ".join(sorted(_GPT_IMAGE_SIZES))
+            raise ImageProviderError(
+                "openai",
+                f"Unsupported aspect_ratio '{aspect_ratio}'. Supported: {supported}",
+            )
+        effective_prompt = prompt
+        if negative_prompt:
+            effective_prompt = f"{prompt}\n\nAvoid: {negative_prompt}"
+        api_quality = {"standard": "auto", "hd": "high"}.get(quality, quality)
+        kwargs: dict[str, Any] = {
+            "prompt": effective_prompt,
+            "n": 1,
+            "size": size,
+            "quality": api_quality,
+            "output_format": self._output_format,
+        }
+        if effective_model not in _NO_BACKGROUND_GPT_IMAGE:
+            kwargs["background"] = background
+        elif background == "transparent":
+            logger.debug(
+                "%s does not support background parameter, ignoring", effective_model
+            )
+        return kwargs, _FORMAT_TO_CONTENT_TYPE[self._output_format]
+
     async def generate(
         self,
         prompt: str,
@@ -164,8 +234,12 @@ class OpenAIImageProvider:
             model: Specific model to use for this call (e.g., ``"dall-e-3"``).
                 Overrides the constructor model. Size table selection adjusts
                 automatically.
-            reference_images: Not supported by this provider. Raises
-                :class:`ImageInputUnsupported` when non-empty.
+            reference_images: For gpt-image models, triggers image-to-image
+                editing / multi-image composition via ``images.edit``. Up to
+                16 reference images are accepted. Raises
+                :class:`ImageInputUnsupported` for dall-e models (no
+                no-mask edit endpoint). Raises :class:`TooManyInputImages`
+                when more than 16 references are supplied.
 
         Returns:
             ImageResult with generated image.
@@ -174,34 +248,61 @@ class OpenAIImageProvider:
             ImageProviderError: On API errors.
             ImageContentPolicyError: On content policy rejection.
             ImageProviderConnectionError: On network errors.
-            ImageInputUnsupported: When reference_images are supplied.
+            ImageInputUnsupported: When reference_images are supplied to a
+                dall-e model.
+            TooManyInputImages: When more than 16 reference_images are given.
         """
         if reference_images:
-            raise ImageInputUnsupported("openai", model)
+            return await self._edit(
+                prompt,
+                reference_images=reference_images,
+                negative_prompt=negative_prompt,
+                aspect_ratio=aspect_ratio,
+                quality=quality,
+                background=background,
+                model=model,
+            )
         effective_model = model or self._model
         # NOTE: any model not matching 'gpt-image*' (e.g. dall-e-2) falls back to
         # DALL-E 3 sizes/format. Unknown models will fail at the API level.
         is_gpt_image = _is_gpt_image_model(effective_model)
-        sizes = _GPT_IMAGE_SIZES if is_gpt_image else _DALLE3_SIZES
-        # dall-e-3 only produces PNG; gpt-image-* uses configured format
-        effective_format = self._output_format if is_gpt_image else "png"
-        content_type = _FORMAT_TO_CONTENT_TYPE[effective_format]
 
-        effective_prompt = prompt
-        if negative_prompt:
-            effective_prompt = f"{prompt}\n\nAvoid: {negative_prompt}"
-
-        api_quality = quality
         if is_gpt_image:
-            api_quality = {"standard": "auto", "hd": "high"}.get(quality, quality)
-
-        size = sizes.get(aspect_ratio)
-        if size is None:
-            supported = ", ".join(sorted(sizes))
-            raise ImageProviderError(
-                "openai",
-                f"Unsupported aspect_ratio '{aspect_ratio}'. Supported: {supported}",
+            gpt_kwargs, content_type = self._gpt_image_request(
+                effective_model=effective_model,
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                aspect_ratio=aspect_ratio,
+                quality=quality,
+                background=background,
             )
+            api_kwargs: dict[str, Any] = {"model": effective_model, **gpt_kwargs}
+            size = gpt_kwargs["size"]
+            api_quality = gpt_kwargs["quality"]
+        else:
+            # dall-e-3 only produces PNG; has its own size table
+            sizes = _DALLE3_SIZES
+            size = sizes.get(aspect_ratio)
+            if size is None:
+                supported = ", ".join(sorted(sizes))
+                raise ImageProviderError(
+                    "openai",
+                    f"Unsupported aspect_ratio '{aspect_ratio}'. Supported: {supported}",
+                )
+            effective_prompt = prompt
+            if negative_prompt:
+                effective_prompt = f"{prompt}\n\nAvoid: {negative_prompt}"
+            api_quality = quality
+            content_type = _FORMAT_TO_CONTENT_TYPE["png"]
+            api_kwargs = {
+                "model": effective_model,
+                "prompt": effective_prompt,
+                "n": 1,
+                "size": size,
+                "quality": api_quality,
+                "response_format": "b64_json",
+            }
+            logger.debug("dall-e-3 does not support background parameter, ignoring")
 
         logger.debug(
             "OpenAI image generation: model=%s size=%s quality=%s",
@@ -211,25 +312,6 @@ class OpenAIImageProvider:
         )
 
         try:
-            api_kwargs: dict[str, Any] = {
-                "model": effective_model,
-                "prompt": effective_prompt,
-                "n": 1,
-                "size": size,
-                "quality": api_quality,
-            }
-            if is_gpt_image:
-                api_kwargs["output_format"] = effective_format
-                if effective_model not in _NO_BACKGROUND_GPT_IMAGE:
-                    api_kwargs["background"] = background
-                elif background == "transparent":
-                    logger.debug(
-                        "%s does not support background parameter, ignoring",
-                        effective_model,
-                    )
-            else:
-                api_kwargs["response_format"] = "b64_json"
-                logger.debug("dall-e-3 does not support background parameter, ignoring")
             response = await self._client.images.generate(**api_kwargs)
         except ImageProviderError:
             raise
@@ -260,6 +342,93 @@ class OpenAIImageProvider:
             b64_data,
             content_type=content_type,
             **metadata,
+        )
+
+    async def _edit(
+        self,
+        prompt: str,
+        *,
+        reference_images: Sequence[InputImage],
+        negative_prompt: str | None,
+        aspect_ratio: str,
+        quality: str,
+        background: str,
+        model: str | None,
+    ) -> ImageResult:
+        """Edit/compose using OpenAI ``images.edit`` (gpt-image family only).
+
+        Args:
+            prompt: Edit description.
+            reference_images: 1..16 input images (gpt-image composition).
+            negative_prompt: Appended as ``"Avoid: ..."``.
+            aspect_ratio: Maps to OpenAI size parameter.
+            quality: ``"standard"`` or ``"hd"``; mapped to API values.
+            background: Background transparency (``opaque``, ``transparent``).
+            model: Override model; must be a gpt-image model.
+
+        Returns:
+            ImageResult with edited image and ``edited=True`` in metadata.
+
+        Raises:
+            ImageInputUnsupported: model has no no-mask edit endpoint (dall-e).
+            TooManyInputImages: more than 16 references supplied.
+            ImageProviderError: On API errors.
+            ImageContentPolicyError: On content policy rejection.
+            ImageProviderConnectionError: On network errors.
+        """
+        effective_model = model or self._model
+        if not _is_gpt_image_model(effective_model):
+            raise ImageInputUnsupported("openai", effective_model)
+        if len(reference_images) > _MAX_INPUT_IMAGES:
+            raise TooManyInputImages(
+                "openai", effective_model, _MAX_INPUT_IMAGES, len(reference_images)
+            )
+
+        kwargs, content_type = self._gpt_image_request(
+            effective_model=effective_model,
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            aspect_ratio=aspect_ratio,
+            quality=quality,
+            background=background,
+        )
+        kwargs["model"] = effective_model
+        kwargs["image"] = [
+            (f"reference_{i}{_ext_for(ref.content_type)}", ref.data, ref.content_type)
+            for i, ref in enumerate(reference_images)
+        ]
+
+        logger.debug(
+            "OpenAI image edit: model=%s refs=%d size=%s",
+            effective_model,
+            len(reference_images),
+            kwargs["size"],
+        )
+        try:
+            response = await self._client.images.edit(**kwargs)
+        except ImageProviderError:
+            raise
+        except Exception as e:
+            self._handle_error(e)
+
+        if not response.data:
+            raise ImageProviderError("openai", "Empty response from image edit API")
+        b64_data = response.data[0].b64_json
+        if not b64_data:
+            raise ImageProviderError("openai", "No image data in edit response")
+        logger.info(
+            "OpenAI image edited: model=%s refs=%d",
+            effective_model,
+            len(reference_images),
+        )
+        return ImageResult.from_base64(
+            b64_data,
+            content_type=content_type,
+            model=effective_model,
+            size=kwargs["size"],
+            quality=quality,
+            api_quality=kwargs["quality"],
+            edited=True,
         )
 
     def _handle_error(self, error: Exception) -> NoReturn:

--- a/tests/test_openai_discovery.py
+++ b/tests/test_openai_discovery.py
@@ -389,3 +389,32 @@ class TestDiscoverNewGptImageModels:
             "dall-e-3",
             "dall-e-2",
         }
+
+
+class TestDiscoverImageInputCapability:
+    """Verify image-input capability fields on gpt-image models."""
+
+    async def test_gpt_image_models_advertise_image_input(
+        self, provider: OpenAIImageProvider
+    ) -> None:
+        """gpt-image models advertise image-input support; dall-e-3 does not."""
+        provider._client.models = MagicMock()
+        provider._client.models.list = AsyncMock(
+            return_value=_make_model(
+                "gpt-image-2",
+                "gpt-image-1.5",
+                "gpt-image-1",
+                "gpt-image-1-mini",
+                "dall-e-3",
+            )
+        )
+
+        caps = await provider.discover_capabilities()
+
+        by_id = {m.model_id: m for m in caps.models}
+        for mid in ("gpt-image-2", "gpt-image-1.5", "gpt-image-1", "gpt-image-1-mini"):
+            assert by_id[mid].supports_image_input is True
+            assert by_id[mid].max_input_images == 16
+        # dall-e-3 has no edit support
+        assert by_id["dall-e-3"].supports_image_input is False
+        assert by_id["dall-e-3"].max_input_images == 0

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -495,3 +495,25 @@ class TestOpenAIEdit:
             reference_images=[InputImage(data=b"a", content_type="image/png")],
         )
         assert "Avoid: dogs" in provider._client.images.edit.call_args.kwargs["prompt"]
+
+    async def test_edit_empty_response_raises(self) -> None:
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        empty = MagicMock()
+        empty.data = []
+        provider._client.images.edit = AsyncMock(return_value=empty)
+        with pytest.raises(ImageProviderError, match="Empty response"):
+            await provider.generate(
+                "x", reference_images=[InputImage(data=b"a", content_type="image/png")]
+            )
+
+    async def test_edit_missing_b64_raises(self) -> None:
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(return_value=self._mk_response(b64=""))
+        with pytest.raises(ImageProviderError, match="No image data"):
+            await provider.generate(
+                "x", reference_images=[InputImage(data=b"a", content_type="image/png")]
+            )

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -545,6 +545,16 @@ class TestOpenAIEdit:
                 reference_images=[InputImage(data=b"a", content_type="image/png")],
             )
 
+    async def test_edit_unsupported_content_type_raises(self) -> None:
+        provider = self._mk_provider()
+        with pytest.raises(
+            ImageProviderError, match="Unsupported reference-image content type"
+        ):
+            await provider.generate(
+                "x",
+                reference_images=[InputImage(data=b"a", content_type="image/gif")],
+            )
+
     async def test_edit_exactly_16_references_accepted(self) -> None:
         provider = self._mk_provider()
         provider._client = MagicMock()

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -564,3 +564,16 @@ class TestOpenAIEdit:
         await provider.generate("x", reference_images=refs)
         provider._client.images.edit.assert_awaited_once()
         assert len(provider._client.images.edit.call_args.kwargs["image"]) == 16
+
+    async def test_edit_gpt_image_2_omits_background(self) -> None:
+        provider = self._mk_provider("gpt-image-2")
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(return_value=self._mk_response())
+        await provider.generate(
+            "x",
+            background="transparent",
+            reference_images=[InputImage(data=b"a", content_type="image/png")],
+        )
+        # gpt-image-2 does not accept background; it is omitted from the request.
+        assert "background" not in provider._client.images.edit.call_args.kwargs

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -419,12 +419,79 @@ class TestErrorHandling:
 
 
 @pytest.mark.usefixtures("_mock_openai")
-async def test_openai_rejects_reference_images() -> None:
-    """OpenAI provider raises ImageInputUnsupported when reference_images are given."""
-    provider = OpenAIImageProvider(api_key="sk-test")
+async def test_openai_rejects_reference_images_for_non_edit_model() -> None:
+    """dall-e-3 has no edit endpoint -> reference_images raises ImageInputUnsupported."""
+    provider = OpenAIImageProvider(api_key="sk-test", model="dall-e-3")
 
     with pytest.raises(ImageInputUnsupported):
         await provider.generate(
             "a cat",
             reference_images=[InputImage(data=b"x", content_type="image/png")],
         )
+
+
+@pytest.mark.usefixtures("_mock_openai")
+class TestOpenAIEdit:
+    """Tests for the OpenAI images.edit (image-to-image / composition) path."""
+
+    def _mk_provider(self, model: str = "gpt-image-1") -> OpenAIImageProvider:
+        return OpenAIImageProvider(api_key="sk-test", model=model)
+
+    def _mk_response(self, b64: str = "aGk=") -> MagicMock:
+        item = MagicMock()
+        item.b64_json = b64
+        resp = MagicMock()
+        resp.data = [item]
+        return resp
+
+    async def test_edit_with_single_reference_calls_images_edit(self) -> None:
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(return_value=self._mk_response())
+
+        ref = InputImage(data=b"png-bytes", content_type="image/png", source_id="a")
+        result = await provider.generate("make it blue", reference_images=[ref])
+
+        provider._client.images.edit.assert_awaited_once()
+        kwargs = provider._client.images.edit.call_args.kwargs
+        assert kwargs["model"] == "gpt-image-1"
+        assert isinstance(kwargs["image"], list) and len(kwargs["image"]) == 1
+        # file tuple: (filename, data, content_type)
+        _fname, data, ctype = kwargs["image"][0]
+        assert data == b"png-bytes"
+        assert ctype == "image/png"
+        assert result.provider_metadata.get("edited") is True
+
+    async def test_edit_with_multiple_references(self) -> None:
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(return_value=self._mk_response())
+        refs = [
+            InputImage(data=b"a", content_type="image/png"),
+            InputImage(data=b"b", content_type="image/jpeg"),
+        ]
+        await provider.generate("compose", reference_images=refs)
+        assert len(provider._client.images.edit.call_args.kwargs["image"]) == 2
+
+    async def test_edit_too_many_references_raises(self) -> None:
+        from image_generation_mcp.providers.types import TooManyInputImages
+
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        refs = [InputImage(data=b"x", content_type="image/png") for _ in range(17)]
+        with pytest.raises(TooManyInputImages):
+            await provider.generate("x", reference_images=refs)
+
+    async def test_edit_negative_prompt_appended(self) -> None:
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(return_value=self._mk_response())
+        await provider.generate(
+            "x",
+            negative_prompt="dogs",
+            reference_images=[InputImage(data=b"a", content_type="image/png")],
+        )
+        assert "Avoid: dogs" in provider._client.images.edit.call_args.kwargs["prompt"]

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -473,7 +473,11 @@ class TestOpenAIEdit:
             InputImage(data=b"b", content_type="image/jpeg"),
         ]
         await provider.generate("compose", reference_images=refs)
-        assert len(provider._client.images.edit.call_args.kwargs["image"]) == 2
+        image_arg = provider._client.images.edit.call_args.kwargs["image"]
+        assert len(image_arg) == 2
+        # filenames carry the content-type's extension
+        assert image_arg[0][0].endswith(".png")
+        assert image_arg[1][0].endswith(".jpg")
 
     async def test_edit_too_many_references_raises(self) -> None:
         from image_generation_mcp.providers.types import TooManyInputImages
@@ -517,3 +521,36 @@ class TestOpenAIEdit:
             await provider.generate(
                 "x", reference_images=[InputImage(data=b"a", content_type="image/png")]
             )
+
+    async def test_edit_api_error_is_funneled(self) -> None:
+        from openai import APIConnectionError
+
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(
+            side_effect=APIConnectionError(request=MagicMock())
+        )
+        with pytest.raises(ImageProviderConnectionError):
+            await provider.generate(
+                "x", reference_images=[InputImage(data=b"a", content_type="image/png")]
+            )
+
+    async def test_edit_per_call_dalle_override_rejected(self) -> None:
+        provider = self._mk_provider("gpt-image-1")
+        with pytest.raises(ImageInputUnsupported):
+            await provider.generate(
+                "x",
+                model="dall-e-3",
+                reference_images=[InputImage(data=b"a", content_type="image/png")],
+            )
+
+    async def test_edit_exactly_16_references_accepted(self) -> None:
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.edit = AsyncMock(return_value=self._mk_response())
+        refs = [InputImage(data=b"x", content_type="image/png") for _ in range(16)]
+        await provider.generate("x", reference_images=refs)
+        provider._client.images.edit.assert_awaited_once()
+        assert len(provider._client.images.edit.call_args.kwargs["image"]) == 16

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1775,6 +1775,45 @@ class TestTransformImageTool:
             f"2-image auto request must route to openai (cap 16), got {chosen}"
         )
 
+    async def test_transform_image_auto_no_provider_for_count_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """auto-routing raises when no provider accepts the requested ref count."""
+        svc = ImageService(scratch_dir=tmp_path)
+        svc.register_provider("gemini", PlaceholderImageProvider())
+        svc._capabilities["gemini"] = ProviderCapabilities(
+            provider_name="gemini",
+            models=(
+                ModelCapabilities(
+                    model_id="gemini-flash",
+                    display_name="Gemini",
+                    supports_image_input=True,
+                    max_input_images=1,
+                ),
+            ),
+            discovered_at=1000.0,
+        )
+        ids: list[str] = []
+        for i in range(2):
+            res = await PlaceholderImageProvider().generate(
+                f"src {i}", aspect_ratio="1:1"
+            )
+            ids.append(svc.register_image(res, "gemini", prompt=f"src {i}").id)
+
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("transform_image")
+        assert tool is not None
+        with pytest.raises(ValueError, match="No configured provider accepts"):
+            await tool.fn(
+                prompt="two refs",
+                reference_images=ids,
+                provider="auto",
+                service=svc,
+                config=await self._make_cfg(),
+                ctx=await self._make_ctx(),
+            )
+
     # F1: missing backing file raises ValueError (not raw OSError)
     async def test_transform_image_missing_backing_file_raises_value_error(
         self, tmp_path: Path

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1689,6 +1689,92 @@ class TestTransformImageTool:
             f"Expected auto-routing to select 'fakegen'; got {chosen_provider_name}"
         )
 
+    async def test_transform_image_auto_routes_multi_image_to_higher_cap_provider(
+        self, tmp_path: Path
+    ) -> None:
+        """auto-routing must honor max_input_images for the request's ref count.
+
+        Gemini caps at 1 reference; OpenAI accepts 16. A 2-image auto request
+        must route to OpenAI, not Gemini (which would then reject the count).
+        """
+        svc = ImageService(scratch_dir=tmp_path)
+        svc.register_provider("placeholder", PlaceholderImageProvider())
+        svc.register_provider("gemini", PlaceholderImageProvider())
+        svc.register_provider("openai", PlaceholderImageProvider())
+        svc._capabilities["gemini"] = ProviderCapabilities(
+            provider_name="gemini",
+            models=(
+                ModelCapabilities(
+                    model_id="gemini-flash",
+                    display_name="Gemini",
+                    supports_image_input=True,
+                    max_input_images=1,
+                ),
+            ),
+            discovered_at=1000.0,
+        )
+        svc._capabilities["openai"] = ProviderCapabilities(
+            provider_name="openai",
+            models=(
+                ModelCapabilities(
+                    model_id="gpt-image-1",
+                    display_name="GPT Image 1",
+                    supports_image_input=True,
+                    max_input_images=16,
+                ),
+            ),
+            discovered_at=1000.0,
+        )
+
+        # Two real gallery source images
+        ids: list[str] = []
+        for i in range(2):
+            res = await PlaceholderImageProvider().generate(
+                f"src {i}", aspect_ratio="1:1"
+            )
+            ids.append(svc.register_image(res, "placeholder", prompt=f"src {i}").id)
+
+        stub_result = await PlaceholderImageProvider().generate("x", aspect_ratio="1:1")
+        chosen: list[str] = []
+
+        async def _fake_generate(
+            *_args: object, **kwargs: object
+        ) -> tuple[str, ImageResult]:
+            chosen.append(str(kwargs.get("provider")))
+            return "openai", stub_result
+
+        svc.generate = AsyncMock(side_effect=_fake_generate)  # type: ignore[assignment]
+
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("transform_image")
+        assert tool is not None
+        ctx = await self._make_ctx()
+        cfg = await self._make_cfg()
+
+        result = await tool.fn(
+            prompt="compose two",
+            reference_images=ids,
+            provider="auto",
+            service=svc,
+            config=cfg,
+            ctx=ctx,
+        )
+        metadata = json.loads(
+            next(c for c in result.content if isinstance(c, TextContent)).text
+        )
+        image_id = metadata["image_id"]
+        pending = None
+        for _ in range(100):
+            pending = svc.get_pending(image_id)
+            if pending and pending.status in ("completed", "failed"):
+                break
+            await asyncio.sleep(0.02)
+        assert pending is not None and pending.status == "completed"
+        assert chosen == ["openai"], (
+            f"2-image auto request must route to openai (cap 16), got {chosen}"
+        )
+
     # F1: missing backing file raises ValueError (not raw OSError)
     async def test_transform_image_missing_backing_file_raises_value_error(
         self, tmp_path: Path


### PR DESCRIPTION
## OpenAI gpt-image image editing and composition

Closes #258. Part of epic #256 (Refs #256).

Adds reference-image input for the OpenAI provider via the `images.edit` endpoint, so `transform_image` now supports OpenAI **image-to-image edits and multi-image composition** (up to 16 references) on the gpt-image family, alongside the existing Gemini support.

### What this delivers
- **OpenAI `_edit()` path** — when `reference_images` are supplied, the gpt-image family (gpt-image-2 / 1.5 / 1 / 1-mini) routes to `images.edit` with the references as file tuples; up to 16 references for composition. dall-e-3 / dall-e-2 raise `ImageInputUnsupported` (no no-mask reference edit). More than 16 raises `TooManyInputImages`.
- **Shared `_gpt_image_request()` helper** — request-building (size, quality mapping, output_format, background) is factored out so `generate()` and `_edit()` don't duplicate it.
- **Capability metadata** — `supports_image_input=True` / `max_input_images=16` on the four gpt-image models (surfaced via `list_providers`).
- **Count-aware auto-routing** — `transform_image` with `provider="auto"` now selects a provider whose model accepts the request's reference count (Gemini caps at 1, OpenAI at 16), so a multi-image auto request routes to OpenAI instead of failing on Gemini.

### Scope
- Multi-image composition for OpenAI is included (the API natively accepts up to 16). #260 remains Gemini-specific composition.
- Masks remain out of scope (tracked by #261). The `transform_image` tool does not send a mask; the endpoint's mask capability is reflected by `supports_mask` in `list_providers`.
- No `transform_image` tool-shape changes beyond the auto-routing fix; it was already capability-routed.

### Tests & gates
- 951 tests pass (Python 3.11–3.14), ruff + mypy clean, mkdocs builds, docs Vale-clean on changed lines.
- New coverage: single + multi reference reach `images.edit` with correct file tuples and extensions; `TooManyInputImages` at >16 and exactly-16 accepted; `ImageInputUnsupported` for dall-e (constructor and per-call override); edit-path API-error funnel; empty/missing-b64 response guards; capability fields on the four gpt-image models (and absence on dall-e); multi-image auto-routes to the higher-capacity provider; the text-to-image path is unchanged after the `_gpt_image_request` refactor.

### Docs
`docs/providers/openai.md` (image input section) and `docs/tools.md` (transform_image now lists OpenAI + 16-ref composition).

### Review
Local: per-task reviews, an opus whole-branch review, and a full preflight-circus pass; the one real finding (multi-image auto-routing) is fixed with a dedicated regression test, and the doc/test cluster was closed comprehensively. Vale shows red only on pre-existing `docs/providers/openai.md` content (the known #244 gate, non-blocking; main unprotected) — this PR adds no new Vale errors on its changed lines. Bots have not yet reviewed the pushed commit; not a merge-ready signal.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
