### PR TITLE
docs: correct PAID_PROVIDERS default in README (#264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ All domain environment variables use the `IMAGE_GENERATION_MCP_` prefix.
 
 | Variable | Default | Required | Description |
 |---|---|---|---|
-| `IMAGE_GENERATION_MCP_PAID_PROVIDERS` | `openai,gemini` | No | Comma-separated paid provider names. Triggers elicitation confirmation on capable clients. Set to empty to disable. |
+| `IMAGE_GENERATION_MCP_PAID_PROVIDERS` | `openai` | No | Comma-separated paid provider names. Triggers an elicitation cost-confirmation on capable clients. Gemini is omitted by default (generous free tier); add `gemini` if you rely on `quality="hd"`, which bills thinking tokens. Set to empty to disable. |
 | `IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE` | `64` | No | Max cached transforms. Set to `0` to disable caching. |
 
 ### Reference image input (`transform_image`)


### PR DESCRIPTION
## Correct the PAID_PROVIDERS default in the README

Closes #264.

`paid_providers` gates the cost-confirmation elicitation. The code default is `frozenset({"openai"})` (`config.py`), and `docs/configuration.md`, `docs/providers/gemini.md`, and `docs/tools.md` already document `openai`. Only the **README config table** claimed `openai,gemini` — the lone doc bug.

Gemini is intentionally **not** gated by default: it has a generous free tier (see `docs/providers/gemini.md`). Corrected the README cell to `openai` and added the rationale plus the nuance that `quality="hd"` bills thinking tokens (add `gemini` then).

### Scope
One-line README correction; no code change. The code default was already correct.

### Verification
`grep -rn "openai,gemini"` across `.md`/`.py` now finds no stray default (was only README.md:234).

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
