### PR TITLE
test: add template client fixture + smoke coverage (closes #277)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastmcp import Client
+
+from image_generation_mcp.server import make_server
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import AsyncIterator, Generator
+    from pathlib import Path
+    from typing import Any
 
     from image_generation_mcp.providers.gemini import GeminiImageProvider
 
@@ -25,6 +30,24 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for key in list(os.environ):
         if key.startswith("IMAGE_GENERATION_MCP_"):
             monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+async def client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[Client[Any]]:
+    """In-memory FastMCP client connected to a fresh ``make_server()``.
+
+    Template-conformant smoke fixture: the lifespan runs on connect, so the
+    yielded client exercises the wired server (tools / resources / prompts and
+    the started service). Scratch/styles dirs are pointed at ``tmp_path`` so the
+    lifespan's style-library load (and any image writes) never touch the user's
+    home directory.
+    """
+    monkeypatch.setenv("IMAGE_GENERATION_MCP_SCRATCH_DIR", str(tmp_path / "images"))
+    monkeypatch.setenv("IMAGE_GENERATION_MCP_STYLES_DIR", str(tmp_path / "styles"))
+    async with Client(make_server()) as c:
+        yield c
 
 
 @pytest.fixture

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -30,6 +30,7 @@ async def test_get_server_info_tool_registered(client: Client[Any]) -> None:
     assert "get_server_info" in tools
 
     result = await client.call_tool("get_server_info", {})
+    assert result.content, "get_server_info returned no content"
     first = result.content[0]
     assert hasattr(first, "text"), (
         f"expected text tool content, got {type(first).__name__}"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,6 +1,19 @@
-"""Smoke tests for Image Generation MCP."""
+"""Smoke tests for Image Generation MCP.
+
+Restores the template's smoke-coverage classes adapted to this server's actual
+MCP surface: server construction, ``get_server_info``, and that the core domain
+tools and prompts are wired. The template's example-specific smoke tests
+(``status://`` resource, ``summarize`` prompt, ``_server_apps.register_apps``,
+the template ``register_file_exchange`` check) don't port — this repo replaced
+those scaffolds with domain features covered by their own test modules.
+"""
 
 from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastmcp import Client
 
 from image_generation_mcp.server import make_server
 
@@ -9,3 +22,31 @@ def test_make_server_constructs() -> None:
     """make_server() returns a FastMCP instance without raising."""
     server = make_server()
     assert server is not None
+
+
+async def test_get_server_info_tool_registered(client: Client[Any]) -> None:
+    """``get_server_info`` is wired and returns the wrapper info block."""
+    tools = {t.name for t in await client.list_tools()}
+    assert "get_server_info" in tools
+
+    result = await client.call_tool("get_server_info", {})
+    first = result.content[0]
+    assert hasattr(first, "text"), (
+        f"expected text tool content, got {type(first).__name__}"
+    )
+    payload = json.loads(first.text)
+    assert payload["server_name"] == "image-generation-mcp"
+    assert "server_version" in payload
+    assert "core_version" in payload
+
+
+async def test_core_tools_registered(client: Client[Any]) -> None:
+    """A core read tool is discoverable on the default (read-only) server."""
+    tools = {t.name for t in await client.list_tools()}
+    assert "list_providers" in tools
+
+
+async def test_domain_prompts_registered(client: Client[Any]) -> None:
+    """The domain prompts are registered and discoverable."""
+    prompts = {p.name for p in await client.list_prompts()}
+    assert {"select_provider", "sd_prompt_guide", "apply_style"} <= prompts


### PR DESCRIPTION
## Summary

Re-converges the template-owned test scaffolding (#277). This repo only ever carried a **no-op placeholder** `test_smoke.py` and **no shared `client` fixture** (the template's example smoke tests never ported cleanly), so this brings both up to real, template-conformant coverage.

## What changed

- **`conftest.py`** — adds the template's async `client` fixture (in-memory FastMCP `Client` over `make_server()`; the lifespan runs on connect, so the yielded client exercises the wired server). It points scratch/styles dirs at `tmp_path` so the lifespan's style-library load never writes to the user's home directory. Existing domain fixtures kept.
- **`test_smoke.py`** — smoke coverage adapted to this server's actual MCP surface: `get_server_info` (wired here), a core read tool (`list_providers`), and the domain prompts (`select_provider`/`sd_prompt_guide`/`apply_style`). `test_make_server_constructs` retained.

## Why not the template's other four smoke tests

They target example scaffolds this repo replaced with domain features, so they can't port verbatim:

| Template smoke test | Why it doesn't port |
|---|---|
| `test_register_apps_logs…` | repo has no `_server_apps.py` |
| `test_status_resource…` (`status://`) | replaced by domain resources (gallery/viewer) |
| `test_summarize_prompt…` | replaced by domain prompts |
| `test_no_file_exchange_scaffolding` | repo ships its own `create_download_link` |

Those domain features are covered by their own modules (`test_mcp_integration`, `test_resources`, `test_prompts`, …).

## Verification

- ruff check ✓ · ruff format --check ✓ · mypy (66 files) ✓ · pre-commit ✓
- `pytest` → **909 passed**, 2 skipped. New smoke tests assert real registered names/values (not tautological); the `client` fixture is function-scoped (fresh server per test) and writes only under `tmp_path`.
- Local preflight (7 lenses) cleared the change; a flagged latent home-dir-write in the fixture (style-library load on a clean machine) is fixed by the `tmp_path` scratch/styles override.

Part of #273.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
