### PR TITLE
feat: SD WebUI img2img + denoising strength (#259)

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -50,11 +50,13 @@ check_generation_status
 create_download_link
 delete_image
 delete_style
+denoising
 downscaled
 edit_image
 frontmatter
 gallery_full_image
 generate_image
+img2img
 inpainting
 lightbox
 Lightbox
@@ -69,4 +71,5 @@ sandboxed
 save_style
 show_image
 transform_image
+txt2img
 webchat

--- a/docs/design/2026-06-27-sd-img2img-plan.md
+++ b/docs/design/2026-06-27-sd-img2img-plan.md
@@ -1,0 +1,290 @@
+# SD WebUI img2img + denoising strength (Issue #259) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Implement reference-image input for the SD WebUI provider via the `/sdapi/v1/img2img` endpoint, and add a `strength` (denoising) parameter to `transform_image` that only SD uses.
+
+**Architecture:** The foundation already threads `reference_images` through `ImageProvider.generate()`, the `transform_image` tool, and the capability model. SD WebUI currently *rejects* `reference_images`. This issue (1) threads a new optional `strength: float` param through the same path (protocol → service → `_start_background_generation` → tool), which only SD consumes (others ignore with a debug log); and (2) implements SD's img2img path with `init_images` + `denoising_strength`, advertising `supports_image_input` / `max_input_images=1`.
+
+**Tech Stack:** Python 3.11+, httpx (SD WebUI REST API), pytest (httpx mocked), uv, ruff, mypy.
+
+## Global Constraints
+
+- Python 3.11+; full type hints; Google-style docstrings.
+- `logging.getLogger(__name__)`; no f-strings in log calls (lazy `%s`, event-name-first); no bare `except`.
+- Hard gates before push: `uv run pytest -x -q`; `uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .`; `uv run mypy src/ tests/`; patch coverage ≥ 80%; docs updated.
+- TDD: failing test first → implement → pass → commit. Conventional commits with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+- **SD WebUI img2img API** (A1111/Forge `/sdapi/v1/img2img`): same payload as `txt2img` PLUS `init_images` (list of base64-encoded image strings, no data: prefix) and `denoising_strength` (float 0–1, A1111 default 0.75). Response shape is identical to txt2img (`data["images"][0]` base64, `data["info"]`).
+- **`strength` is SD-specific.** Range 0–1. Default 0.75 when unset. Non-SD providers ignore it (debug log when set). It only takes effect with `reference_images` (img2img); txt2img ignores it.
+
+## Scope decisions
+- SD img2img uses a single init image → `max_input_images=1`; >1 raises `TooManyInputImages`.
+- `strength` is added to `transform_image` and threaded through the provider protocol (matching the `reference_images` precedent), consumed only by SD.
+- No mask support (that is OpenAI #261). No SD inpainting.
+
+---
+
+## File Structure
+
+- **Modify** `src/image_generation_mcp/providers/types.py` — add `strength: float | None = None` to the `ImageProvider.generate()` protocol signature + docstring.
+- **Modify** `src/image_generation_mcp/service.py` — add `strength` to `ImageService.generate()`, pass through to the provider.
+- **Modify** `src/image_generation_mcp/_server_tools.py` — add `strength` to `_start_background_generation` (pass-through) and to the `transform_image` tool (with 0–1 validation), thread to `service.generate`.
+- **Modify** `src/image_generation_mcp/providers/gemini.py`, `providers/openai.py`, `providers/placeholder.py` — accept `strength`; ignore with a debug log when set.
+- **Modify** `src/image_generation_mcp/providers/sd_webui.py` — extract a shared payload builder; add the img2img path (`reference_images` → `/sdapi/v1/img2img` with `init_images` + `denoising_strength`); advertise `supports_image_input` / `max_input_images=1`; consume `strength`.
+- **Tests:** `tests/test_tools.py`, `tests/test_sd_webui_provider.py`, `tests/test_sd_webui_discovery.py`, `tests/test_gemini_provider.py`, `tests/test_openai_provider.py`, `tests/test_placeholder.py`, `tests/test_service.py`.
+- **Docs:** `docs/providers/sd-webui.md`, `docs/tools.md`.
+
+---
+
+## Task 1: Thread `strength` through the protocol, service, tool, and non-SD providers
+
+**Files:**
+- Modify: `providers/types.py`, `service.py`, `_server_tools.py`, `providers/gemini.py`, `providers/openai.py`, `providers/placeholder.py`
+- Test: `tests/test_tools.py`, `tests/test_service.py`, `tests/test_gemini_provider.py`, `tests/test_openai_provider.py`, `tests/test_placeholder.py`
+
+**Interfaces:**
+- Produces: `strength: float | None = None` on `ImageProvider.generate()`, `ImageService.generate()`, `_start_background_generation(...)`, and the `transform_image` tool. The tool validates `0.0 <= strength <= 1.0` (else `ValueError`). gemini/openai/placeholder accept and ignore it (debug log when not None). SD accepts it (consumed in Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_tools.py` (`TestTransformImageTool`), add strength-validation tests (mirror the existing param-validation tests; an out-of-range strength must raise before enqueue):
+
+```python
+@pytest.mark.parametrize("bad", [-0.1, 1.5, 2.0])
+async def test_transform_image_rejects_out_of_range_strength(
+    self, service: ImageService, bad: float
+) -> None:
+    # service fixture: placeholder only (no image-input) is fine — validation
+    # happens before provider routing. Use an image-input-capable service so we
+    # reach the strength check; simplest: inject a capable provider like the
+    # other transform tests, then assert ValueError on bad strength.
+    ...
+```
+
+> Implementer: reach the strength validation by using the same image-input-capable harness as the other `transform_image` tests (inject a fake provider with `supports_image_input=True` via `service._capabilities`, register one gallery image). Place the `strength` range check in the tool right after the existing enum validations and assert `pytest.raises(ValueError, match="strength")` for each bad value.
+
+In `tests/test_gemini_provider.py`, `tests/test_openai_provider.py`, `tests/test_placeholder.py` add one test each that passing `strength` to a non-SD provider's `generate()` is accepted and ignored (no error). Example (placeholder):
+
+```python
+async def test_placeholder_ignores_strength() -> None:
+    from image_generation_mcp.providers.placeholder import PlaceholderImageProvider
+
+    result = await PlaceholderImageProvider().generate("x", strength=0.5)
+    assert result.image_data  # produced normally, strength ignored
+```
+
+For gemini/openai, mirror an existing successful-generate test in that file but pass `strength=0.5` and assert it still returns an ImageResult (the SDK call is mocked; strength must not be forwarded to the SDK kwargs — assert it is absent from the call kwargs).
+
+In `tests/test_service.py`, add a test that `ImageService.generate(..., strength=0.5)` forwards `strength=0.5` to the provider (AsyncMock fake): `assert fake.generate.call_args.kwargs["strength"] == 0.5`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_tools.py -k strength tests/test_service.py -k strength tests/test_placeholder.py -k strength -v`
+Expected: FAIL — `generate()`/tool don't accept `strength` yet (`TypeError: unexpected keyword argument 'strength'`).
+
+- [ ] **Step 3: Implement the plumbing**
+
+**`providers/types.py`** — in the `ImageProvider.generate()` protocol signature, add before `progress_callback`:
+```python
+        strength: float | None = None,
+```
+Document it:
+```
+            strength: Denoising strength (0.0–1.0) for image-to-image. Only
+                SD WebUI uses it (as ``denoising_strength``); other providers
+                ignore it. Has no effect without ``reference_images``.
+```
+
+**`service.py`** — add `strength: float | None = None` to `ImageService.generate()` (before `progress_callback`), document it, and pass `strength=strength` to `resolved_provider.generate(...)`.
+
+**`_server_tools.py`** — add `strength: float | None = None` to `_start_background_generation(...)` and forward it in its `service.generate(...)` call. In the `transform_image` tool, add `strength: float | None = None` to the signature, validate after the other enum checks:
+```python
+        if strength is not None and not 0.0 <= strength <= 1.0:
+            raise ValueError(
+                f"strength must be between 0.0 and 1.0; got {strength}."
+            )
+```
+and pass `strength=strength` into `_start_background_generation(...)`. Document the param in the tool docstring (SD-only denoising; 0–1; no effect without an SD provider / reference images).
+
+**`gemini.py`, `openai.py`, `placeholder.py`** — add `strength: float | None = None` to each `generate()` signature (before `progress_callback`). At the top of each body (after any existing reference-image handling), add:
+```python
+        if strength is not None:
+            logger.debug("strength is not supported by <provider>; ignoring")
+```
+Use the provider's name. Do NOT forward `strength` to the underlying SDK/API kwargs. (openai/gemini: place after the reference-image dispatch/guard so the edit path is unaffected; openai's `_edit` does not take strength.)
+
+**`sd_webui.py`** — add `strength: float | None = None` to `generate()` (before `progress_callback`). For this task SD does not yet use it (no img2img). Add a `# noqa: ARG002`-free placeholder: keep the param; Task 2 consumes it. (To avoid an unused-arg lint error now, Task 1 may leave a `# noqa: ARG002` on `strength` that Task 2 removes — OR sequence so Task 2 immediately follows. Prefer: Task 1 adds `strength` to sd_webui with `# noqa: ARG002`; Task 2 removes the noqa when it wires img2img.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_tools.py tests/test_service.py tests/test_gemini_provider.py tests/test_openai_provider.py tests/test_placeholder.py -q`
+Expected: PASS (new strength tests + existing tests unchanged).
+
+- [ ] **Step 5: Full gates + commit**
+
+```bash
+uv run pytest -x -q
+uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .
+uv run mypy src/ tests/
+git add src/image_generation_mcp/ tests/
+git commit -m "feat: thread strength (denoising) param through transform_image; non-SD providers ignore it
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: SD WebUI img2img path + capability
+
+**Files:**
+- Modify: `src/image_generation_mcp/providers/sd_webui.py`
+- Test: `tests/test_sd_webui_provider.py`, `tests/test_sd_webui_discovery.py`
+
+**Interfaces:**
+- Consumes: `strength` (Task 1), `InputImage`, `TooManyInputImages`, `_MAX_INPUT_IMAGES`.
+- Produces: SD `generate()` routes to img2img when `reference_images` is non-empty; advertises `supports_image_input=True, max_input_images=1` on every checkpoint.
+
+Behavior contract:
+1. `reference_images` empty/None → existing txt2img behavior, unchanged.
+2. `reference_images` non-empty: `len > 1` → `TooManyInputImages("sd_webui", effective_model, 1, len)`; build the shared payload + `init_images=[base64(ref.data)]` + `denoising_strength=strength if strength is not None else 0.75`; POST `/sdapi/v1/img2img`; parse the response identically to txt2img; metadata `edited=True`.
+3. Capability: `supports_image_input=True, max_input_images=1` on each checkpoint.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_sd_webui_provider.py` (mirror the existing txt2img test mocking — it patches `provider._client.post` / uses an httpx mock; follow the file's pattern):
+
+```python
+async def test_img2img_with_reference_calls_img2img_endpoint() -> None:
+    # provider = SdWebuiImageProvider(host="http://localhost:7860")
+    # mock client.post to return 200 with {"images": ["<b64>"], "info": "{}"}
+    # call generate("edit", reference_images=[InputImage(data=b"...", content_type="image/png")], strength=0.4)
+    # assert the POST url ends with /sdapi/v1/img2img
+    # assert payload["init_images"] == [base64.b64encode(b"...").decode()]
+    # assert payload["denoising_strength"] == 0.4
+    ...
+
+async def test_img2img_default_denoising_when_strength_none() -> None:
+    # same, strength=None → payload["denoising_strength"] == 0.75
+
+async def test_img2img_too_many_references_raises() -> None:
+    # two refs → TooManyInputImages
+
+async def test_txt2img_unaffected_by_strength_without_references() -> None:
+    # generate("x", strength=0.3) with no reference_images → posts to /txt2img,
+    # payload has no init_images / denoising_strength
+```
+
+> Use the real base64 of small bytes; mock the HTTP client the same way the existing SD tests do (inspect `tests/test_sd_webui_provider.py` for the exact mock pattern — likely `respx` or a `MagicMock`/`AsyncMock` on `provider._client.post` returning an object with `.status_code` and `.json()`).
+
+In `tests/test_sd_webui_discovery.py`, assert each discovered checkpoint reports `supports_image_input is True` and `max_input_images == 1`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_sd_webui_provider.py -k img2img tests/test_sd_webui_discovery.py -k image_input -v`
+Expected: FAIL — SD still raises `ImageInputUnsupported` for reference_images; capability fields are default False/0.
+
+- [ ] **Step 3: Implement**
+
+Add a module constant near the top: `_MAX_INPUT_IMAGES = 1` and `_DEFAULT_DENOISING_STRENGTH = 0.75`. Import `TooManyInputImages` from `.types`. Add `import base64`.
+
+Extract a shared payload builder so txt2img and img2img don't duplicate it:
+```python
+    def _build_payload(
+        self,
+        *,
+        prompt: str,
+        negative_prompt: str | None,
+        aspect_ratio: str,
+        effective_model: str | None,
+        preset: _SdWebuiPreset,
+    ) -> tuple[dict[str, Any], int, int]:
+        """Build the shared SD WebUI request payload; returns (payload, w, h)."""
+        # (move the current width/height + payload + negative + distilled_cfg +
+        #  override_settings construction from generate() into here, returning
+        #  the payload dict and the width/height for metadata/progress.)
+```
+Refactor the existing txt2img `generate()` body to call `_build_payload` (no behavior change to txt2img).
+
+Replace the `if reference_images: raise ImageInputUnsupported(...)` guard with a dispatch: when `reference_images` is non-empty, build the payload via `_build_payload`, then:
+```python
+        if reference_images:
+            if len(reference_images) > _MAX_INPUT_IMAGES:
+                raise TooManyInputImages(
+                    "sd_webui", effective_model, _MAX_INPUT_IMAGES,
+                    len(reference_images),
+                )
+            payload["init_images"] = [
+                base64.b64encode(reference_images[0].data).decode("ascii")
+            ]
+            payload["denoising_strength"] = (
+                strength if strength is not None else _DEFAULT_DENOISING_STRENGTH
+            )
+            url = f"{self._host}/sdapi/v1/img2img"
+        else:
+            url = f"{self._host}/sdapi/v1/txt2img"
+```
+Keep the existing POST / error handling / response parsing (it is endpoint-agnostic). Add `edited=True` to the metadata when img2img is used. Remove the `# noqa: ARG002` from `strength` (now used). Update the `generate()` docstring (`reference_images` now does img2img; `strength` is denoising).
+
+In `discover_capabilities`, add to each `ModelCapabilities(...)`:
+```python
+                    supports_image_input=True,
+                    max_input_images=_MAX_INPUT_IMAGES,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_sd_webui_provider.py tests/test_sd_webui_discovery.py -q`
+Expected: PASS (img2img tests + capability + existing txt2img tests unchanged).
+
+- [ ] **Step 5: Full gates + commit**
+
+```bash
+uv run pytest -x -q
+uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .
+uv run mypy src/ tests/
+git add src/image_generation_mcp/providers/sd_webui.py tests/test_sd_webui_provider.py tests/test_sd_webui_discovery.py
+git commit -m "feat(sd_webui): img2img reference-image input with denoising strength
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Documentation
+
+**Files:**
+- Modify: `docs/providers/sd-webui.md`, `docs/tools.md`
+
+- [ ] **Step 1: Document**
+
+In `docs/providers/sd-webui.md`, add an "Image input (img2img)" section: any discovered checkpoint accepts a single reference image via `transform_image` (img2img); the `strength` parameter maps to `denoising_strength` (0–1, default 0.75; lower preserves the init image, higher regenerates more). `supports_image_input` / `max_input_images=1` appear in `list_providers`.
+
+In `docs/tools.md`, document the new `strength` parameter on `transform_image`: SD-WebUI-only denoising strength (0–1); ignored by Gemini and OpenAI; no effect without a reference image.
+
+**Vale-clean** (site docs): no em-dashes (use commas/parentheses), no "e.g."/"i.e." (write "for example"/"that is"), no "**Note:**" metacommentary, no three-parallel-verb lists. Run `vale sync` then `vale --minAlertLevel=error docs/providers/sd-webui.md docs/tools.md` and fix errors on added lines; add genuine terms to `.vale/styles/config/vocabularies/Base/accept.txt` if needed.
+
+- [ ] **Step 2: Verify + commit**
+
+```bash
+uv run mkdocs build 2>&1 | tail -5
+vale --minAlertLevel=error docs/providers/sd-webui.md docs/tools.md
+git add docs/providers/sd-webui.md docs/tools.md
+git commit -m "docs: document SD WebUI img2img and the strength parameter
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Pre-PR verification
+
+- [ ] `uv run pytest -x -q` pass; ruff/format clean; `uv run mypy src/ tests/` clean.
+- [ ] `uv run pytest --cov=image_generation_mcp.providers.sd_webui --cov=image_generation_mcp._server_tools --cov-report=term-missing` — patch coverage ≥ 80% (img2img path, both denoising branches, TooManyInputImages, strength validation, non-SD ignore).
+- [ ] Grep for any provider-name-hardcoded user-facing string introduced (lesson from #263/#265); keep messages provider-neutral where appropriate.
+- [ ] Run `preflight-circus` against `BASE..HEAD` before `gh pr create`.
+- [ ] PR body: `Closes #259`, `Refs #256`, agent-attribution signature; note Vale red is the known #244 gate (non-blocking) if it shows on the new plan doc / pre-existing content.
+
+## Self-Review notes (author)
+- `strength` threaded exactly like `reference_images` (protocol → service → helper → tool), consumed only by SD; non-SD ignore-with-log. Tool validates 0–1.
+- `_build_payload` extraction prevents txt2img/img2img duplication (pre-empts the DRY finding pattern seen on #258/#263).
+- Type consistency: `strength: float | None`, `_MAX_INPUT_IMAGES = 1`, `_DEFAULT_DENOISING_STRENGTH = 0.75`, `init_images=[b64]`, metadata `edited=True`.

--- a/docs/providers/sd-webui.md
+++ b/docs/providers/sd-webui.md
@@ -159,6 +159,14 @@ generate_image(prompt="...", provider="sd_webui", model="dreamshaperXL_v21.safet
 
 Use `list_providers` to discover available checkpoints and their model IDs.
 
+## Image input (img2img)
+
+Any discovered SD WebUI checkpoint accepts a single reference image through the `transform_image` tool. When a reference image is supplied, the provider calls `/sdapi/v1/img2img` instead of `/sdapi/v1/txt2img`.
+
+The `strength` parameter controls `denoising_strength` in the SD WebUI API payload. Values range from 0.0 to 1.0 (default 0.75 when omitted). Lower values preserve more of the reference image; higher values allow the model to regenerate more of the output.
+
+`list_providers` reports `supports_image_input: true` and `max_input_images: 1` for every discovered checkpoint. Pass exactly one reference image; passing more than one returns an error.
+
 ## Background transparency
 
 The `background` parameter is **not supported** by SD WebUI. When `background="transparent"` is passed, it is silently ignored (a debug log is emitted). Stable Diffusion does not natively support transparent background generation.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -110,14 +110,14 @@ Edit or transform an existing image using a model that accepts image input (imag
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | str | *(required)* | Description of the desired edit or transformation (natural language) |
-| `reference_images` | list[str] | *(required)* | One or more gallery `image_id` values, `image://` URIs, or (when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`) local file paths to use as source images; Gemini supports one reference image per call, OpenAI gpt-image models support up to 16 (multi-image composition); check `max_input_images` in `list_providers` |
-| `provider` | str | `"auto"` | Provider to use, or `"auto"`. Use a Gemini or OpenAI provider for image-to-image tasks; check `supports_image_input` in `list_providers` |
+| `reference_images` | list[str] | *(required)* | One or more gallery `image_id` values, `image://` URIs, or (when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`) local file paths to use as source images; check `max_input_images` in `list_providers` for each provider's reference-count limit (some accept one, others up to 16 for composition) |
+| `provider` | str | `"auto"` | Provider to use, or `"auto"`. Image-to-image needs a provider that reports `supports_image_input` in `list_providers` |
 | `negative_prompt` | str | `null` | Things to avoid in the result (provider support varies) |
 | `aspect_ratio` | str | `"1:1"` | Desired aspect ratio of the output image |
 | `quality` | str | `"standard"` | Quality level: `standard` or `hd` |
 | `background` | str | `"opaque"` | Background mode: `opaque` or `transparent` (provider-dependent) |
 | `model` | str | `null` | Specific model ID; see `list_providers` |
-| `strength` | float | `null` | SD WebUI only: denoising strength for image-to-image (0.0 to 1.0, default 0.75 when omitted). Lower values preserve more of the reference image; higher values regenerate more. Ignored by Gemini and OpenAI. Has no effect without a reference image. |
+| `strength` | float | `null` | SD WebUI only: denoising strength for image-to-image (0.0 to 1.0, default 0.75 when omitted). Lower values preserve more of the reference image; higher values regenerate more. Other providers ignore it. Has no effect without a reference image. |
 
 ### Reference image input forms
 
@@ -127,7 +127,7 @@ Each entry in `reference_images` is resolved in order:
 2. **`image://` URI**: a full resource URI, such as `"image://a1b2c3d4e5f6/view"`.
 3. **Local file path**: absolute path on the server host, such as `"/home/user/photo.png"`. Only accepted when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`; rejected with an error otherwise.
 
-Call `list_providers` and inspect `supports_image_input` and `max_input_images` on each model to confirm which provider can handle your input count. Gemini supports one reference image per call. OpenAI gpt-image models (`gpt-image-1`, `gpt-image-1.5`, `gpt-image-1-mini`, `gpt-image-2`) support up to 16 reference images for multi-image composition. `dall-e-3` and `dall-e-2` do not accept reference images.
+Call `list_providers` and inspect `supports_image_input` and `max_input_images` on each model to confirm which provider can handle your input count. Gemini and SD WebUI support one reference image per call. OpenAI gpt-image models (`gpt-image-1`, `gpt-image-1.5`, `gpt-image-1-mini`, `gpt-image-2`) support up to 16 reference images for multi-image composition. `dall-e-3` and `dall-e-2` do not accept reference images.
 
 ### Return value
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -117,6 +117,7 @@ Edit or transform an existing image using a model that accepts image input (imag
 | `quality` | str | `"standard"` | Quality level: `standard` or `hd` |
 | `background` | str | `"opaque"` | Background mode: `opaque` or `transparent` (provider-dependent) |
 | `model` | str | `null` | Specific model ID; see `list_providers` |
+| `strength` | float | `null` | SD WebUI only: denoising strength for image-to-image (0.0 to 1.0, default 0.75 when omitted). Lower values preserve more of the reference image; higher values regenerate more. Ignored by Gemini and OpenAI. Has no effect without a reference image. |
 
 ### Reference image input forms
 

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -580,11 +580,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             background: ``"opaque"`` or ``"transparent"``
                 (provider-dependent).
             model: Specific model id; see ``list_providers``.
-            strength: Denoising strength for image-to-image generation
-                (0.0-1.0, where 1.0 ignores the reference image entirely
-                and 0.0 changes nothing). Only used by SD WebUI; Gemini
-                and OpenAI ignore this parameter. Has no effect without
-                an SD WebUI provider.
+            strength: Denoising strength for SD WebUI img2img (0.0-1.0,
+                where higher regenerates more and lower preserves the
+                reference image). Used only by SD WebUI and only with a
+                reference image; other providers and the text-to-image
+                path ignore it.
 
         Returns:
             JSON with ``status``, ``image_id``, ``original_uri`` (pending).

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -651,8 +651,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         # accepts at least len(resolved) references, so auto-selection cannot
         # pick a provider that would then reject this request's reference count
         # (Gemini and SD WebUI cap at 1; OpenAI accepts up to 16). Prefer
-        # Gemini among the eligible providers (higher-quality edits); otherwise
-        # the first eligible provider alphabetically for determinism.
+        # Gemini among the eligible providers (higher-quality edits); the
+        # explicit check keeps that preference robust if a future provider
+        # would otherwise sort ahead of "gemini". Else pick the first eligible
+        # provider alphabetically for determinism.
         if provider == "auto":
             eligible = sorted(
                 name

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -547,11 +547,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         Supply one or more reference images (gallery ``image_id``, an
         ``image://`` URI, or — when enabled — a local file path) plus a
-        prompt describing the change.  Served by providers that report
-        ``supports_image_input`` in ``list_providers`` (Gemini accepts one
-        reference image; OpenAI gpt-image models accept up to 16 for
-        multi-image composition); check ``supports_image_input`` /
-        ``max_input_images`` there to route.
+        prompt describing the change.  Served by any provider that reports
+        ``supports_image_input`` in ``list_providers``; each provider's
+        ``max_input_images`` there gives its reference-image limit (some
+        accept one, others up to 16 for multi-image composition).
 
         Returns immediately; poll ``check_generation_status(image_id)``
         and then ``show_image(uri=original_uri)`` once completed — same
@@ -571,9 +570,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 ``IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true``) local
                 file paths to use as the source image(s).
             provider: Provider to use, or ``"auto"`` to select
-                automatically.  Image-to-image is served by providers that
-                report ``supports_image_input`` in ``list_providers``
-                (Gemini, one reference image; OpenAI gpt-image, up to 16).
+                automatically.  Image-to-image is served by any provider that
+                reports ``supports_image_input`` in ``list_providers``; check
+                ``max_input_images`` there for each provider's reference limit.
             negative_prompt: Things to avoid in the result (provider
                 support varies).
             aspect_ratio: Desired aspect ratio of the output image.
@@ -651,9 +650,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         # whose capabilities include a model that supports image input AND
         # accepts at least len(resolved) references, so auto-selection cannot
         # pick a provider that would then reject this request's reference count
-        # (Gemini caps at 1; OpenAI accepts up to 16). Prefer Gemini among the
-        # eligible providers (higher-quality edits); otherwise the first
-        # eligible provider alphabetically for determinism.
+        # (Gemini and SD WebUI cap at 1; OpenAI accepts up to 16). Prefer
+        # Gemini among the eligible providers (higher-quality edits); otherwise
+        # the first eligible provider alphabetically for determinism.
         if provider == "auto":
             eligible = sorted(
                 name

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -168,6 +168,7 @@ def _start_background_generation(
     background: str,
     model: str | None,
     reference_images: Sequence[InputImage] | None = None,
+    strength: float | None = None,
     source_image_ids: list[str] | None = None,
     label: str = "generation",
 ) -> None:
@@ -188,6 +189,9 @@ def _start_background_generation(
         background: Background transparency (``"opaque"`` or ``"transparent"``).
         model: Specific model override, or ``None``.
         reference_images: Optional reference images for image-to-image tasks.
+        strength: Denoising strength (0.0-1.0) for image-to-image. Forwarded
+            to the provider; only SD WebUI uses it. Has no effect without
+            ``reference_images``.
         source_image_ids: Optional list of source image IDs to record as
             provenance on the resulting :class:`ImageRecord`.
         label: Short label used in log messages (e.g. ``"generation"`` or
@@ -227,6 +231,7 @@ def _start_background_generation(
                 background=background,
                 model=model,
                 reference_images=reference_images,
+                strength=strength,
                 progress_callback=_on_progress,
             )
             await asyncio.to_thread(
@@ -533,6 +538,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         quality: str = "standard",
         background: str = "opaque",
         model: str | None = None,
+        strength: float | None = None,
         service: ImageService = Depends(get_service),
         config: ProjectConfig = Depends(get_config),
         ctx: Context = CurrentContext(),
@@ -575,6 +581,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             background: ``"opaque"`` or ``"transparent"``
                 (provider-dependent).
             model: Specific model id; see ``list_providers``.
+            strength: Denoising strength for image-to-image generation
+                (0.0-1.0, where 1.0 ignores the reference image entirely
+                and 0.0 changes nothing). Only used by SD WebUI; Gemini
+                and OpenAI ignore this parameter. Has no effect without
+                an SD WebUI provider.
 
         Returns:
             JSON with ``status``, ``image_id``, ``original_uri`` (pending).
@@ -601,6 +612,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             raise ValueError(msg)
         if not reference_images:
             raise ValueError("reference_images must not be empty.")
+        if strength is not None and not 0.0 <= strength <= 1.0:
+            raise ValueError(f"strength must be between 0.0 and 1.0; got {strength}.")
         if not _any_provider_supports_image_input(service):
             raise ValueError(
                 "No configured provider supports reference-image input. "
@@ -716,6 +729,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             background=background,
             model=model,
             reference_images=resolved,
+            strength=strength,
             source_image_ids=source_ids,
             label="transform",
         )

--- a/src/image_generation_mcp/providers/gemini.py
+++ b/src/image_generation_mcp/providers/gemini.py
@@ -162,7 +162,7 @@ class GeminiImageProvider:
         from google.genai import types
 
         if strength is not None:
-            logger.debug("strength is not supported by gemini; ignoring")
+            logger.debug("strength_ignored provider=gemini reason=unsupported")
 
         if aspect_ratio not in _ASPECT_RATIOS:
             raise ImageProviderError(

--- a/src/image_generation_mcp/providers/gemini.py
+++ b/src/image_generation_mcp/providers/gemini.py
@@ -125,6 +125,7 @@ class GeminiImageProvider:
         background: str = "opaque",
         model: str | None = None,
         reference_images: Sequence[InputImage] | None = None,
+        strength: float | None = None,
         progress_callback: ProgressCallback | None = None,  # noqa: ARG002
     ) -> ImageResult:
         """Generate an image using the Gemini generateContent API.
@@ -146,6 +147,7 @@ class GeminiImageProvider:
                 passing more than one raises ``TooManyInputImages``.
                 When provided, the image bytes are sent as inline image parts
                 alongside the prompt for guided generation.
+            strength: Ignored — Gemini does not support denoising strength.
             progress_callback: Ignored — Gemini does not report progress.
 
         Returns:
@@ -158,6 +160,9 @@ class GeminiImageProvider:
             TooManyInputImages: If more than one reference image is supplied.
         """
         from google.genai import types
+
+        if strength is not None:
+            logger.debug("strength is not supported by gemini; ignoring")
 
         if aspect_ratio not in _ASPECT_RATIOS:
             raise ImageProviderError(

--- a/src/image_generation_mcp/providers/openai.py
+++ b/src/image_generation_mcp/providers/openai.py
@@ -266,7 +266,7 @@ class OpenAIImageProvider:
             TooManyInputImages: When more than 16 reference_images are given.
         """
         if strength is not None:
-            logger.debug("strength is not supported by openai; ignoring")
+            logger.debug("strength_ignored provider=openai reason=unsupported")
 
         if reference_images:
             return await self._edit(

--- a/src/image_generation_mcp/providers/openai.py
+++ b/src/image_generation_mcp/providers/openai.py
@@ -229,6 +229,7 @@ class OpenAIImageProvider:
         background: str = "opaque",
         model: str | None = None,
         reference_images: Sequence[InputImage] | None = None,
+        strength: float | None = None,
         progress_callback: ProgressCallback | None = None,  # noqa: ARG002
     ) -> ImageResult:
         """Generate an image via OpenAI Images API.
@@ -251,6 +252,7 @@ class OpenAIImageProvider:
                 :class:`ImageInputUnsupported` for dall-e models (no
                 no-mask edit endpoint). Raises :class:`TooManyInputImages`
                 when more than 16 references are supplied.
+            strength: Ignored — OpenAI does not support denoising strength.
 
         Returns:
             ImageResult with generated image.
@@ -263,6 +265,9 @@ class OpenAIImageProvider:
                 non-gpt-image model (dall-e or unknown).
             TooManyInputImages: When more than 16 reference_images are given.
         """
+        if strength is not None:
+            logger.debug("strength is not supported by openai; ignoring")
+
         if reference_images:
             return await self._edit(
                 prompt,

--- a/src/image_generation_mcp/providers/placeholder.py
+++ b/src/image_generation_mcp/providers/placeholder.py
@@ -110,6 +110,7 @@ class PlaceholderImageProvider:
         background: str = "opaque",
         model: str | None = None,
         reference_images: Sequence[InputImage] | None = None,
+        strength: float | None = None,
         progress_callback: ProgressCallback | None = None,  # noqa: ARG002
     ) -> ImageResult:
         """Generate a placeholder PNG.
@@ -124,6 +125,7 @@ class PlaceholderImageProvider:
             model: Ignored by the placeholder provider.
             reference_images: Not supported by this provider. Raises
                 :class:`ImageInputUnsupported` when non-empty.
+            strength: Ignored by the placeholder provider.
 
         Returns:
             ImageResult with a solid-color PNG.
@@ -133,6 +135,8 @@ class PlaceholderImageProvider:
         """
         if reference_images:
             raise ImageInputUnsupported("placeholder", model)
+        if strength is not None:
+            logger.debug("strength is not supported by placeholder; ignoring")
         if model is not None:
             logger.debug("Placeholder provider ignores model parameter: %r", model)
         if aspect_ratio not in _ASPECT_RATIO_TO_SIZE:

--- a/src/image_generation_mcp/providers/placeholder.py
+++ b/src/image_generation_mcp/providers/placeholder.py
@@ -136,7 +136,7 @@ class PlaceholderImageProvider:
         if reference_images:
             raise ImageInputUnsupported("placeholder", model)
         if strength is not None:
-            logger.debug("strength is not supported by placeholder; ignoring")
+            logger.debug("strength_ignored provider=placeholder reason=unsupported")
         if model is not None:
             logger.debug("Placeholder provider ignores model parameter: %r", model)
         if aspect_ratio not in _ASPECT_RATIO_TO_SIZE:

--- a/src/image_generation_mcp/providers/sd_webui.py
+++ b/src/image_generation_mcp/providers/sd_webui.py
@@ -340,9 +340,8 @@ class SdWebuiImageProvider:
             preset=effective_preset,
         )
 
-        is_img2img = bool(reference_images)
-        if strength is not None and not is_img2img:
-            logger.debug("strength_ignored reason=no_reference_images endpoint=txt2img")
+        # Branch on ``reference_images`` directly (not a precomputed bool) so
+        # mypy narrows ``Sequence | None`` to non-None inside the img2img block.
         if reference_images:
             if len(reference_images) > _MAX_INPUT_IMAGES:
                 raise TooManyInputImages(
@@ -359,7 +358,13 @@ class SdWebuiImageProvider:
             )
             url = f"{self._host}/sdapi/v1/img2img"
         else:
+            if strength is not None:
+                logger.debug(
+                    "strength_ignored provider=sd_webui "
+                    "reason=no_reference_images endpoint=txt2img"
+                )
             url = f"{self._host}/sdapi/v1/txt2img"
+        is_img2img = bool(reference_images)
 
         logger.debug(
             "SD WebUI generate: host=%s model=%s size=%dx%d img2img=%s",

--- a/src/image_generation_mcp/providers/sd_webui.py
+++ b/src/image_generation_mcp/providers/sd_webui.py
@@ -341,16 +341,16 @@ class SdWebuiImageProvider:
         )
 
         is_img2img = bool(reference_images)
-        if is_img2img:
-            if len(reference_images) > _MAX_INPUT_IMAGES:  # type: ignore[arg-type]
+        if reference_images:
+            if len(reference_images) > _MAX_INPUT_IMAGES:
                 raise TooManyInputImages(
                     "sd_webui",
                     effective_model,
                     _MAX_INPUT_IMAGES,
-                    len(reference_images),  # type: ignore[arg-type]
+                    len(reference_images),
                 )
             payload["init_images"] = [
-                base64.b64encode(reference_images[0].data).decode("ascii")  # type: ignore[index]
+                base64.b64encode(reference_images[0].data).decode("ascii")
             ]
             payload["denoising_strength"] = (
                 strength if strength is not None else _DEFAULT_DENOISING_STRENGTH

--- a/src/image_generation_mcp/providers/sd_webui.py
+++ b/src/image_generation_mcp/providers/sd_webui.py
@@ -11,6 +11,7 @@ Ported from questfoundry — prompt distillation removed entirely.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import time
@@ -26,12 +27,12 @@ from image_generation_mcp.providers.capabilities import (
 )
 from image_generation_mcp.providers.model_styles import resolve_style
 from image_generation_mcp.providers.types import (
-    ImageInputUnsupported,
     ImageProviderConnectionError,
     ImageProviderError,
     ImageResult,
     InputImage,
     ProgressCallback,
+    TooManyInputImages,
 )
 
 if TYPE_CHECKING:
@@ -41,6 +42,8 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 180.0  # SDXL at high res can be slow on consumer GPUs
 _PROGRESS_POLL_INTERVAL = 2.0  # seconds between /sdapi/v1/progress polls
+_MAX_INPUT_IMAGES = 1
+_DEFAULT_DENOISING_STRENGTH = 0.75
 
 
 # -- Model-aware generation presets -------------------------------------------
@@ -223,6 +226,56 @@ class SdWebuiImageProvider:
         """Close the underlying HTTP client."""
         await self._client.aclose()
 
+    def _build_payload(
+        self,
+        *,
+        prompt: str,
+        negative_prompt: str | None,
+        aspect_ratio: str,
+        effective_model: str | None,
+        preset: _SdWebuiPreset,
+    ) -> tuple[dict[str, Any], int, int]:
+        """Build the shared SD WebUI request payload.
+
+        Args:
+            prompt: Positive text prompt.
+            negative_prompt: Negative prompt, or None.
+            aspect_ratio: Desired aspect ratio string (e.g. ``"1:1"``).
+            effective_model: Resolved checkpoint name, or None.
+            preset: Architecture preset for this model.
+
+        Returns:
+            Tuple of ``(payload_dict, width, height)``.
+        """
+        default_size = preset.sizes["1:1"]
+        width, height = preset.sizes.get(aspect_ratio, default_size)
+
+        payload: dict[str, Any] = {
+            "prompt": prompt,
+            "width": width,
+            "height": height,
+            "steps": preset.steps,
+            "cfg_scale": preset.cfg_scale,
+            "sampler_name": preset.sampler,
+            "scheduler": preset.scheduler,
+        }
+
+        # Flux models do not support negative prompts — omit entirely.
+        # Other architectures always include the field (empty string if None).
+        if preset.supports_negative_prompt:
+            payload["negative_prompt"] = negative_prompt or ""
+        elif negative_prompt:
+            logger.debug("Model does not support negative prompts, ignoring")
+
+        # distilled_cfg_scale is a Forge-specific parameter for Flux models
+        if preset.distilled_cfg_scale is not None:
+            payload["distilled_cfg_scale"] = preset.distilled_cfg_scale
+
+        if effective_model:
+            payload["override_settings"] = {"sd_model_checkpoint": effective_model}
+
+        return payload, width, height
+
     async def generate(
         self,
         prompt: str,
@@ -233,10 +286,14 @@ class SdWebuiImageProvider:
         background: str = "opaque",
         model: str | None = None,
         reference_images: Sequence[InputImage] | None = None,
-        strength: float | None = None,  # noqa: ARG002
+        strength: float | None = None,
         progress_callback: ProgressCallback | None = None,
     ) -> ImageResult:
-        """Generate an image via SD WebUI txt2img API.
+        """Generate or edit an image via the SD WebUI API.
+
+        When ``reference_images`` is empty or None, calls ``/sdapi/v1/txt2img``
+        (standard text-to-image).  When a single reference image is supplied,
+        calls ``/sdapi/v1/img2img`` using that image as the init image.
 
         Args:
             prompt: Positive text prompt (SD tag format recommended).
@@ -248,24 +305,25 @@ class SdWebuiImageProvider:
             model: Specific checkpoint name to use for this call. Overrides
                 the constructor model for preset detection and
                 ``override_settings``.
-            reference_images: Not supported by this provider. Raises
-                :class:`ImageInputUnsupported` when non-empty.
-            strength: Denoising strength for image-to-image generation
-                (0.0-1.0). Reserved for Task 2 (img2img); not yet consumed.
+            reference_images: Optional single reference image used as the
+                img2img init image.  Pass exactly one :class:`InputImage`;
+                passing more than one raises :class:`TooManyInputImages`.
+            strength: Denoising strength for img2img (0.0-1.0). Ignored for
+                txt2img.  Defaults to 0.75 when reference_images is supplied
+                and strength is None.
             progress_callback: Optional callback invoked with
                 ``(fraction, message)`` during generation.  When provided,
                 ``/sdapi/v1/progress`` is polled concurrently.
 
         Returns:
-            ImageResult with PNG data and provider metadata.
+            ImageResult with PNG data and provider metadata.  Metadata
+            includes ``edited=True`` when img2img was used.
 
         Raises:
             ImageProviderConnectionError: If SD WebUI is unreachable.
             ImageProviderError: On API errors.
-            ImageInputUnsupported: When reference_images are supplied.
+            TooManyInputImages: When more than one reference image is supplied.
         """
-        if reference_images:
-            raise ImageInputUnsupported("sd_webui", model)
         effective_model = model or self._model
         effective_preset = _resolve_preset(effective_model)
 
@@ -273,44 +331,44 @@ class SdWebuiImageProvider:
             logger.debug(
                 "SD WebUI does not support background transparency control, ignoring"
             )
-        default_size = effective_preset.sizes["1:1"]
-        width, height = effective_preset.sizes.get(aspect_ratio, default_size)
 
-        payload: dict[str, Any] = {
-            "prompt": prompt,
-            "width": width,
-            "height": height,
-            "steps": effective_preset.steps,
-            "cfg_scale": effective_preset.cfg_scale,
-            "sampler_name": effective_preset.sampler,
-            "scheduler": effective_preset.scheduler,
-        }
+        payload, width, height = self._build_payload(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            aspect_ratio=aspect_ratio,
+            effective_model=effective_model,
+            preset=effective_preset,
+        )
 
-        # Flux models do not support negative prompts — omit entirely.
-        # Other architectures always include the field (empty string if None).
-        if effective_preset.supports_negative_prompt:
-            payload["negative_prompt"] = negative_prompt or ""
-        elif negative_prompt:
-            logger.debug("Model does not support negative prompts, ignoring")
-
-        # distilled_cfg_scale is a Forge-specific parameter for Flux models
-        if effective_preset.distilled_cfg_scale is not None:
-            payload["distilled_cfg_scale"] = effective_preset.distilled_cfg_scale
-
-        if effective_model:
-            payload["override_settings"] = {"sd_model_checkpoint": effective_model}
-
-        url = f"{self._host}/sdapi/v1/txt2img"
+        is_img2img = bool(reference_images)
+        if is_img2img:
+            if len(reference_images) > _MAX_INPUT_IMAGES:  # type: ignore[arg-type]
+                raise TooManyInputImages(
+                    "sd_webui",
+                    effective_model,
+                    _MAX_INPUT_IMAGES,
+                    len(reference_images),  # type: ignore[arg-type]
+                )
+            payload["init_images"] = [
+                base64.b64encode(reference_images[0].data).decode("ascii")  # type: ignore[index]
+            ]
+            payload["denoising_strength"] = (
+                strength if strength is not None else _DEFAULT_DENOISING_STRENGTH
+            )
+            url = f"{self._host}/sdapi/v1/img2img"
+        else:
+            url = f"{self._host}/sdapi/v1/txt2img"
 
         logger.debug(
-            "SD WebUI generate: host=%s model=%s size=%dx%d",
+            "SD WebUI generate: host=%s model=%s size=%dx%d img2img=%s",
             self._host,
             effective_model,
             width,
             height,
+            is_img2img,
         )
 
-        # Run txt2img with concurrent progress polling when callback provided
+        # Run generation with concurrent progress polling when callback provided
         progress_task: asyncio.Task[None] | None = None
         if progress_callback is not None:
             progress_task = asyncio.create_task(
@@ -374,13 +432,16 @@ class SdWebuiImageProvider:
         }
         if seed is not None:
             metadata["seed"] = seed
+        if is_img2img:
+            metadata["edited"] = True
 
         logger.info(
-            "SD WebUI image generated: model=%s size=%dx%d seed=%s",
+            "SD WebUI image generated: model=%s size=%dx%d seed=%s img2img=%s",
             active_model,
             width,
             height,
             seed,
+            is_img2img,
         )
 
         return ImageResult.from_base64(
@@ -484,6 +545,8 @@ class SdWebuiImageProvider:
                     supported_formats=("png",),
                     supports_negative_prompt=preset.supports_negative_prompt,
                     supports_background=False,
+                    supports_image_input=True,
+                    max_input_images=_MAX_INPUT_IMAGES,
                     max_resolution=max_resolution,
                     default_steps=preset.steps,
                     default_cfg=preset.cfg_scale,

--- a/src/image_generation_mcp/providers/sd_webui.py
+++ b/src/image_generation_mcp/providers/sd_webui.py
@@ -341,6 +341,8 @@ class SdWebuiImageProvider:
         )
 
         is_img2img = bool(reference_images)
+        if strength is not None and not is_img2img:
+            logger.debug("strength_ignored reason=no_reference_images endpoint=txt2img")
         if reference_images:
             if len(reference_images) > _MAX_INPUT_IMAGES:
                 raise TooManyInputImages(

--- a/src/image_generation_mcp/providers/sd_webui.py
+++ b/src/image_generation_mcp/providers/sd_webui.py
@@ -233,6 +233,7 @@ class SdWebuiImageProvider:
         background: str = "opaque",
         model: str | None = None,
         reference_images: Sequence[InputImage] | None = None,
+        strength: float | None = None,  # noqa: ARG002
         progress_callback: ProgressCallback | None = None,
     ) -> ImageResult:
         """Generate an image via SD WebUI txt2img API.
@@ -249,6 +250,8 @@ class SdWebuiImageProvider:
                 ``override_settings``.
             reference_images: Not supported by this provider. Raises
                 :class:`ImageInputUnsupported` when non-empty.
+            strength: Denoising strength for image-to-image generation
+                (0.0-1.0). Reserved for Task 2 (img2img); not yet consumed.
             progress_callback: Optional callback invoked with
                 ``(fraction, message)`` during generation.  When provided,
                 ``/sdapi/v1/progress`` is polled concurrently.

--- a/src/image_generation_mcp/providers/types.py
+++ b/src/image_generation_mcp/providers/types.py
@@ -105,6 +105,7 @@ class ImageProvider(Protocol):
         background: str = "opaque",
         model: str | None = None,
         reference_images: Sequence[InputImage] | None = None,
+        strength: float | None = None,
         progress_callback: ProgressCallback | None = None,
     ) -> ImageResult:
         """Generate an image from a text prompt.
@@ -122,6 +123,9 @@ class ImageProvider(Protocol):
             reference_images: Optional input images for image-to-image edits
                 or composition. Providers that do not support image input
                 raise :class:`ImageInputUnsupported` when this is non-empty.
+            strength: Denoising strength (0.0-1.0) for image-to-image. Only
+                SD WebUI uses it (as ``denoising_strength``); other providers
+                ignore it. Has no effect without ``reference_images``.
             progress_callback: Optional callback invoked with
                 ``(fraction, message)`` during generation.  Only supported
                 by SD WebUI; other providers ignore this parameter.

--- a/src/image_generation_mcp/service.py
+++ b/src/image_generation_mcp/service.py
@@ -433,6 +433,7 @@ class ImageService:
         background: str = "opaque",
         model: str | None = None,
         reference_images: Sequence[InputImage] | None = None,
+        strength: float | None = None,
         progress_callback: ProgressCallback | None = None,
     ) -> tuple[str, ImageResult]:
         """Generate an image using a provider.
@@ -449,6 +450,9 @@ class ImageService:
                 or ``"dall-e-3"`` for OpenAI). Passed through to the provider.
             reference_images: Optional list of input images for image-to-image
                 generation. Passed through to the provider unchanged.
+            strength: Denoising strength (0.0-1.0) for image-to-image. Only
+                SD WebUI uses it; other providers ignore it. Has no effect
+                without ``reference_images``.
             progress_callback: Optional callback invoked with
                 ``(fraction, message)`` during generation.  Only SD WebUI
                 uses this; other providers ignore it.
@@ -488,6 +492,7 @@ class ImageService:
             background=background,
             model=model,
             reference_images=reference_images,
+            strength=strength,
             progress_callback=progress_callback,
         )
 

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -464,3 +464,27 @@ class TestGeminiProvider:
         ]
         with pytest.raises(TooManyInputImages):
             await provider.generate("x", reference_images=refs)
+
+    async def test_generate_ignores_strength(self) -> None:
+        """Passing strength=0.5 is accepted and not forwarded to generate_content kwargs."""
+        provider = GeminiImageProvider(api_key="AIza-test")
+        fake_image_bytes = b"fake-png-data"
+
+        mock_inline = MagicMock()
+        mock_inline.data = fake_image_bytes
+        mock_inline.mime_type = "image/png"
+        mock_part = MagicMock()
+        mock_part.inline_data = mock_inline
+        mock_response = MagicMock()
+        mock_response.parts = [mock_part]
+
+        provider._client = MagicMock()
+        gen = AsyncMock(return_value=mock_response)
+        provider._client.aio.models.generate_content = gen
+
+        result = await provider.generate("a cat", strength=0.5)
+
+        assert result.image_data == fake_image_bytes
+        # strength must NOT be forwarded to the Gemini SDK call
+        call_kwargs = gen.call_args.kwargs
+        assert "strength" not in call_kwargs

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -577,3 +577,17 @@ class TestOpenAIEdit:
         )
         # gpt-image-2 does not accept background; it is omitted from the request.
         assert "background" not in provider._client.images.edit.call_args.kwargs
+
+    async def test_generate_ignores_strength(self) -> None:
+        """Passing strength=0.5 is accepted and not forwarded to images.generate kwargs."""
+        provider = self._mk_provider()
+        provider._client = MagicMock()
+        provider._client.images = MagicMock()
+        provider._client.images.generate = AsyncMock(return_value=self._mk_response())
+
+        result = await provider.generate("a cat", aspect_ratio="1:1", strength=0.5)
+
+        assert result.image_data == b"hi"  # _mk_response uses b64="aGk=" → b"hi"
+        # strength must NOT be forwarded to the OpenAI SDK call
+        call_kwargs = provider._client.images.generate.call_args.kwargs
+        assert "strength" not in call_kwargs

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -115,3 +115,11 @@ async def test_placeholder_rejects_reference_images() -> None:
             "x",
             reference_images=[InputImage(data=b"x", content_type="image/png")],
         )
+
+
+async def test_placeholder_ignores_strength() -> None:
+    """Placeholder provider accepts strength and ignores it (no error)."""
+    provider = PlaceholderImageProvider()
+
+    result = await provider.generate("x", strength=0.5)
+    assert result.image_data  # produced normally, strength ignored

--- a/tests/test_sd_webui_discovery.py
+++ b/tests/test_sd_webui_discovery.py
@@ -755,3 +755,33 @@ class TestSdWebuiDiscoverStyleProfile:
         m = caps.models[0]
         assert m.style_profile is not None
         assert "unknown checkpoint" in m.style_profile.label.lower()
+
+
+# -- Image input capability tests ---------------------------------------------
+
+
+class TestSdWebuiDiscoverImageInputCapability:
+    """Verify supports_image_input and max_input_images on all checkpoints."""
+
+    async def test_all_checkpoints_support_image_input(self) -> None:
+        """Every discovered checkpoint reports supports_image_input=True."""
+        provider = _make_provider()
+        provider._client.get = _mock_get(_CHECKPOINTS_ALL_FIVE)
+        caps = await provider.discover_capabilities()
+
+        assert caps.models, "expected at least one model"
+        for model_caps in caps.models:
+            assert model_caps.supports_image_input is True, (
+                f"expected supports_image_input for {model_caps.model_id}"
+            )
+
+    async def test_all_checkpoints_max_input_images_is_one(self) -> None:
+        """Every discovered checkpoint reports max_input_images=1."""
+        provider = _make_provider()
+        provider._client.get = _mock_get(_CHECKPOINTS_ALL_FIVE)
+        caps = await provider.discover_capabilities()
+
+        for model_caps in caps.models:
+            assert model_caps.max_input_images == 1, (
+                f"expected max_input_images==1 for {model_caps.model_id}"
+            )

--- a/tests/test_sd_webui_provider.py
+++ b/tests/test_sd_webui_provider.py
@@ -689,6 +689,24 @@ class TestImg2Img:
         payload = json.loads(request.content)
         assert payload["denoising_strength"] == 0.75
 
+    async def test_img2img_explicit_zero_strength_preserved(self, httpx_mock) -> None:
+        """strength=0.0 is forwarded as denoising_strength=0.0, not defaulted."""
+        b64_image = base64.b64encode(b"output-png").decode()
+        httpx_mock.post(
+            "http://localhost:7860/sdapi/v1/img2img",
+            json={"images": [b64_image], "info": "{}"},
+        )
+
+        provider = SdWebuiImageProvider(host="http://localhost:7860")
+        await provider.generate(
+            "edit this",
+            reference_images=[InputImage(data=b"raw", content_type="image/png")],
+            strength=0.0,
+        )
+
+        payload = json.loads(httpx_mock.get_request().content)
+        assert payload["denoising_strength"] == 0.0
+
     async def test_img2img_too_many_references_raises(self) -> None:
         """Two reference images raises TooManyInputImages before any HTTP call."""
         provider = SdWebuiImageProvider(host="http://localhost:7860")

--- a/tests/test_sd_webui_provider.py
+++ b/tests/test_sd_webui_provider.py
@@ -22,11 +22,11 @@ from image_generation_mcp.providers.sd_webui import (
     _resolve_preset,
 )
 from image_generation_mcp.providers.types import (
-    ImageInputUnsupported,
     ImageProvider,
     ImageProviderConnectionError,
     ImageProviderError,
     InputImage,
+    TooManyInputImages,
 )
 
 
@@ -639,12 +639,82 @@ class _HttpxMock:
         self._monkeypatch.setattr(httpx.AsyncClient, "get", _mock_get)
 
 
-async def test_sd_webui_rejects_reference_images() -> None:
-    """SD WebUI provider raises ImageInputUnsupported when reference_images are given."""
-    provider = SdWebuiImageProvider(host="http://localhost:7860")
+# -- img2img tests -------------------------------------------------------
 
-    with pytest.raises(ImageInputUnsupported):
-        await provider.generate(
-            "a cat",
-            reference_images=[InputImage(data=b"x", content_type="image/png")],
+
+class TestImg2Img:
+    """Tests for SD WebUI img2img (reference-image) dispatch."""
+
+    async def test_img2img_with_reference_posts_to_img2img(self, httpx_mock) -> None:
+        """When reference_images is given, POST goes to /sdapi/v1/img2img."""
+        raw_bytes = b"fake-raw-png"
+        b64_image = base64.b64encode(b"output-png").decode()
+        httpx_mock.post(
+            "http://localhost:7860/sdapi/v1/img2img",
+            json={"images": [b64_image], "info": "{}"},
         )
+
+        provider = SdWebuiImageProvider(host="http://localhost:7860")
+        result = await provider.generate(
+            "edit this",
+            reference_images=[InputImage(data=raw_bytes, content_type="image/png")],
+            strength=0.4,
+        )
+
+        request = httpx_mock.get_request()
+        assert "/sdapi/v1/img2img" in str(request.url)
+        payload = json.loads(request.content)
+        assert payload["init_images"] == [base64.b64encode(raw_bytes).decode("ascii")]
+        assert payload["denoising_strength"] == 0.4
+        assert result.provider_metadata["edited"] is True
+
+    async def test_img2img_default_denoising_when_strength_none(
+        self, httpx_mock
+    ) -> None:
+        """When strength is None, denoising_strength defaults to 0.75."""
+        b64_image = base64.b64encode(b"output-png").decode()
+        httpx_mock.post(
+            "http://localhost:7860/sdapi/v1/img2img",
+            json={"images": [b64_image], "info": "{}"},
+        )
+
+        provider = SdWebuiImageProvider(host="http://localhost:7860")
+        await provider.generate(
+            "edit this",
+            reference_images=[InputImage(data=b"raw", content_type="image/png")],
+            strength=None,
+        )
+
+        request = httpx_mock.get_request()
+        payload = json.loads(request.content)
+        assert payload["denoising_strength"] == 0.75
+
+    async def test_img2img_too_many_references_raises(self) -> None:
+        """Two reference images raises TooManyInputImages before any HTTP call."""
+        provider = SdWebuiImageProvider(host="http://localhost:7860")
+
+        with pytest.raises(TooManyInputImages):
+            await provider.generate(
+                "edit this",
+                reference_images=[
+                    InputImage(data=b"img1", content_type="image/png"),
+                    InputImage(data=b"img2", content_type="image/png"),
+                ],
+            )
+
+    async def test_txt2img_unaffected_when_no_references(self, httpx_mock) -> None:
+        """With no reference_images, POSTs to /txt2img and has no img2img fields."""
+        b64_image = base64.b64encode(b"output-png").decode()
+        httpx_mock.post(
+            "http://localhost:7860/sdapi/v1/txt2img",
+            json={"images": [b64_image], "info": "{}"},
+        )
+
+        provider = SdWebuiImageProvider(host="http://localhost:7860")
+        await provider.generate("a cat", strength=0.3)
+
+        request = httpx_mock.get_request()
+        assert "/sdapi/v1/txt2img" in str(request.url)
+        payload = json.loads(request.content)
+        assert "init_images" not in payload
+        assert "denoising_strength" not in payload

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -195,3 +195,21 @@ async def test_generate_passes_reference_images_to_provider(tmp_path: Path) -> N
     await service.generate("p", provider="fake", reference_images=refs)
 
     assert fake.generate.call_args.kwargs["reference_images"] == refs
+
+
+async def test_generate_forwards_strength_to_provider(tmp_path: Path) -> None:
+    """generate() forwards strength to the resolved provider."""
+    from unittest.mock import AsyncMock
+
+    from image_generation_mcp.providers.types import ImageResult
+
+    service = ImageService(scratch_dir=tmp_path, default_provider="fake")
+    fake = AsyncMock()
+    fake.generate = AsyncMock(
+        return_value=ImageResult(image_data=b"x", content_type="image/png")
+    )
+    service.register_provider("fake", fake)
+
+    await service.generate("p", provider="fake", strength=0.5)
+
+    assert fake.generate.call_args.kwargs["strength"] == 0.5

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2070,3 +2070,53 @@ class TestTransformImageTool:
             f"image://{image_id}/view"
             "{?format,width,height,quality,crop_x,crop_y,crop_w,crop_h,rotate,flip}"
         )
+
+    # F12: strength parameter validation
+    @pytest.mark.parametrize("bad", [-0.1, 1.5, 2.0])
+    async def test_transform_image_rejects_out_of_range_strength(
+        self, tmp_path: Path, bad: float
+    ) -> None:
+        """Out-of-range strength raises ValueError matching 'strength' before enqueue."""
+        svc = ImageService(scratch_dir=tmp_path)
+        provider = PlaceholderImageProvider()
+        svc.register_provider("placeholder", provider)
+
+        # Inject image-input-capable capabilities so we reach the strength check
+        svc._capabilities["placeholder"] = ProviderCapabilities(
+            provider_name="placeholder",
+            models=(
+                ModelCapabilities(
+                    model_id="placeholder",
+                    display_name="Placeholder",
+                    supports_image_input=True,
+                    max_input_images=4,
+                ),
+            ),
+            discovered_at=1000.0,
+        )
+
+        # Register a real source image in the gallery
+        src_result = await provider.generate("source image", aspect_ratio="1:1")
+        src_record = svc.register_image(
+            src_result, "placeholder", prompt="source image"
+        )
+        source_image_id = src_record.id
+
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("transform_image")
+        assert tool is not None
+
+        ctx = await self._make_ctx()
+        cfg = await self._make_cfg()
+
+        with pytest.raises(ValueError, match="strength"):
+            await tool.fn(
+                prompt="make it blue",
+                reference_images=[source_image_id],
+                provider="placeholder",
+                strength=bad,
+                service=svc,
+                config=cfg,
+                ctx=ctx,
+            )


### PR DESCRIPTION
## SD WebUI img2img + denoising strength

Closes #259. Part of epic #256 (Refs #256).

Adds reference-image input for the SD WebUI provider via `/sdapi/v1/img2img`, and a `strength` (denoising) parameter to `transform_image` that only SD consumes. SD WebUI now joins Gemini and OpenAI as an image-to-image provider.

### What this delivers
- **SD WebUI img2img** — when `reference_images` is supplied, SD routes to `/sdapi/v1/img2img` with the reference as `init_images` (base64) and `denoising_strength`. Single init image (`max_input_images=1`); more than one raises `TooManyInputImages`.
- **`strength` parameter** — threaded through the provider protocol → service → `transform_image` (validated 0.0–1.0), mapping to SD's `denoising_strength` (default 0.75 when omitted; lower preserves the init image, higher regenerates more). Gemini, OpenAI, and placeholder accept it and ignore it with a debug log; it has no effect without a reference image.
- **Shared `_build_payload()`** — txt2img and img2img share request construction (no duplication); txt2img behavior is unchanged.
- **Capability metadata** — `supports_image_input=True` / `max_input_images=1` on every discovered SD checkpoint (surfaced via `list_providers`).

### Scope
- Single init image for SD (img2img); multi-image composition stays OpenAI-only (#260 covers Gemini composition). No mask / inpainting (that is OpenAI #261).
- Auto-routing already honors `max_input_images` per reference count (added in #258), so a 1-image `provider="auto"` request can pick SD, while 2+ image requests still route to OpenAI.

### Tests & gates
- 966 tests pass (Python 3.11–3.14), ruff + mypy (strict) clean, mkdocs builds, docs Vale-clean on changed lines.
- New coverage: img2img posts to the right endpoint with correct `init_images` / `denoising_strength`; default 0.75 vs explicit strength (including explicit 0.0); `TooManyInputImages` at >1; txt2img unaffected with no references; `strength` validation (out-of-range) and non-SD ignore (not forwarded to their SDK); SD capability fields on every checkpoint.

### Docs
`docs/providers/sd-webui.md` (img2img section) and `docs/tools.md` (the `strength` parameter; image-input provider guidance made generic so it points at `list_providers`/`max_input_images` rather than enumerating providers).

### Review
Local: per-task reviews plus an opus whole-branch review. The whole-branch review's one finding (image-input guidance still enumerated only Gemini/OpenAI) is fixed and rot-proofed (made provider-neutral). Vale shows red only on pre-existing / design-doc content (the known #244 gate, non-blocking; main unprotected) — this PR's changed lines are Vale-clean. Bots have not yet reviewed the pushed commit; not a merge-ready signal.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
