### PR TITLE
docs: reference-image input closeout + prompt guidance (#262)

### DIFF
--- a/docs/design/provider-system.md
+++ b/docs/design/provider-system.md
@@ -67,11 +67,39 @@ class ImageProvider(Protocol):
         quality: str = "standard",
         background: str = "opaque",
         model: str | None = None,
+        reference_images: Sequence[InputImage] | None = None,
+        strength: float | None = None,
+        mask: InputImage | None = None,
         progress_callback: ProgressCallback | None = None,
     ) -> ImageResult: ...
 
     async def discover_capabilities(self) -> ProviderCapabilities: ...
 ```
+
+## Image-input primitive
+
+Reference-image input (image-to-image, composition, masking) extends the same
+`generate()` method rather than adding a parallel method. Three optional
+parameters carry it:
+
+- `reference_images`: a sequence of `InputImage` value objects (decoded bytes
+  plus content type and optional `source_id` provenance). Empty or `None`
+  means text-to-image.
+- `strength`: denoising strength for SD WebUI img2img (`0.0`-`1.0`). Other
+  providers ignore it with a debug log; it has no effect without a reference
+  image.
+- `mask`: a single `InputImage` inpainting mask. Only OpenAI gpt-image models
+  consume it; the other providers raise `ImageProviderError` when a mask is
+  supplied.
+
+Input resolution lives in `_input_images.py`, the only module aware of input
+sources. It maps a gallery `image_id`, an `image://` URI, or a gated local
+file path to an `InputImage`. The `transform_image` tool resolves references,
+then routes on three capability fields exposed by `discover_capabilities`:
+`supports_image_input`, `max_input_images`, and `supports_mask`. Auto-routing
+selects a provider whose model accepts the supplied reference count, and a
+mask request is routed only to a mask-capable model. Result provenance is
+generalized to `source_image_ids: list[str]`.
 
 The optional `model` parameter allows per-call model selection. When set, it
 overrides the provider's constructor default. SD WebUI uses it for both preset
@@ -232,7 +260,7 @@ and injected via FastMCP's `Depends()` system.
 
 1. **Provider registry** -- `register_provider(name, provider)` at startup
 2. **Capability discovery** -- `discover_all_capabilities()` introspects each provider (graceful degradation)
-3. **Generation dispatch** -- `generate(prompt, *, provider, ..., progress_callback=...)` resolves provider and delegates (forwards `progress_callback` to the provider)
+3. **Generation dispatch** -- `generate(prompt, *, provider, ..., reference_images=..., strength=..., mask=..., progress_callback=...)` resolves provider and delegates (forwards reference-image input and `progress_callback` to the provider)
 4. **Image registry** -- `register_image()` saves original + sidecar JSON, indexes in memory
 5. **Image retrieval** -- `get_image(id)` and `list_images()` for registered images
 6. **Startup rebuild** -- `_load_registry()` reconstructs in-memory registry from sidecar files

--- a/docs/design/provider-system.md
+++ b/docs/design/provider-system.md
@@ -396,7 +396,7 @@ All environment variables use the `IMAGE_GENERATION_MCP_` prefix.
 
 - **More providers:** BFL/FLUX, Stability, Ideogram, FAL, Replicate
 - **ComfyUI provider:** Workflow-based API with CLIP text encode nodes
