### PR TITLE
feat: Gemini multi-image composition (#260)

### DIFF
--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -80,11 +80,21 @@ The watermark is invisible to the human eye and does not affect image quality or
 
 ## Image input (image-to-image)
 
-Gemini models accept a reference image alongside a text prompt via the `transform_image` tool. Use this for description-driven edits such as swapping backgrounds or applying a different visual style.
+Gemini models accept one or more reference images alongside a text prompt via the `transform_image` tool. Use this for description-driven edits such as swapping backgrounds or applying a different visual style, and for multi-image composition.
 
-**This release accepts one reference image per request.** Pass a gallery `image_id`, an `image://` URI, or (when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`) a local file path in the `reference_images` parameter. The reference image is sent as an inline image part alongside the prompt.
+Pass gallery `image_id` values, `image://` URIs, or (when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`) local file paths in the `reference_images` parameter. Each reference image is sent as an inline image part alongside the prompt.
 
-Call `list_providers` and inspect `supports_image_input` and `max_input_images` on each model entry to confirm image-input availability at runtime.
+### Multi-image composition and character consistency
+
+Supply several reference images to compose a scene from their elements or to keep a character consistent across generations. The per-call reference limit depends on the model:
+
+| Model | Max reference images |
+|-------|----------------------|
+| `gemini-2.5-flash-image` | 3 |
+| `gemini-3.1-flash-image-preview` | 14 |
+| `gemini-3-pro-image-preview` | 14 |
+
+The Gemini 3 models accept up to 14 reference images. For character consistency, give the model a few clear shots of the same subject and describe the scene you want. Reference order is preserved in the request. Exceeding a model's limit raises an error before the API call; check `max_input_images` in `list_providers` to confirm the cap at runtime, and `supports_image_input` for availability.
 
 ```
 transform_image(

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -82,7 +82,15 @@ The watermark is invisible to the human eye and does not affect image quality or
 
 Gemini models accept one or more reference images alongside a text prompt via the `transform_image` tool. Use this for description-driven edits such as swapping backgrounds or applying a different visual style, and for multi-image composition.
 
-Pass gallery `image_id` values, `image://` URIs, or (when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`) local file paths in the `reference_images` parameter. Each reference image is sent as an inline image part alongside the prompt.
+Pass gallery `image_id` values, `image://` URIs, or (when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`) local file paths in the `reference_images` parameter. Each reference image is sent as an inline image part alongside the prompt. A single-reference edit looks like:
+
+```
+transform_image(
+  prompt="Replace the background with a sunset sky",
+  reference_images=["a1b2c3d4e5f6"],
+  provider="gemini"
+)
+```
 
 ### Multi-image composition and character consistency
 
@@ -95,16 +103,6 @@ Supply several reference images to compose a scene from their elements or to kee
 | `gemini-3-pro-image-preview` | 14 |
 
 The Gemini 3 models accept up to 14 reference images. For character consistency, give the model a few clear shots of the same subject and describe the scene you want. Reference order is preserved in the request. Exceeding a model's limit raises an error before the API call; check `max_input_images` in `list_providers` to confirm the cap at runtime, and `supports_image_input` for availability.
-
-```
-transform_image(
-  prompt="Replace the background with a sunset sky",
-  reference_images=["a1b2c3d4e5f6"],
-  provider="gemini"
-)
-```
-
-Multi-image composition passes several reference IDs (Gemini 3 models):
 
 ```
 transform_image(

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -104,6 +104,17 @@ transform_image(
 )
 ```
 
+Multi-image composition passes several reference IDs (Gemini 3 models):
+
+```
+transform_image(
+  prompt="Place the character from the first image into the scene of the second",
+  reference_images=["a1b2c3d4e5f6", "0f1e2d3c4b5a", "9a8b7c6d5e4f"],
+  provider="gemini",
+  model="gemini-3-pro-image-preview"
+)
+```
+
 The same fire-and-forget pattern applies: `transform_image` returns immediately with a pending `image_id`; poll `check_generation_status(image_id)` and call `show_image(uri=original_uri)` once completed.
 
 ## Prompt style

--- a/src/image_generation_mcp/_server_tools.py
+++ b/src/image_generation_mcp/_server_tools.py
@@ -650,9 +650,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         # whose capabilities include a model that supports image input AND
         # accepts at least len(resolved) references, so auto-selection cannot
         # pick a provider that would then reject this request's reference count
-        # (Gemini and SD WebUI cap at 1; OpenAI accepts up to 16). Prefer
-        # Gemini among the eligible providers (higher-quality edits); the
-        # explicit check keeps that preference robust if a future provider
+        # (caps vary by model and are read from max_input_images below).
+        # Prefer Gemini among the eligible providers (higher-quality edits);
+        # the explicit check keeps that preference robust if a future provider
         # would otherwise sort ahead of "gemini". Else pick the first eligible
         # provider alphabetically for determinism.
         if provider == "auto":

--- a/src/image_generation_mcp/providers/gemini.py
+++ b/src/image_generation_mcp/providers/gemini.py
@@ -73,8 +73,22 @@ _KNOWN_IMAGE_MODELS: list[tuple[str, str]] = [
 _SUPPORTED_ASPECT_RATIOS: tuple[str, ...] = tuple(_ASPECT_RATIOS)
 _SUPPORTED_QUALITIES: tuple[str, ...] = ("standard", "hd")
 
-# Maximum number of reference images accepted per generate() call.
-_MAX_INPUT_IMAGES = 1
+# Maximum reference images per generate() call, by model. Gemini 3 image
+# models accept up to 14 reference images for multi-image composition (per the
+# ai.google.dev image-generation docs). The older gemini-2.5-flash-image has no
+# documented multi-image limit, so a conservative cap is applied. Unknown
+# models fall back to the conservative default.
+_MAX_INPUT_IMAGES_BY_MODEL: dict[str, int] = {
+    "gemini-2.5-flash-image": 3,
+    "gemini-3.1-flash-image-preview": 14,
+    "gemini-3-pro-image-preview": 14,
+}
+_DEFAULT_MAX_INPUT_IMAGES = 3
+
+
+def _max_input_images(model: str) -> int:
+    """Return the reference-image cap for a Gemini model."""
+    return _MAX_INPUT_IMAGES_BY_MODEL.get(model, _DEFAULT_MAX_INPUT_IMAGES)
 
 
 class GeminiImageProvider:
@@ -143,8 +157,9 @@ class GeminiImageProvider:
             background: Ignored — Gemini does not support transparent backgrounds.
             model: Override the default model for this call.
             reference_images: Optional list of reference images for
-                image-to-image editing. At most one image is accepted;
-                passing more than one raises ``TooManyInputImages``.
+                image-to-image editing and multi-image composition. The
+                per-model cap is 3 for gemini-2.5-flash-image and up to 14 for
+                Gemini 3 models; passing more raises ``TooManyInputImages``.
                 When provided, the image bytes are sent as inline image parts
                 alongside the prompt for guided generation.
             strength: Ignored — Gemini does not support denoising strength.
@@ -157,7 +172,8 @@ class GeminiImageProvider:
             ImageProviderError: If generation fails or returns no image.
             ImageContentPolicyError: If the prompt violates content policy.
             ImageProviderConnectionError: If the Gemini API is unreachable.
-            TooManyInputImages: If more than one reference image is supplied.
+            TooManyInputImages: If more reference images than the model's cap
+                are supplied.
         """
         from google.genai import types
 
@@ -173,9 +189,10 @@ class GeminiImageProvider:
 
         effective_model = model or self._model
 
-        if reference_images and len(reference_images) > _MAX_INPUT_IMAGES:
+        max_refs = _max_input_images(effective_model)
+        if reference_images and len(reference_images) > max_refs:
             raise TooManyInputImages(
-                "gemini", effective_model, _MAX_INPUT_IMAGES, len(reference_images)
+                "gemini", effective_model, max_refs, len(reference_images)
             )
 
         full_prompt = prompt
@@ -263,7 +280,7 @@ class GeminiImageProvider:
                     supports_negative_prompt=False,
                     supports_background=False,
                     supports_image_input=True,
-                    max_input_images=_MAX_INPUT_IMAGES,
+                    max_input_images=_max_input_images(model_id),
                     prompt_style="natural_language",
                     style_profile=resolve_style("gemini", model_id),
                     # SynthID watermark: see docs/providers/gemini.md.

--- a/src/image_generation_mcp/providers/gemini.py
+++ b/src/image_generation_mcp/providers/gemini.py
@@ -160,8 +160,8 @@ class GeminiImageProvider:
             model: Override the default model for this call.
             reference_images: Optional list of reference images for
                 image-to-image editing and multi-image composition. The
-                per-model cap is 3 for gemini-2.5-flash-image and up to 14 for
-                Gemini 3 models; passing more raises ``TooManyInputImages``.
+                per-model cap is reported as ``max_input_images`` in
+                ``list_providers``; passing more raises ``TooManyInputImages``.
                 When provided, the image bytes are sent as inline image parts
                 alongside the prompt for guided generation.
             strength: Ignored — Gemini does not support denoising strength.

--- a/src/image_generation_mcp/providers/gemini.py
+++ b/src/image_generation_mcp/providers/gemini.py
@@ -64,6 +64,8 @@ _THINKING_MODELS: frozenset[str] = frozenset(
 # Known Gemini image-capable models in preference order.
 # Discovery returns this static list — models.list() does not reliably filter
 # image-generation models, so we maintain the known set here.
+# When adding a model, also add its reference-image cap to
+# _MAX_INPUT_IMAGES_BY_MODEL below; otherwise the conservative default applies.
 _KNOWN_IMAGE_MODELS: list[tuple[str, str]] = [
     ("gemini-2.5-flash-image", "Gemini 2.5 Flash Image"),
     ("gemini-3.1-flash-image-preview", "Gemini 3.1 Flash Image Preview"),

--- a/tests/test_gemini_discovery.py
+++ b/tests/test_gemini_discovery.py
@@ -145,12 +145,17 @@ class TestDiscoverCapabilities:
     async def test_gemini_advertises_image_input(
         self, gemini_provider: GeminiImageProvider
     ) -> None:
-        """All Gemini models advertise supports_image_input=True and max_input_images=1."""
+        """Gemini models advertise supports_image_input=True with per-model caps."""
         caps = await gemini_provider.discover_capabilities()
 
+        by_id = {m.model_id: m for m in caps.models}
         for m in caps.models:
             assert m.supports_image_input is True
-            assert m.max_input_images == 1
+        # Gemini 3 image models accept up to 14 reference images; the older
+        # 2.5-flash-image uses a conservative cap.
+        assert by_id["gemini-2.5-flash-image"].max_input_images == 3
+        assert by_id["gemini-3.1-flash-image-preview"].max_input_images == 14
+        assert by_id["gemini-3-pro-image-preview"].max_input_images == 14
 
     async def test_degraded_on_unexpected_exception(
         self, gemini_provider: GeminiImageProvider, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -514,6 +514,29 @@ class TestGeminiProvider:
         with pytest.raises(TooManyInputImages):
             await provider.generate("x", reference_images=refs15)
 
+    async def test_per_call_model_override_uses_override_cap(self) -> None:
+        """The cap follows the per-call model override, not the constructor model."""
+        from image_generation_mcp.providers.types import InputImage
+
+        # Constructed as 2.5-flash (cap 3) but called with a Gemini 3 model.
+        provider = GeminiImageProvider(api_key="AIza-test")
+        mock_inline = MagicMock()
+        mock_inline.data = b"out-png"
+        mock_inline.mime_type = "image/png"
+        mock_part = MagicMock()
+        mock_part.inline_data = mock_inline
+        mock_response = MagicMock()
+        mock_response.parts = [mock_part]
+        provider._client = MagicMock()
+        provider._client.aio.models.generate_content = AsyncMock(
+            return_value=mock_response
+        )
+        refs = [InputImage(data=b"x", content_type="image/png") for _ in range(5)]
+        # 5 refs exceeds 2.5-flash's cap (3) but is within gemini-3-pro's (14).
+        await provider.generate(
+            "compose", model="gemini-3-pro-image-preview", reference_images=refs
+        )  # no raise
+
     async def test_generate_ignores_strength(self) -> None:
         """Passing strength=0.5 is accepted and not forwarded to generate_content kwargs."""
         provider = GeminiImageProvider(api_key="AIza-test")

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -528,14 +528,15 @@ class TestGeminiProvider:
         mock_response = MagicMock()
         mock_response.parts = [mock_part]
         provider._client = MagicMock()
-        provider._client.aio.models.generate_content = AsyncMock(
-            return_value=mock_response
-        )
+        gen = AsyncMock(return_value=mock_response)
+        provider._client.aio.models.generate_content = gen
         refs = [InputImage(data=b"x", content_type="image/png") for _ in range(5)]
         # 5 refs exceeds 2.5-flash's cap (3) but is within gemini-3-pro's (14).
         await provider.generate(
             "compose", model="gemini-3-pro-image-preview", reference_images=refs
         )  # no raise
+        # [prompt, 5 image parts]
+        assert len(gen.call_args.kwargs["contents"]) == 6
 
     async def test_generate_ignores_strength(self) -> None:
         """Passing strength=0.5 is accepted and not forwarded to generate_content kwargs."""

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -452,18 +452,67 @@ class TestGeminiProvider:
         assert isinstance(contents, list)
         assert len(contents) == 2
 
-    async def test_generate_rejects_two_reference_images(self) -> None:
-        """More than one reference image raises TooManyInputImages."""
-        from image_generation_mcp.providers.types import InputImage, TooManyInputImages
+    async def test_generate_accepts_multiple_reference_images(self) -> None:
+        """Multiple reference images (within the model cap) are all sent as parts."""
+        from image_generation_mcp.providers.types import InputImage
 
-        provider = GeminiImageProvider(api_key="AIza-test")
+        provider = GeminiImageProvider(api_key="AIza-test")  # 2.5-flash, cap 3
+        mock_inline = MagicMock()
+        mock_inline.data = b"out-png"
+        mock_inline.mime_type = "image/png"
+        mock_part = MagicMock()
+        mock_part.inline_data = mock_inline
+        mock_response = MagicMock()
+        mock_response.parts = [mock_part]
         provider._client = MagicMock()
+        gen = AsyncMock(return_value=mock_response)
+        provider._client.aio.models.generate_content = gen
+
         refs = [
             InputImage(data=b"a", content_type="image/png"),
             InputImage(data=b"b", content_type="image/png"),
+            InputImage(data=b"c", content_type="image/png"),
         ]
+        await provider.generate("compose", reference_images=refs)
+        contents = gen.call_args.kwargs["contents"]
+        # [prompt, part, part, part]
+        assert len(contents) == 4
+
+    async def test_generate_rejects_over_cap_reference_images(self) -> None:
+        """More references than the model's cap raises TooManyInputImages."""
+        from image_generation_mcp.providers.types import InputImage, TooManyInputImages
+
+        provider = GeminiImageProvider(api_key="AIza-test")  # 2.5-flash, cap 3
+        provider._client = MagicMock()
+        refs = [InputImage(data=b"x", content_type="image/png") for _ in range(4)]
         with pytest.raises(TooManyInputImages):
             await provider.generate("x", reference_images=refs)
+
+    async def test_generate_gemini3_accepts_up_to_14_references(self) -> None:
+        """Gemini 3 models accept up to 14 reference images."""
+        from image_generation_mcp.providers.types import InputImage, TooManyInputImages
+
+        provider = GeminiImageProvider(
+            api_key="AIza-test", model="gemini-3-pro-image-preview"
+        )
+        mock_inline = MagicMock()
+        mock_inline.data = b"out-png"
+        mock_inline.mime_type = "image/png"
+        mock_part = MagicMock()
+        mock_part.inline_data = mock_inline
+        mock_response = MagicMock()
+        mock_response.parts = [mock_part]
+        provider._client = MagicMock()
+        gen = AsyncMock(return_value=mock_response)
+        provider._client.aio.models.generate_content = gen
+        refs14 = [InputImage(data=b"x", content_type="image/png") for _ in range(14)]
+        await provider.generate("compose", reference_images=refs14)  # no raise
+        # [prompt, 14 image parts]
+        assert len(gen.call_args.kwargs["contents"]) == 15
+
+        refs15 = [InputImage(data=b"x", content_type="image/png") for _ in range(15)]
+        with pytest.raises(TooManyInputImages):
+            await provider.generate("x", reference_images=refs15)
 
     async def test_generate_ignores_strength(self) -> None:
         """Passing strength=0.5 is accepted and not forwarded to generate_content kwargs."""


### PR DESCRIPTION
## Gemini multi-image composition

Closes #260. Part of epic #256 (Refs #256).

Raises Gemini's reference-image cap from one to per-model limits, enabling multi-image composition and character consistency.

### What this delivers
- **Per-model reference caps** — replaces the single `_MAX_INPUT_IMAGES = 1` constant with `_MAX_INPUT_IMAGES_BY_MODEL` + an `_max_input_images(model)` helper, used by both the `generate()` cap guard and `discover_capabilities()`:

  | Model | Max reference images |
  |-------|----------------------|
  | `gemini-2.5-flash-image` | 3 |
  | `gemini-3.1-flash-image-preview` | 14 |
  | `gemini-3-pro-image-preview` | 14 |

  Values verified against the ai.google.dev image-generation docs ("Gemini 3 image models let you mix up to 14 reference images"); gemini-2.5-flash-image has no documented multi-image limit, so a conservative cap of 3 is applied (unknown models fall back to 3).
- The `generate()` contents builder already appended all references, so this lifts the cap and surfaces the per-model `max_input_images` via `list_providers`. `transform_image` auto-routing already honors `max_input_images >= reference count`, so a multi-image request can now route to a Gemini 3 model.

### Scope
- Gemini-only (per #260). OpenAI composition shipped in #258; SD WebUI is single-image (#259). Masks remain #261.

### Tests & gates
- 969 tests pass (Python 3.11–3.14), ruff + mypy (strict) clean, mkdocs builds, docs Vale-clean on changed lines.
- Coverage: multiple references within cap are all sent as parts (contents length); over-cap raises `TooManyInputImages`; Gemini 3 accepts 14 and rejects 15; the discovery test asserts the per-model caps. The old "rejects two reference images" test is rewritten (2.5-flash now accepts 3).

### Docs
`docs/providers/gemini.md` gains a "Multi-image composition and character consistency" section with the per-model cap table. The cross-provider tool docs stay generic (point at `list_providers` / `max_input_images`).

### Review
Local: a whole-branch review whose one substantive finding (a stale "Gemini caps at 1" routing comment) is fixed and made rot-proof (it now notes caps are read from `max_input_images`); the Gemini docstring no longer references a private constant. Vale shows red only on pre-existing / design-doc content (the known #244 gate, non-blocking; main unprotected) — this PR's changed lines are Vale-clean. Bots have not yet reviewed the pushed commit; not a merge-ready signal.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
