### PR TITLE
chore: add gitleaks pre-commit + restore vendor_spa.py (closes #278)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,12 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
       - id: check-json
+
+  # gitleaks secret scanning — the same scanner as the ci.yml secrets job
+  # (which runs gitleaks/gitleaks-action); versions are pinned independently.
+  # Satisfies CLAUDE.md's pre-commit/CI secret-scanning alignment. pre-commit
+  # fetches the gitleaks binary itself and honours the repo's .gitleaks.toml.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,7 @@ repos:
       - id: check-added-large-files
       - id: check-json
 
-  # gitleaks secret scanning — the same scanner as the ci.yml secrets job
-  # (which runs gitleaks/gitleaks-action); versions are pinned independently.
-  # Satisfies CLAUDE.md's pre-commit/CI secret-scanning alignment. pre-commit
-  # fetches the gitleaks binary itself and honours the repo's .gitleaks.toml.
+  # gitleaks secret scanning; pre-commit fetches the binary and honours .gitleaks.toml
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1
     hooks:

--- a/scripts/vendor_spa.py
+++ b/scripts/vendor_spa.py
@@ -1,0 +1,18 @@
+"""Vendor SPA dependencies inline (starter).
+
+Copy MV's scripts/vendor_spa.py once you're ready to ship a real MCP
+Apps UI.  Until then, this is a documented no-op.
+"""
+
+from __future__ import annotations
+
+
+def main() -> None:
+    """No-op placeholder — replace with real vendor pipeline when needed."""
+    print(
+        "vendor_spa.py: no-op placeholder — see MV's scripts/vendor_spa.py for the real pipeline."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Minor template-conformance cleanup (#278). Two of the three audited items; the third is intentionally **not** done because restoring it would reverse a sound security decision.

## What changed

- **`.pre-commit-config.yaml`** — add the gitleaks hook (template's `v8.30.1`, scanning with the repo's existing `.gitleaks.toml`). This makes CLAUDE.md's pre-commit claim — *"runs … gitleaks secret scanning … aligned with the ci.yml … secrets job so a clean pre-commit run implies a clean CI lane"* — **true**, rather than weakening the doc to excuse the gap. `pre-commit run --all-files` passes incl. gitleaks (the `.gitleaks.toml` allowlist covers the test fake-keys). Vale is intentionally not added (needs a system binary; CLAUDE.md doesn't claim pre-commit prose-linting).
- **`scripts/vendor_spa.py`** — restore the template's documented no-op placeholder (template-owned / always-rendered; pre-empts a copier-update re-creation).

## Not done — and why

**Restoring the CodeQL `query-filters` block** (the audit listed it). PR #34 **deliberately removed** that filter after explicit gemini + maintainer consensus: it suppresses `py/clear-text-storage-of-sensitive-information` for a scaffold `src/…/git.py` this repo doesn't have, and *"if a future git.py is added, it may silently bypass a real alert."* Restoring it would reverse that security decision and re-introduce the latent-suppression hazard. The template shipping a filter for a non-existent file is **upstream template debt** (cf. #271) — to fix in `fastmcp-server-template` or handle on the #279 copier update, not re-introduce here.

## Verification

- `pre-commit run --all-files` green (ruff, mypy, gitleaks, standard hooks).
- `vendor_spa.py` runs as a documented no-op; ruff/mypy clean.
- Local preflight (6 lenses) flagged the codeql reversal (now reverted) and a comment over-claim (softened); gitleaks + vendor_spa cleared.

Part of #273. Closes #278.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