-- **Image editing:** Masks, inpainting, background removal
+- **Background removal:** Automated subject isolation (editing, composition, and masking shipped in epic #256)
 - **Rate limiting:** Per-provider request throttling
 - **Auto-cleanup:** TTL-based scratch directory cleanup
 - **Response caching:** Cache frequently-requested transforms

--- a/docs/guides/image-input.md
+++ b/docs/guides/image-input.md
@@ -1,0 +1,125 @@
+# Image input: editing, composition, and masking
+
+The [`transform_image`](../tools.md#transform_image) tool feeds one or more
+existing images *into* generation. Use it to edit a picture from a text
+instruction, transfer a style, compose several references into one scene, or
+repaint a masked region. This is distinct from `generate_image` (text only,
+no reference image) and from `edit_image` (local geometry operations such as
+crop, rotate, and flip).
+
+## How input images are supplied
+
+Every reference is a string in the `reference_images` list (and the optional
+`mask`). Three forms are accepted:
+
+1. A gallery `image_id`, the 12-character hex ID returned by a prior
+   `generate_image` or `transform_image` call.
+2. An `image://<id>/view` resource URI.
+3. A local filesystem path, allowed only when
+   `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true` (off by default). See
+   [Configuration](../configuration.md).
+
+`transform_image` runs as a background task. It returns immediately with a
+`status: "generating"` response and an `image_id`. Poll
+`check_generation_status(image_id)` until completion, then call
+`show_image(uri=original_uri)` once to display the result. Provenance is
+recorded: the response and the finished record carry `source_image_ids`
+listing every reference (and mask) the result derived from.
+
+## Capability matrix
+
+Reference-image support varies by provider and model. Call `list_providers`
+and read each model's `supports_image_input`, `max_input_images`, and
+`supports_mask` for the authoritative runtime values.
+
+| Capability | Gemini | OpenAI | SD WebUI |
+|------------|--------|--------|----------|
+| Image-to-image edit | Yes | gpt-image family | Yes (img2img) |
+| Reference images per call | 3 (2.5-flash), 14 (Gemini 3) | up to 16 | 1 |
+| Multi-image composition | Yes (Gemini 3) | Yes | No (single init image) |
+| Inpainting mask | No | gpt-image family | No |
+| Denoising `strength` | No | No | Yes (`0.0`-`1.0`) |
+
+When `provider="auto"`, selection is capability-aware: it picks a provider
+whose model accepts the supplied reference count, and a mask request is routed
+only to a mask-capable model.
+
+## Workflows
+
+### Edit and style transfer
+
+Pass a single reference and describe the change. Good for background swaps,
+restyles, and other description-driven edits.
+
+```
+transform_image(
+  prompt="Repaint this photo in the style of a watercolor landscape",
+  reference_images=["a1b2c3d4e5f6"]
+)
+```
+
+Any image-input provider handles a single reference. See
+[Gemini](../providers/gemini.md#image-input-image-to-image),
+[OpenAI](../providers/openai.md#image-input-editing-and-composition), and
+[SD WebUI](../providers/sd-webui.md#image-input-img2img).
+
+### Multi-image composition
+
+Supply several references to compose a scene from their elements or to keep a
+character consistent across generations. The Gemini 3 models accept up to 14
+references; OpenAI's gpt-image family accepts up to 16.
+
+```
+transform_image(
+  prompt="Place the character from the first image into the scene of the second",
+  reference_images=["a1b2c3d4e5f6", "0f1e2d3c4b5a", "9a8b7c6d5e4f"],
+  provider="gemini",
+  model="gemini-3-pro-image-preview"
+)
+```
+
+See [Gemini multi-image composition](../providers/gemini.md#multi-image-composition-and-character-consistency).
+
+### Inpainting with a mask
+
+Supply a `mask` to repaint only the masked region of the first reference
+image. Masks are an OpenAI gpt-image capability. The mask must match the first
+reference image's size and format and carry an alpha channel; OpenAI enforces
+this and returns an error on a mismatch.
+
+```
+transform_image(
+  prompt="Replace the masked area with a vase of flowers",
+  reference_images=["a1b2c3d4e5f6"],
+  mask="b2c3d4e5f6a1",
+  provider="openai"
+)
+```
+
+See [OpenAI masks](../providers/openai.md#masks).
+
+### Controlling edit strength (SD WebUI)
+
+For SD WebUI img2img, `strength` is the denoising strength, from `0.0` to
+`1.0`. Lower values preserve the reference image; higher values regenerate
+more of it. It defaults to `0.75` and has no effect on other providers or
+without a reference image.
+
+```
+transform_image(
+  prompt="Turn this sketch into a finished oil painting",
+  reference_images=["a1b2c3d4e5f6"],
+  provider="sd_webui",
+  strength=0.55
+)
+```
+
+See [SD WebUI img2img](../providers/sd-webui.md#image-input-img2img).
+
+## Related pages
+
+- [Tools: `transform_image`](../tools.md#transform_image) for the full
+  parameter reference.
+- [Image Assets](image-assets.md) for how generated images are stored and
+  addressed.
+- [Providers overview](../providers/index.md) for per-provider detail.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -98,6 +98,8 @@ Edit or transform an existing image using a model that accepts image input (imag
 
 `transform_image` is distinct from `edit_image` (which applies local geometry transforms such as crop, rotate, and flip directly in the server) and from `generate_image` (text-only, no reference image).
 
+For task-oriented walkthroughs (editing, composition, masking, and SD `strength`), see the [Image input guide](guides/image-input.md).
+
 | Property | Value |
 |----------|-------|
 | **Tags** | `write` (hidden in read-only mode) |
@@ -128,7 +130,7 @@ Each entry in `reference_images` is resolved in order:
 2. **`image://` URI**: a full resource URI, such as `"image://a1b2c3d4e5f6/view"`.
 3. **Local file path**: absolute path on the server host, such as `"/home/user/photo.png"`. Only accepted when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`; rejected with an error otherwise.
 
-Call `list_providers` and inspect `supports_image_input` and `max_input_images` on each model to confirm which provider can handle your input count. Gemini and SD WebUI support one reference image per call. OpenAI gpt-image models (`gpt-image-1`, `gpt-image-1.5`, `gpt-image-1-mini`, `gpt-image-2`) support up to 16 reference images for multi-image composition. `dall-e-3` and `dall-e-2` do not accept reference images.
+Call `list_providers` and inspect `supports_image_input` and `max_input_images` on each model to confirm which provider can handle your input count. Reference-count limits vary by model: SD WebUI accepts a single reference, Gemini accepts several (more on the Gemini 3 models), and OpenAI's gpt-image family accepts the most for multi-image composition. `max_input_images` carries the authoritative per-model value; `dall-e-3` and `dall-e-2` do not accept reference images. See the [Image input guide](guides/image-input.md) for the current capability matrix.
 
 ### Return value
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ plugins:
           - prompts.md: MCP prompts with workflow descriptions
         Guides:
           - guides/authentication.md: Authentication modes -- bearer, OIDC, multi-auth
+          - guides/image-input.md: Image input -- editing, composition, and masking via transform_image
           - guides/prompt-writing.md: Provider-specific prompt writing tips
           - guides/styles.md: Style library -- reusable creative briefs for consistent generation
         Deployment:
@@ -147,6 +148,7 @@ nav:
   - Guides:
       - Authentication: guides/authentication.md
       - Client Compatibility: guides/client-compatibility.md
+      - Image Input (i2i): guides/image-input.md
       - Prompt Writing: guides/prompt-writing.md
       - Image Assets: guides/image-assets.md
       - Style Library: guides/styles.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,7 +148,7 @@ nav:
   - Guides:
       - Authentication: guides/authentication.md
       - Client Compatibility: guides/client-compatibility.md
-      - Image Input (i2i): guides/image-input.md
+      - Image Input (image-to-image): guides/image-input.md
       - Prompt Writing: guides/prompt-writing.md
       - Image Assets: guides/image-assets.md
       - Style Library: guides/styles.md

--- a/src/image_generation_mcp/_server_prompts.py
+++ b/src/image_generation_mcp/_server_prompts.py
@@ -54,8 +54,9 @@ Choose the best provider for the user's request based on these guidelines.
 
 - **Production:** `gemini-2.5-flash-image` (production GA). Cheap (~$0.04/image),
   fast, supports 14 aspect ratios from 21:9 to 9:16 (including ultra-wide
-  4:1 / 8:1), multi-image compositing (up to 3 inputs), and conversational
-  image editing. Outputs carry an invisible SynthID watermark.
+  4:1 / 8:1), multi-image compositing (3 references on 2.5-flash, up to 14 on
+  the Gemini 3 models), and conversational image editing. Outputs carry an
+  invisible SynthID watermark.
 - **Preview:** `gemini-3.1-flash-image-preview` and `gemini-3-pro-image-preview`
   add reasoning ("thinking") for layout-heavy and dense-typography work.
   Preview-tier — surface stability not guaranteed.
@@ -120,6 +121,26 @@ Choose the best provider for the user's request based on these guidelines.
 9. For **general requests** → default to **gemini** when available, then
    **openai**.
 
+## Reference-Image Input (transform_image)
+
+When the request supplies an existing image (edit, style transfer,
+composition, or inpainting), use `transform_image` instead of
+`generate_image`, and pick the provider by what the task needs:
+
+- **Edit or style transfer** (one reference) → any image-input provider:
+  **gemini**, **openai** (gpt-image), or **sd_webui** (img2img).
+- **Multi-image composition** (several references) → **gemini** on a Gemini 3
+  model (up to 14 references) or **openai** gpt-image (up to 16). **sd_webui**
+  takes a single reference only.
+- **Inpainting with a mask** → **openai** gpt-image (the only mask-capable
+  family).
+- **Fine-grained edit control** → **sd_webui**, using `strength` (denoising
+  `0.0`-`1.0`; lower preserves the reference).
+
+Check `supports_image_input`, `max_input_images`, and `supports_mask` on
+`list_providers` for the authoritative per-model values; `provider="auto"`
+already routes on them.
+
 **Avoid deprecated models for new long-lived workflows.** Check the
 `warnings` array on `list_providers`'s response — it lists every configured
 model whose `lifecycle` is `legacy` or `deprecated`, including removal dates
@@ -128,10 +149,11 @@ when known.
 ## Usage
 
 Call `generate_image` with `provider="auto"` for automatic selection, or
-specify a provider name directly. Pass `model="<id>"` to pin a specific
-model_id within the provider. Use `list_providers` to see which providers
-are currently available, what models each has loaded, and per-model
-narrative guidance.
+specify a provider name directly. For requests that supply an existing image
+(editing, composition, or masking), call `transform_image` instead. Pass
+`model="<id>"` to pin a specific model_id within the provider. Use
+`list_providers` to see which providers are currently available, what models
+each has loaded, and per-model narrative guidance.
 """
 
 _SD_PROMPT_GUIDE = """\


### PR DESCRIPTION
## Reference-image input: documentation closeout

Closes #262. Completes the epic #256 documentation narrative.

The per-issue docs shipped with each capability PR (#257–#261); this catches the cross-cutting site narrative and the design/prompt references.

### Changes
- **New site guide** `docs/guides/image-input.md` — task-oriented workflows (edit, style transfer, multi-image composition, inpainting masks, SD `strength`) built on `transform_image`, with a per-provider capability matrix and cross-links to the provider pages and the tools reference. Added to the mkdocs nav and the `llmstxt` sections.
- **`docs/design/provider-system.md`** — documents the image-input primitive: the `reference_images` / `strength` / `mask` parameters on `generate()`, the `InputImage` resolver (`_input_images.py`), and the `supports_image_input` / `max_input_images` / `supports_mask` routing. This also reconciles the spec deferred from #261.
- **`select_provider` prompt** — adds a "Reference-Image Input (transform_image)" selection section, fixes the stale Gemini "up to 3 inputs" (now per-model: 3 on 2.5-flash, up to 14 on the Gemini 3 models), and mentions `transform_image` in Usage.
- **`docs/tools.md`** — back-links `transform_image` to the new guide and replaces a stale "Gemini and SD WebUI support one reference image" line with rot-proof guidance pointing at `list_providers` / the capability matrix.

### Verification
- `mkdocs build --strict` passes (all new cross-links resolve); 981 tests pass; ruff + mypy clean.
- A doc-accuracy review confirmed every capability claim against the provider code (Gemini 3/14, OpenAI 16, SD 1, masks = OpenAI gpt-image, `strength` = SD); it also caught the stale `tools.md` line now fixed.
- All prose added here is Vale-clean on its lines.

### Known gate
`Docs Prose (Vale)` remains red on ~1,243 **pre-existing** errors across the live docs (tech-term vocab gaps + the project's intentional em-dash style + a few ai-tells rules). Making Vale green is the dedicated #244, deferred here by maintainer decision. So #262's "Docs Prose CI passes" acceptance is not met in this PR; it will be once #244 lands. Bots have not yet reviewed the pushed commit; not a merge-ready signal.

Refs #256.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
