### PR TITLE
refactor(config): adopt ProjectConfig.from_env() classmethod (closes #274)

### DIFF
--- a/src/image_generation_mcp/_cli_impl.py
+++ b/src/image_generation_mcp/_cli_impl.py
@@ -36,7 +36,7 @@ def _normalise_http_path(path: str | None) -> str:
 def _cmd_serve(args: argparse.Namespace) -> None:
     """Run the MCP server."""
     try:
-        from image_generation_mcp.config import load_config
+        from image_generation_mcp.config import ProjectConfig
         from image_generation_mcp.server import make_server
     except ImportError:
         logger.error(
@@ -45,7 +45,7 @@ def _cmd_serve(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     transport = args.transport
-    config = load_config()
+    config = ProjectConfig.from_env()
     server = make_server(transport=transport, config=config)
     env_http_path = os.environ.get(f"{_ENV_PREFIX}_HTTP_PATH")
     http_path = _normalise_http_path(args.path or env_http_path)

--- a/src/image_generation_mcp/_server_deps.py
+++ b/src/image_generation_mcp/_server_deps.py
@@ -54,8 +54,8 @@ def make_service_lifespan(config: ProjectConfig) -> Any:
 
     Args:
         config: A fully-loaded :class:`~image_generation_mcp.config.ProjectConfig`
-            instance produced by a single :func:`load_config` call in
-            :func:`~image_generation_mcp.server.make_server`.
+            instance produced by a single :meth:`ProjectConfig.from_env` call
+            in :func:`~image_generation_mcp.server.make_server`.
 
     Returns:
         A FastMCP lifespan coroutine that initialises the service object and

--- a/src/image_generation_mcp/config.py
+++ b/src/image_generation_mcp/config.py
@@ -47,120 +47,120 @@ class ProjectConfig:
     max_input_image_bytes: int = 20 * 1024 * 1024
     # CONFIG-FIELDS-END
 
+    @classmethod
+    def from_env(cls) -> ProjectConfig:
+        """Load configuration from environment variables.
 
-def load_config() -> ProjectConfig:
-    """Load configuration from environment variables.
+        Reads:
 
-    Reads:
+        - ``IMAGE_GENERATION_MCP_READ_ONLY``: disable write tools; default ``true``.
+        - ``IMAGE_GENERATION_MCP_SCRATCH_DIR``: image save directory.
+        - ``IMAGE_GENERATION_MCP_OPENAI_API_KEY``: OpenAI API key.
+        - ``IMAGE_GENERATION_MCP_GOOGLE_API_KEY``: Google API key (Gemini).
+        - ``IMAGE_GENERATION_MCP_SD_WEBUI_HOST``: SD WebUI URL (also accepts deprecated ``A1111_HOST``).
+        - ``IMAGE_GENERATION_MCP_SD_WEBUI_MODEL``: SD WebUI checkpoint name (also accepts deprecated ``A1111_MODEL``).
+        - ``IMAGE_GENERATION_MCP_DEFAULT_PROVIDER``: default provider; default ``"auto"``.
+        - ``IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE``: transform LRU cache size; default ``64``.
+        - ``IMAGE_GENERATION_MCP_PAID_PROVIDERS``: comma-separated list; default ``"openai"``.
+        - ``IMAGE_GENERATION_MCP_STYLES_DIR``: style preset dir; default ``~/.image-generation-mcp/styles/``.
+        - ``IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT``: enable local file input; default ``false``.
+        - ``IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES``: max input image size in bytes; default ``20971520`` (20 MiB).
 
-    - ``IMAGE_GENERATION_MCP_READ_ONLY``: disable write tools; default ``true``.
-    - ``IMAGE_GENERATION_MCP_SCRATCH_DIR``: image save directory.
-    - ``IMAGE_GENERATION_MCP_OPENAI_API_KEY``: OpenAI API key.
-    - ``IMAGE_GENERATION_MCP_GOOGLE_API_KEY``: Google API key (Gemini).
-    - ``IMAGE_GENERATION_MCP_SD_WEBUI_HOST``: SD WebUI URL (also accepts deprecated ``A1111_HOST``).
-    - ``IMAGE_GENERATION_MCP_SD_WEBUI_MODEL``: SD WebUI checkpoint name (also accepts deprecated ``A1111_MODEL``).
-    - ``IMAGE_GENERATION_MCP_DEFAULT_PROVIDER``: default provider; default ``"auto"``.
-    - ``IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE``: transform LRU cache size; default ``64``.
-    - ``IMAGE_GENERATION_MCP_PAID_PROVIDERS``: comma-separated list; default ``"openai"``.
-    - ``IMAGE_GENERATION_MCP_STYLES_DIR``: style preset dir; default ``~/.image-generation-mcp/styles/``.
-    - ``IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT``: enable local file input; default ``false``.
-    - ``IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES``: max input image size in bytes; default ``20971520`` (20 MiB).
+        Plus all generic ``ServerConfig`` env vars (BASE_URL, BEARER_TOKEN,
+        OIDC_*, EVENT_STORE_URL, SERVER_NAME, INSTRUCTIONS) — see
+        ``fastmcp_pvl_core.ServerConfig.from_env``.
 
-    Plus all generic ``ServerConfig`` env vars (BASE_URL, BEARER_TOKEN,
-    OIDC_*, EVENT_STORE_URL, SERVER_NAME, INSTRUCTIONS) — see
-    ``fastmcp_pvl_core.ServerConfig.from_env``.
+        Returns:
+            A populated :class:`ProjectConfig` instance.
+        """
+        server = ServerConfig.from_env(_ENV_PREFIX)
 
-    Returns:
-        A populated :class:`ProjectConfig` instance.
-    """
-    server = ServerConfig.from_env(env_prefix=_ENV_PREFIX)
+        # CONFIG-FROM-ENV-START — image-generation domain reads; kept across copier update
+        # SERVER_NAME is an IG-domain field — core's ServerConfig does not carry it,
+        # so this is the only place it's read.
+        server_name = env(_ENV_PREFIX, "SERVER_NAME")
+        read_only = parse_bool(env(_ENV_PREFIX, "READ_ONLY", "true"))
 
-    # CONFIG-FROM-ENV-START — image-generation domain reads; kept across copier update
-    # SERVER_NAME is an IG-domain field — core's ServerConfig does not carry it,
-    # so this is the only place it's read.
-    server_name = env(_ENV_PREFIX, "SERVER_NAME")
-    read_only = parse_bool(env(_ENV_PREFIX, "READ_ONLY", "true"))
+        scratch_dir = Path(env(_ENV_PREFIX, "SCRATCH_DIR") or _DEFAULT_SCRATCH_DIR)
 
-    scratch_dir = Path(env(_ENV_PREFIX, "SCRATCH_DIR") or _DEFAULT_SCRATCH_DIR)
+        openai_api_key = env(_ENV_PREFIX, "OPENAI_API_KEY")
+        google_api_key = env(_ENV_PREFIX, "GOOGLE_API_KEY")
 
-    openai_api_key = env(_ENV_PREFIX, "OPENAI_API_KEY")
-    google_api_key = env(_ENV_PREFIX, "GOOGLE_API_KEY")
-
-    sd_webui_host = env(_ENV_PREFIX, "SD_WEBUI_HOST")
-    if not sd_webui_host and (legacy := env(_ENV_PREFIX, "A1111_HOST")):
-        logger.warning(
-            "IMAGE_GENERATION_MCP_A1111_HOST is deprecated — "
-            "use IMAGE_GENERATION_MCP_SD_WEBUI_HOST instead"
-        )
-        sd_webui_host = legacy
-
-    sd_webui_model = env(_ENV_PREFIX, "SD_WEBUI_MODEL")
-    if not sd_webui_model and (legacy := env(_ENV_PREFIX, "A1111_MODEL")):
-        logger.warning(
-            "IMAGE_GENERATION_MCP_A1111_MODEL is deprecated — "
-            "use IMAGE_GENERATION_MCP_SD_WEBUI_MODEL instead"
-        )
-        sd_webui_model = legacy
-
-    default_provider = env(_ENV_PREFIX, "DEFAULT_PROVIDER") or "auto"
-    if default_provider == "a1111":
-        logger.warning(
-            "DEFAULT_PROVIDER='a1111' is deprecated — use 'sd_webui' instead"
-        )
-        default_provider = "sd_webui"
-
-    raw_cache = env(_ENV_PREFIX, "TRANSFORM_CACHE_SIZE")
-    transform_cache_size = 64
-    if raw_cache:
-        try:
-            transform_cache_size = int(raw_cache)
-        except ValueError:
+        sd_webui_host = env(_ENV_PREFIX, "SD_WEBUI_HOST")
+        if not sd_webui_host and (legacy := env(_ENV_PREFIX, "A1111_HOST")):
             logger.warning(
-                "Invalid TRANSFORM_CACHE_SIZE=%r — using default 64", raw_cache
+                "IMAGE_GENERATION_MCP_A1111_HOST is deprecated — "
+                "use IMAGE_GENERATION_MCP_SD_WEBUI_HOST instead"
             )
+            sd_webui_host = legacy
 
-    raw_paid = env(_ENV_PREFIX, "PAID_PROVIDERS")
-    paid_providers = (
-        frozenset(p.lower() for p in parse_list(raw_paid))
-        if raw_paid is not None
-        else frozenset({"openai"})
-    )
-
-    styles_dir = Path(env(_ENV_PREFIX, "STYLES_DIR") or _DEFAULT_STYLES_DIR)
-
-    allow_local_file_input = parse_bool(
-        env(_ENV_PREFIX, "ALLOW_LOCAL_FILE_INPUT", "false")
-    )
-
-    raw_max_input = env(_ENV_PREFIX, "MAX_INPUT_IMAGE_BYTES")
-    max_input_image_bytes = 20 * 1024 * 1024
-    if raw_max_input:
-        try:
-            max_input_image_bytes = int(raw_max_input)
-        except ValueError:
+        sd_webui_model = env(_ENV_PREFIX, "SD_WEBUI_MODEL")
+        if not sd_webui_model and (legacy := env(_ENV_PREFIX, "A1111_MODEL")):
             logger.warning(
-                "Invalid MAX_INPUT_IMAGE_BYTES=%r — using default %d",
-                raw_max_input,
-                max_input_image_bytes,
+                "IMAGE_GENERATION_MCP_A1111_MODEL is deprecated — "
+                "use IMAGE_GENERATION_MCP_SD_WEBUI_MODEL instead"
             )
+            sd_webui_model = legacy
 
-    config = ProjectConfig(
-        server=server,
-        server_name=server_name,
-        read_only=read_only,
-        scratch_dir=scratch_dir,
-        openai_api_key=openai_api_key,
-        google_api_key=google_api_key,
-        sd_webui_host=sd_webui_host,
-        sd_webui_model=sd_webui_model,
-        default_provider=default_provider,
-        transform_cache_size=transform_cache_size,
-        paid_providers=paid_providers,
-        styles_dir=styles_dir,
-        allow_local_file_input=allow_local_file_input,
-        max_input_image_bytes=max_input_image_bytes,
-    )
-    # CONFIG-FROM-ENV-END
+        default_provider = env(_ENV_PREFIX, "DEFAULT_PROVIDER") or "auto"
+        if default_provider == "a1111":
+            logger.warning(
+                "DEFAULT_PROVIDER='a1111' is deprecated — use 'sd_webui' instead"
+            )
+            default_provider = "sd_webui"
 
-    logger.debug("load_config: read_only=%s", config.read_only)
-    return config
+        raw_cache = env(_ENV_PREFIX, "TRANSFORM_CACHE_SIZE")
+        transform_cache_size = 64
+        if raw_cache:
+            try:
+                transform_cache_size = int(raw_cache)
+            except ValueError:
+                logger.warning(
+                    "Invalid TRANSFORM_CACHE_SIZE=%r — using default 64", raw_cache
+                )
+
+        raw_paid = env(_ENV_PREFIX, "PAID_PROVIDERS")
+        paid_providers = (
+            frozenset(p.lower() for p in parse_list(raw_paid))
+            if raw_paid is not None
+            else frozenset({"openai"})
+        )
+
+        styles_dir = Path(env(_ENV_PREFIX, "STYLES_DIR") or _DEFAULT_STYLES_DIR)
+
+        allow_local_file_input = parse_bool(
+            env(_ENV_PREFIX, "ALLOW_LOCAL_FILE_INPUT", "false")
+        )
+
+        raw_max_input = env(_ENV_PREFIX, "MAX_INPUT_IMAGE_BYTES")
+        max_input_image_bytes = 20 * 1024 * 1024
+        if raw_max_input:
+            try:
+                max_input_image_bytes = int(raw_max_input)
+            except ValueError:
+                logger.warning(
+                    "Invalid MAX_INPUT_IMAGE_BYTES=%r — using default %d",
+                    raw_max_input,
+                    max_input_image_bytes,
+                )
+
+        config = cls(
+            server=server,
+            server_name=server_name,
+            read_only=read_only,
+            scratch_dir=scratch_dir,
+            openai_api_key=openai_api_key,
+            google_api_key=google_api_key,
+            sd_webui_host=sd_webui_host,
+            sd_webui_model=sd_webui_model,
+            default_provider=default_provider,
+            transform_cache_size=transform_cache_size,
+            paid_providers=paid_providers,
+            styles_dir=styles_dir,
+            allow_local_file_input=allow_local_file_input,
+            max_input_image_bytes=max_input_image_bytes,
+        )
+        # CONFIG-FROM-ENV-END
+
+        logger.debug("from_env: read_only=%s", config.read_only)
+        return config

--- a/src/image_generation_mcp/server.py
+++ b/src/image_generation_mcp/server.py
@@ -127,9 +127,7 @@ def make_server(
         A configured :class:`fastmcp.FastMCP` instance.
     """
     if config is None:
-        from image_generation_mcp.config import load_config
-
-        config = load_config()
+        config = ProjectConfig.from_env()
     configure_logging_from_env()
 
     auth = build_auth(config.server)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 """Tests for config.py — env var loading edge cases.
 
 Covers:
-- load_config() with various env var combinations
+- ProjectConfig.from_env() with various env var combinations
 - scratch dir default and custom path
 - openai_api_key, sd_webui_host, sd_webui_model, default_provider branches
 - TRANSFORM_CACHE_SIZE invalid value logs warning and uses default
@@ -25,7 +25,7 @@ from fastmcp_pvl_core import parse_bool as _parse_bool
 
 from image_generation_mcp.config import (
     _DEFAULT_SCRATCH_DIR,
-    load_config,
+    ProjectConfig,
 )
 
 
@@ -42,86 +42,86 @@ class TestParseBool:
 
 
 class TestLoadConfigDefaults:
-    """load_config() with no env vars uses ProjectConfig defaults."""
+    """ProjectConfig.from_env() with no env vars uses ProjectConfig defaults."""
 
     def test_read_only_default(self) -> None:
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.read_only is True
 
     def test_scratch_dir_default(self) -> None:
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.scratch_dir == _DEFAULT_SCRATCH_DIR
 
     def test_openai_api_key_default_none(self) -> None:
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.openai_api_key is None
 
     def test_sd_webui_host_default_none(self) -> None:
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.sd_webui_host is None
 
     def test_default_provider_default_auto(self) -> None:
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.default_provider == "auto"
 
     def test_transform_cache_size_default(self) -> None:
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.transform_cache_size == 64
 
     def test_paid_providers_default(self) -> None:
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.paid_providers == frozenset({"openai"})
 
 
 class TestLoadConfigEnvVars:
-    """load_config() reads env vars correctly."""
+    """ProjectConfig.from_env() reads env vars correctly."""
 
     def test_read_only_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_READ_ONLY", "false")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.read_only is False
 
     def test_scratch_dir_custom(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_SCRATCH_DIR", str(tmp_path))
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.scratch_dir == tmp_path
 
     def test_openai_api_key_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_OPENAI_API_KEY", "sk-test-key")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.openai_api_key == "sk-test-key"
 
     def test_google_api_key_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_GOOGLE_API_KEY", "AIza-test")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.google_api_key == "AIza-test"
 
     def test_google_api_key_unset(self) -> None:
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.google_api_key is None
 
     def test_sd_webui_host_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(
             "IMAGE_GENERATION_MCP_SD_WEBUI_HOST", "http://localhost:7860"
         )
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.sd_webui_host == "http://localhost:7860"
 
     def test_sd_webui_model_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_SD_WEBUI_MODEL", "dreamshaper_xl")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.sd_webui_model == "dreamshaper_xl"
 
     def test_default_provider_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_DEFAULT_PROVIDER", "placeholder")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.default_provider == "placeholder"
 
     def test_transform_cache_size_valid(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE", "128")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.transform_cache_size == 128
 
     def test_transform_cache_size_invalid_uses_default(
@@ -129,20 +129,20 @@ class TestLoadConfigEnvVars:
     ) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE", "not-a-number")
         with caplog.at_level(logging.WARNING):
-            config = load_config()
+            config = ProjectConfig.from_env()
         assert config.transform_cache_size == 64
         assert "Invalid TRANSFORM_CACHE_SIZE" in caplog.text
 
     def test_base_url_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_BASE_URL", "https://mcp.example.com/")
-        config = load_config()
+        config = ProjectConfig.from_env()
         # core's ServerConfig preserves the trailing slash — consumers strip it
         # at use (e.g. create_download_link in _server_tools.py).
         assert config.server.base_url == "https://mcp.example.com/"
 
     def test_paid_providers_custom(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_PAID_PROVIDERS", "openai,sd_webui")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.paid_providers == frozenset({"openai", "sd_webui"})
 
     def test_paid_providers_empty_falls_back_to_default(
@@ -151,12 +151,12 @@ class TestLoadConfigEnvVars:
         # core's env() treats empty string as unset, so the default kicks in.
         # To explicitly clear the set, point at the "none" marker below.
         monkeypatch.setenv("IMAGE_GENERATION_MCP_PAID_PROVIDERS", "")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.paid_providers == frozenset({"openai"})
 
     def test_paid_providers_with_spaces(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_PAID_PROVIDERS", " openai , sd_webui ")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert "openai" in config.paid_providers
         assert "sd_webui" in config.paid_providers
 
@@ -171,7 +171,7 @@ class TestLoadConfigEnvVars:
         monkeypatch.setenv("IMAGE_GENERATION_MCP_SD_WEBUI_MODEL", "checkpoint_v1")
         monkeypatch.setenv("IMAGE_GENERATION_MCP_DEFAULT_PROVIDER", "openai")
         monkeypatch.setenv("IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE", "32")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.read_only is False
         assert config.scratch_dir == tmp_path
         assert config.openai_api_key == "sk-key"
@@ -182,14 +182,14 @@ class TestLoadConfigEnvVars:
 
 
 class TestLoadConfigDeprecatedEnvVars:
-    """load_config() accepts deprecated A1111_* env vars with a warning."""
+    """ProjectConfig.from_env() accepts deprecated A1111_* env vars with a warning."""
 
     def test_a1111_host_sets_sd_webui_host(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Deprecated IMAGE_GENERATION_MCP_A1111_HOST maps to sd_webui_host."""
         monkeypatch.setenv("IMAGE_GENERATION_MCP_A1111_HOST", "http://host:7860")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.sd_webui_host == "http://host:7860"
 
     def test_a1111_host_deprecated_logs_warning(
@@ -198,7 +198,7 @@ class TestLoadConfigDeprecatedEnvVars:
         """Setting A1111_HOST logs a deprecation warning."""
         monkeypatch.setenv("IMAGE_GENERATION_MCP_A1111_HOST", "http://host:7860")
         with caplog.at_level(logging.WARNING):
-            load_config()
+            ProjectConfig.from_env()
         assert "A1111_HOST" in caplog.text
         assert "deprecated" in caplog.text.lower()
 
@@ -208,7 +208,7 @@ class TestLoadConfigDeprecatedEnvVars:
         """When both SD_WEBUI_HOST and A1111_HOST are set, new name wins."""
         monkeypatch.setenv("IMAGE_GENERATION_MCP_SD_WEBUI_HOST", "http://new-host:7860")
         monkeypatch.setenv("IMAGE_GENERATION_MCP_A1111_HOST", "http://old-host:7860")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.sd_webui_host == "http://new-host:7860"
 
     def test_a1111_model_sets_sd_webui_model(
@@ -216,7 +216,7 @@ class TestLoadConfigDeprecatedEnvVars:
     ) -> None:
         """Deprecated IMAGE_GENERATION_MCP_A1111_MODEL maps to sd_webui_model."""
         monkeypatch.setenv("IMAGE_GENERATION_MCP_A1111_MODEL", "dreamshaper_8")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.sd_webui_model == "dreamshaper_8"
 
     def test_a1111_model_deprecated_logs_warning(
@@ -225,7 +225,7 @@ class TestLoadConfigDeprecatedEnvVars:
         """Setting A1111_MODEL logs a deprecation warning."""
         monkeypatch.setenv("IMAGE_GENERATION_MCP_A1111_MODEL", "dreamshaper_8")
         with caplog.at_level(logging.WARNING):
-            load_config()
+            ProjectConfig.from_env()
         assert "A1111_MODEL" in caplog.text
         assert "deprecated" in caplog.text.lower()
 
@@ -235,7 +235,7 @@ class TestLoadConfigDeprecatedEnvVars:
         """When both SD_WEBUI_MODEL and A1111_MODEL are set, new name wins."""
         monkeypatch.setenv("IMAGE_GENERATION_MCP_SD_WEBUI_MODEL", "new_model")
         monkeypatch.setenv("IMAGE_GENERATION_MCP_A1111_MODEL", "old_model")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.sd_webui_model == "new_model"
 
     def test_default_provider_a1111_maps_to_sd_webui(
@@ -243,7 +243,7 @@ class TestLoadConfigDeprecatedEnvVars:
     ) -> None:
         """Deprecated DEFAULT_PROVIDER="a1111" is remapped to "sd_webui"."""
         monkeypatch.setenv("IMAGE_GENERATION_MCP_DEFAULT_PROVIDER", "a1111")
-        config = load_config()
+        config = ProjectConfig.from_env()
         assert config.default_provider == "sd_webui"
 
     def test_default_provider_a1111_logs_warning(
@@ -252,35 +252,27 @@ class TestLoadConfigDeprecatedEnvVars:
         """Setting DEFAULT_PROVIDER=a1111 logs a deprecation warning."""
         monkeypatch.setenv("IMAGE_GENERATION_MCP_DEFAULT_PROVIDER", "a1111")
         with caplog.at_level(logging.WARNING):
-            load_config()
+            ProjectConfig.from_env()
         assert "deprecated" in caplog.text.lower()
 
 
 def test_allow_local_file_input_defaults_false(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT", raising=False)
-    from image_generation_mcp.config import load_config
-
-    assert load_config().allow_local_file_input is False
+    assert ProjectConfig.from_env().allow_local_file_input is False
 
 
 def test_allow_local_file_input_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT", "true")
-    from image_generation_mcp.config import load_config
-
-    assert load_config().allow_local_file_input is True
+    assert ProjectConfig.from_env().allow_local_file_input is True
 
 
 def test_max_input_image_bytes_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES", raising=False)
-    from image_generation_mcp.config import load_config
-
-    assert load_config().max_input_image_bytes == 20 * 1024 * 1024
+    assert ProjectConfig.from_env().max_input_image_bytes == 20 * 1024 * 1024
 
 
 def test_max_input_image_bytes_invalid_falls_back(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES", "notanumber")
-    from image_generation_mcp.config import load_config
-
-    assert load_config().max_input_image_bytes == 20 * 1024 * 1024
+    assert ProjectConfig.from_env().max_input_image_bytes == 20 * 1024 * 1024


### PR DESCRIPTION
## Summary

Migrates this repo's config loader from the module-level `load_config()` factory to a `ProjectConfig.from_env()` **classmethod**, matching the `fastmcp-server-template` convention. First step of the template re-convergence epic (#273).

## Why

Template v2.6.0 ships `tests/test_config_wizard_drift.py`, which introspects `ProjectConfig.from_env` via `inspect.getsource`. The repo's `load_config()` pattern fails that gate out of the box:

```
AttributeError: type object 'ProjectConfig' has no attribute 'from_env'
```

Sibling `paperless-mcp` already uses `ProjectConfig.from_env()`, confirming this is the live convention, not a new design choice.

## What changed

- **`config.py`** — `load_config()` → `ProjectConfig.from_env()` classmethod. The env-read body is preserved verbatim: deprecation warnings (`A1111_HOST`/`A1111_MODEL`, `DEFAULT_PROVIDER='a1111'`), `int()` validation fallbacks (`TRANSFORM_CACHE_SIZE`, `MAX_INPUT_IMAGE_BYTES`), and the `CONFIG-FROM-ENV` sentinel. Replaced directly — no compatibility shim, per the repo's refactor discipline.
- **`server.py`, `_cli_impl.py`** — callers use `ProjectConfig.from_env()` (dropped the function-local `load_config` imports).
- **`_server_deps.py`** — docstring cross-reference updated.
- **`tests/test_config.py`** — ~43 `load_config()` call sites rewritten to `ProjectConfig.from_env()`; no assertions weakened.

No behavior change.

## Verification

- `grep load_config src tests` → zero references.
- ruff check ✓ · ruff format --check ✓ · mypy (69 files) ✓ · pre-commit ✓
- `pytest` → 981 passed, 2 skipped; `config.py` at **100% line + branch** coverage.
- Drift-detector mechanism confirmed: AST introspection of `from_env`'s source exposes all 15 domain env suffixes.

## Scope boundary

The `fastmcp-pvl-core` floor bump (`>=4.2.0`, which `test_config_wizard_drift.py` also needs for `server_config_env_suffixes`) and the drift test file itself land with the copier update (#279), not here — bundling them would scope-creep this into the update.

Part of #273. Closes #274.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
