### PR TITLE
chore(copier): update template v2.5.3 → v2.6.0 (conflicts + lock) [red until wizard PR]

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.5.3
+_commit: v2.6.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: MCP server for AI image generation via OpenAI, Google GenAI, or

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,37 @@
+name: Bootstrap repo
+
+# Seeds repository labels that checked-in config references but that GitHub
+# does not create on its own.  `.github/dependabot.yml` applies the
+# `dependencies` label to the PRs it opens; a freshly generated repo has no
+# such label, so without this those PRs would land unlabelled (Dependabot
+# silently drops labels that don't exist).
+#
+# Idempotent: `gh label create --force` creates the label or updates it in
+# place, so every run is a no-op once the label exists.  The first push to the
+# default branch seeds it; `workflow_dispatch` lets you re-seed on demand.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/bootstrap.yml
+      - .github/dependabot.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  labels:
+    name: Ensure repository labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create dependencies label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh label create dependencies \
+            --color 0366d6 \
+            --description "Pull requests that update a dependency" \
+            --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-${{ runner.os }}
@@ -51,7 +51,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-${{ runner.os }}
@@ -97,7 +97,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           # `uv python install` writes to UV_PYTHON_INSTALL_DIR, which is
           # separate from the uv package cache and not covered by setup-uv's
@@ -219,7 +219,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-${{ runner.os }}
@@ -252,7 +252,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v3.0.0
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -279,7 +279,7 @@ jobs:
         # Pack list mirrors the Packages = line in .vale.ini; if you add or
         # remove a pack, update both. Bump the v1- prefix to evict all cached
         # packs if Vale changes pack format backward-incompatibly.
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             .vale/styles/Google

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,16 @@ Domain configuration composes `fastmcp_pvl_core.ServerConfig` inside your domain
 
 Env var prefix is `IMAGE_GENERATION_MCP_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
 
+### Config wizard
+
+`docs/javascripts/config-wizard/wizard-spec.json` drives the guided-setup page. It is **domain-owned and write-once** (`_skip_if_exists`): the runtime (`wizard.js`, `generators.js`, `wizard-spec-schema.json`, the generic tests) is template-owned and re-rendered, but the spec itself is never re-rendered, so it does **not** auto-update when you add config or when the template grows new questions. Reconcile it by hand.
+
+Two rules keep the spec honest:
+
+- **Cover the `ServerConfig` surface.** The seed covers the full `ServerConfig` surface plus logging; the drift test enforces completeness, so no explicit field list needs hand-maintaining here. When you add a domain setting that an operator would plausibly configure, add a question for it. When you adopt a new upstream setting, surface it too.
+- **Coverage is CI-enforced:** `tests/test_config_wizard_drift.py` fails if the wizard offers a var no read site consumes (orphan) or omits a setting the server reads: both `ServerConfig` (via `server_config_env_suffixes()`) and your `ProjectConfig.from_env`. Offer every setting; hide niche ones with `advancedGroup`, never by omission. For the coverage check, the only escape is `_COVERED_BY_INFERENCE`, for settings with no dedicated control by design (for example, `AUTH_MODE`, inferred from which auth vars are set). For the orphan check, `FASTMCP_*` vars are exempt: their prefix never matches `IMAGE_GENERATION_MCP_`, so they sit outside the coverage check by construction, and they are read by FastMCP itself rather than by project code.
+- **Only offer vars the server actually consumes.** Every `var` must resolve to a real read site (`ServerConfig.from_env`, your `ProjectConfig.from_env`, the CLI, or a native `FASTMCP_*` var) — *advertised but unread* env vars (e.g. a hint that mentions `IMAGE_GENERATION_MCP_SERVER_NAME` while the scaffold hardcodes the name) must not appear. List secret-bearing vars in `secretKeys` so the wizard masks them and keeps them out of the shareable link. A question may legitimately have **no `var`** when it is a wizard-internal routing key — the seed's `auth` select drives `showIf` but maps to no single env var (auth mode is inferred by `ServerConfig` from which vars are set), so it is not an orphan. Gate `showIf`/`guards` on the questions that are actually visible, and make every `showIf` self-contained: because the runtime checks raw answers with no cascade, a question gated on `auth` must *also* gate on `deployment=server` (the gate on `auth` itself), or it leaks — and emits its var — when `auth` is hidden but its stale answer lingers.
+
 ### Tool icons
 
 Drop SVG / PNG / ICO / JPEG files into `src/image_generation_mcp/static/icons/` and bulk-attach them to registered tools via `fastmcp_pvl_core.register_tool_icons(mcp, {"tool_name": "filename.svg"}, static_dir=...)` at the end of `register_tools()` — or attach at decoration time with `@mcp.tool(icons=[make_icon(STATIC / "x.svg")])` (where `STATIC = Path(__file__).parent / "static" / "icons"` is a shorthand you define at module level). The scaffold ships an empty `static/icons/` directory; commented-out wiring lives in `tools.py`.
@@ -155,6 +165,17 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 - `# DOCKERFILE-UV-EXTRAS-START` / `-END` — `--extra <name>` flags added to both `uv sync` invocations (deps cache layer + project install — adding only to one breaks the cache layer)
 - `# DOCKERFILE-STATE-DIRS-START` / `-END` — state subdirectories created under `/data` (chowned to the runtime user)
 - `# DOCKERFILE-VOLUMES-START` / `-END` — `VOLUME` declarations on the final image
+
+## Tool Registration Checklist
+
+Every MCP tool you register must carry the full set of metadata below — not just the behaviour. A tool that works but lacks a title, hints, or docs is incomplete. When adding or changing a tool, verify each item:
+
+- **Title** — a human-readable `annotations.title` (e.g. `"Search Vault"`). Title-aware clients (notably VS Code, which honours only `title` and `readOnlyHint` among annotations) render this as the tool's label; without it they fall back to the raw machine name. Set it inline in the tool's `annotations={...}` dict.
+- **Behavioural hints** — `readOnlyHint`, and where they apply `destructiveHint` / `idempotentHint`, in the same `annotations` dict. These describe side effects accurately (a destructive tool must set `destructiveHint=True`).
+- **Icon** — an entry wired via `register_tool_icons(...)` or `@mcp.tool(icons=[...])` (see [Tool icons](#tool-icons)).
+- **Docstring** — a Google-style docstring; FastMCP surfaces it as the tool description and per-parameter docs.
+- **Docs entry** — a row in your published tools reference (e.g. `docs/tools/index.md`) so the tool is documented for users (per [Documentation Discipline](#documentation-discipline)).
+- **Enforcement test** — keep a test that enumerates the registered tools and asserts each carries the metadata above (at minimum a non-empty `annotations.title`). Enumerate the *full* registry, not just the client-facing listing, so app-only / hidden tools cannot slip past. Such a test turns this checklist into a CI gate: a future tool added without a title fails loudly rather than silently shipping its machine name.
 
 ## Server Info Tool (`get_server_info`)
 

--- a/FORKING.md
+++ b/FORKING.md
@@ -52,15 +52,28 @@ the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
 ```bash
 # -i.bak + rm keeps this portable across GNU sed (Linux) and BSD sed (macOS),
 # which disagree on the in-place flag's syntax.
-sed -i.bak '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md && rm -f CLAUDE.md.bak
+sed -i.bak \
+  -e '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' \
+  -e '/<!-- ===== TEMPLATE-OWNED SECTIONS BELOW/d' \
+  -e '/<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->/d' \
+  -e 's/ Kept across copier update\.//' \
+  -e 's/ on top of the shipped defaults survive `copier update`\./ on top of the shipped defaults are yours to maintain./' \
+  -e 's/ are preserved across `copier update`\./ are domain-owned./' \
+  -e 's/The block is preserved across `copier update`\./The block is domain-owned./' \
+  CLAUDE.md && rm -f CLAUDE.md.bak
 ```
 
 This deletes the template-coupled sections — the bot-reviewer merge-gate
-paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** —
-while keeping the fork-neutral contributor guidance (Conventions, the PR
-acceptance gates, the Logging Standard, the config contract, GitHub Review
-Types). If your fork added its own `.claude/CLAUDE.md`, apply the same scrub
-there.
+paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** — and
+strips the copier-update wording that no longer describes a detached fork: the
+`TEMPLATE-OWNED SECTIONS` banner fences (a fork owns every section, so the
+template/domain split is moot), the "Kept across copier update" notes on the
+DOMAIN blocks, and the remaining "preserved/survive across copier update" notes
+(the pre-commit defaults, the `Dockerfile` sentinels, and the upstream sentinel).
+The fork-neutral contributor guidance
+(Conventions, the PR acceptance gates, the Logging Standard, the config
+contract, GitHub Review Types) is kept. If your fork added its own
+`.claude/CLAUDE.md`, apply the same scrub there.
 
 ## Step 4 — README cleanup (optional)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <!-- mcp-name: io.github.pvliesdonk/image-generation-mcp -->
 # Image Generation MCP
 
+<!-- mcp-name: io.github.pvliesdonk/image-generation-mcp -->
+
 [![CI](https://github.com/pvliesdonk/image-generation-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/image-generation-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/image-generation-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/image-generation-mcp) [![PyPI](https://img.shields.io/pypi/v/image-generation-mcp)](https://pypi.org/project/image-generation-mcp/) [![Python](https://img.shields.io/pypi/pyversions/image-generation-mcp)](https://pypi.org/project/image-generation-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/image-generation-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/image-generation-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/image-generation-mcp/pkgs/container/image-generation-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/image-generation-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/image-generation-mcp/llms.txt) [![Template](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/pvliesdonk/image-generation-mcp/main/.copier-answers.yml&query=%24._commit&label=template)](https://github.com/pvliesdonk/fastmcp-server-template)
 
 Multi-provider image generation [MCP](https://modelcontextprotocol.io) server built on [FastMCP](https://gofastmcp.com). Generate images from Claude Desktop, Claude Code, or any MCP client using OpenAI, Google Gemini, Stable Diffusion (SD WebUI), or a zero-cost placeholder provider.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- mcp-name: io.github.pvliesdonk/image-generation-mcp -->
 # Image Generation MCP
 
 <!-- mcp-name: io.github.pvliesdonk/image-generation-mcp -->

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,18 @@ All configuration is via environment variables prefixed with `IMAGE_GENERATION_M
 | `IMAGE_GENERATION_MCP_DEFAULT_PROVIDER` | str | `auto` | Default provider selection. Options: `auto` (keyword-based selection), `gemini`, `openai`, `sd_webui`, `placeholder`. |
 | `IMAGE_GENERATION_MCP_STYLES_DIR` | Path | `~/.image-generation-mcp/styles/` | Directory for style preset files (`.md` with YAML frontmatter). Created automatically if it does not exist. See the [Style Library Guide](guides/styles.md). |
 
+## Server identity
+
+These two are read by the scaffold's `make_server()` (not by
+`ServerConfig`), so an operator can rename an instance or override its
+instructions without editing template-owned code:
+
+- `IMAGE_GENERATION_MCP_SERVER_NAME`: the server name reported to clients and
+  by `get_server_info`. Defaults to `image-generation-mcp`.
+- `IMAGE_GENERATION_MCP_INSTRUCTIONS`: replaces the default MCP instructions
+  text. Unset, the scaffold builds the default (which advertises this
+  override).
+
 <!-- DOMAIN-CONFIG-VARS-START -->
 ## Providers
 

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -8,7 +8,9 @@
   "secretKeys": [
     "IMAGE_GENERATION_MCP_BEARER_TOKEN",
     "IMAGE_GENERATION_MCP_OPENAI_API_KEY",
-    "IMAGE_GENERATION_MCP_GOOGLE_API_KEY"
+    "IMAGE_GENERATION_MCP_GOOGLE_API_KEY",
+    "IMAGE_GENERATION_MCP_OIDC_CLIENT_SECRET",
+    "IMAGE_GENERATION_MCP_OIDC_JWT_SIGNING_KEY"
   ],
   "questions": [
     {
@@ -17,17 +19,171 @@
       "help": "Local stdio for Claude Desktop/Code, or an HTTP server for Docker/systemd.",
       "type": "select",
       "options": [
-        { "value": "local", "label": "Local (Claude Desktop / Claude Code, stdio)" },
-        { "value": "server", "label": "Server (HTTP — Docker / Compose / systemd)" }
+        { "value": "local", "label": "Local (Claude Desktop / Claude Code, stdio)", "emit": { "IMAGE_GENERATION_MCP_TRANSPORT": "stdio" } },
+        { "value": "server", "label": "Server (HTTP — Docker / Compose / systemd)", "emit": { "IMAGE_GENERATION_MCP_TRANSPORT": "http" } }
+      ]
+    },
+    {
+      "id": "base_url",
+      "label": "Public base URL",
+      "help": "e.g. https://mcp.example.com — required for OIDC and MCP Apps.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_BASE_URL",
+      "showIf": { "deployment": ["server"] }
+    },
+    {
+      "id": "http_path",
+      "label": "HTTP endpoint path",
+      "help": "Mount path for the MCP endpoint, e.g. /mcp. Defaults to /mcp when unset.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_HTTP_PATH",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Server"
+    },
+    {
+      "id": "host",
+      "label": "Bind host",
+      "help": "Interface the HTTP server binds to. Default 127.0.0.1.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_HOST",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Server"
+    },
+    {
+      "id": "port",
+      "label": "Port",
+      "help": "TCP port for the HTTP server. Default 8000.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_PORT",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Server"
+    },
+    {
+      "id": "auth",
+      "label": "Authentication",
+      "type": "select",
+      "showIf": { "deployment": ["server"] },
+      "options": [
+        { "value": "none", "label": "None" },
+        { "value": "bearer", "label": "Bearer token" },
+        { "value": "oidc", "label": "OIDC" },
+        { "value": "both", "label": "Bearer + OIDC" }
       ]
     },
     {
       "id": "bearer_token",
       "label": "Bearer token",
-      "help": "Any non-empty string enables bearer auth. Leave blank for no authentication.",
+      "help": "Any non-empty string enables bearer auth. Browser-only.",
       "type": "text",
       "var": "IMAGE_GENERATION_MCP_BEARER_TOKEN",
-      "showIf": { "deployment": ["server"] }
+      "showIf": { "deployment": ["server"], "auth": ["bearer", "both"] }
+    },
+    {
+      "id": "oidc_config_url",
+      "label": "OIDC discovery URL",
+      "help": "e.g. https://auth.example.com/.well-known/openid-configuration",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_CONFIG_URL",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] }
+    },
+    {
+      "id": "oidc_client_id",
+      "label": "OIDC client ID",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_CLIENT_ID",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] }
+    },
+    {
+      "id": "oidc_client_secret",
+      "label": "OIDC client secret",
+      "help": "Browser-only; never in the shareable link.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_CLIENT_SECRET",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] }
+    },
+    {
+      "id": "oidc_jwt_signing_key",
+      "label": "OIDC JWT signing key",
+      "help": "Required on Linux/Docker — the default is ephemeral and invalidates tokens on restart. Generate: openssl rand -hex 32.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_JWT_SIGNING_KEY",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] }
+    },
+    {
+      "id": "oidc_audience",
+      "label": "OIDC audience",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_AUDIENCE",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "oidc_required_scopes",
+      "label": "OIDC required scopes (CSV)",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_REQUIRED_SCOPES",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "oidc_verify_access_token",
+      "label": "Verify access token (not id token)",
+      "type": "bool",
+      "var": "IMAGE_GENERATION_MCP_OIDC_VERIFY_ACCESS_TOKEN",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "bearer_tokens_file",
+      "label": "Bearer tokens file (TOML)",
+      "help": "Path to a TOML file of per-token subjects; overrides the single BEARER_TOKEN.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_BEARER_TOKENS_FILE",
+      "showIf": { "deployment": ["server"], "auth": ["bearer", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "bearer_default_subject",
+      "label": "Bearer default subject",
+      "help": "Subject assigned to the single bearer token. Default bearer-anon.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_BEARER_DEFAULT_SUBJECT",
+      "showIf": { "deployment": ["server"], "auth": ["bearer", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "kv_store_url",
+      "label": "KV store URL (HTTP session persistence)",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_KV_STORE_URL",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Persistence"
+    },
+    {
+      "id": "event_store_url",
+      "label": "Event store URL (HTTP resumability)",
+      "help": "Alternative event-store URL for HTTP resumability; prefer KV_STORE_URL for new deployments.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_EVENT_STORE_URL",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Persistence"
+    },
+    {
+      "id": "app_domain",
+      "label": "MCP Apps domain",
+      "help": "Public domain that serves MCP Apps UI resources.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_APP_DOMAIN",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "MCP Apps"
+    },
+    {
+      "id": "server_name",
+      "label": "Server instance name",
+      "help": "Display name for this server instance. Defaults to image-generation-mcp.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_SERVER_NAME",
+      "advancedGroup": "Server"
     },
     {
       "id": "openai_api_key",
@@ -51,11 +207,27 @@
       "var": "IMAGE_GENERATION_MCP_SD_WEBUI_HOST"
     },
     {
+      "id": "sd_webui_model",
+      "label": "SD WebUI checkpoint",
+      "help": "Checkpoint/model name the SD WebUI provider selects before generating. Leave blank to use the instance's current model.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_SD_WEBUI_MODEL",
+      "advancedGroup": "Providers"
+    },
+    {
       "id": "default_provider",
       "label": "Default provider",
       "help": "Provider used when no keyword triggers auto-selection. \"auto\" picks the first configured provider.",
       "type": "text",
       "var": "IMAGE_GENERATION_MCP_DEFAULT_PROVIDER",
+      "advancedGroup": "Providers"
+    },
+    {
+      "id": "paid_providers",
+      "label": "Paid providers (CSV)",
+      "help": "Comma-separated provider names billed as paid (used for cost warnings). Default: openai.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_PAID_PROVIDERS",
       "advancedGroup": "Providers"
     },
     {
@@ -69,10 +241,43 @@
     {
       "id": "scratch_dir",
       "label": "Scratch directory",
-      "help": "Directory where generated images are saved. Defaults to ~/.image-generation-mcp/.",
+      "help": "Directory where generated images are saved. Defaults to ~/.image-generation-mcp/images/.",
       "type": "text",
       "var": "IMAGE_GENERATION_MCP_SCRATCH_DIR",
       "dockerPath": "/data/state/images",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "styles_dir",
+      "label": "Styles directory",
+      "help": "Directory holding style-preset files. Defaults to ~/.image-generation-mcp/styles/.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_STYLES_DIR",
+      "dockerPath": "/data/state/styles",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "transform_cache_size",
+      "label": "Transform cache size",
+      "help": "LRU cache size for image transforms. Default: 64.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "max_input_image_bytes",
+      "label": "Max input image bytes",
+      "help": "Maximum accepted input image size in bytes. Default: 20971520 (20 MiB).",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "allow_local_file_input",
+      "label": "Allow local file input",
+      "help": "Enable reading input images from local file paths. Default: false.",
+      "type": "bool",
+      "var": "IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT",
       "advancedGroup": "Behaviour"
     },
     {
@@ -101,6 +306,11 @@
         "google_api_key": [""],
         "sd_webui_host": [""]
       }
+    },
+    {
+      "level": "warning",
+      "message": "OIDC needs BASE_URL set and (on Linux/Docker) OIDC_JWT_SIGNING_KEY — the default key is ephemeral and invalidates tokens on restart.",
+      "when": { "deployment": ["server"], "auth": ["oidc", "both"] }
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     # httpx and uvicorn come transitively via fastmcp (pulled by
     # fastmcp-pvl-core).  Don't re-list them here.
-    "fastmcp-pvl-core>=4.0.0,<5",
+    "fastmcp-pvl-core>=4.2.0,<5",
     "typer>=0.12",
 
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update

--- a/src/image_generation_mcp/cli.py
+++ b/src/image_generation_mcp/cli.py
@@ -58,8 +58,12 @@ def serve(
     transport: Transport = typer.Option(
         "stdio", help="MCP transport (stdio / http / sse)."
     ),
-    host: str = typer.Option("0.0.0.0", help="Bind host (http only)."),
-    port: int = typer.Option(8000, help="Bind port (http only)."),
+    host: str | None = typer.Option(
+        None, help=f"Bind host (http only; default: ${_ENV_PREFIX}_HOST or 127.0.0.1)."
+    ),
+    port: int | None = typer.Option(
+        None, help=f"Bind port (http only; default: ${_ENV_PREFIX}_PORT or 8000)."
+    ),
     http_path: str | None = typer.Option(
         None,
         "--http-path",
@@ -100,8 +104,8 @@ def serve(
         # containers (Docker/k8s) stop cleanly.
         uvicorn.run(
             server.http_app(path=path, event_store=event_store),
-            host=host,
-            port=port,
+            host=host if host is not None else config.server.host,
+            port=port if port is not None else config.server.port,
             lifespan="on",
             timeout_graceful_shutdown=3,
         )

--- a/src/image_generation_mcp/server.py
+++ b/src/image_generation_mcp/server.py
@@ -21,6 +21,7 @@ from fastmcp_pvl_core import (
     build_instructions,
     build_kv_store,  # noqa: F401  — re-exported for downstream projects' convenience
     configure_logging_from_env,
+    env,
     register_server_info_tool,
     resolve_auth_mode,
     wire_middleware_stack,
@@ -115,6 +116,21 @@ def make_server(
         config = ProjectConfig.from_env()
     configure_logging_from_env()
 
+    # Operator override: INSTRUCTIONS replaces the default instructions text
+    # (the override build_instructions' hint advertises), falling back to the
+    # domain default when unset/empty. server_name is resolved from config below
+    # (config.server_name, honouring an injected make_server(config=...)).
+    instructions = env(_ENV_PREFIX, "INSTRUCTIONS") or build_instructions(
+        read_only=config.read_only,
+        env_prefix=_ENV_PREFIX,
+        domain_line=(
+            "AI image generation server supporting multiple providers "
+            "(OpenAI gpt-image-1/dall-e-3, Google Gemini image, "
+            "Stable Diffusion via SD WebUI, and a zero-cost placeholder). "
+            "Start by calling list_providers to see configured providers."
+        ),
+    )
+
     auth = build_auth(config.server)
     auth_mode = resolve_auth_mode(config.server) if auth is not None else "none"
     if auth_mode == "none":
@@ -152,16 +168,7 @@ def make_server(
 
     mcp = FastMCP(
         name=server_name,
-        instructions=build_instructions(
-            read_only=config.read_only,
-            env_prefix=_ENV_PREFIX,
-            domain_line=(
-                "AI image generation server supporting multiple providers "
-                "(OpenAI gpt-image-1/dall-e-3, Google Gemini image, "
-                "Stable Diffusion via SD WebUI, and a zero-cost placeholder). "
-                "Start by calling list_providers to see configured providers."
-            ),
-        ),
+        instructions=instructions,
         icons=[Icon(src=_LUCIDE.format("palette"), mimeType="image/svg+xml")],
         lifespan=_lifespan,
         auth=auth,
@@ -175,7 +182,7 @@ def make_server(
 
     register_server_info_tool(
         mcp,
-        server_name="image-generation-mcp",
+        server_name=server_name,
         server_version=pkg_ver,
         # DOMAIN-UPSTREAM-START — wire upstream version reporting for servers
         # that talk to a remote service (paperless-mcp, etc.). The provider is

--- a/tests/test_config_wizard_domain.py
+++ b/tests/test_config_wizard_domain.py
@@ -1,25 +1,70 @@
 """Domain-specific config-wizard tests for Image Generation MCP.
 
 This file is owned by the generated project (kept across ``copier update`` via
-``_skip_if_exists``). The template seeds it once with a single skipped
-placeholder test; add browser assertions here that depend on *this project's*
-``wizard-spec.json`` — e.g. that a specific field renders, that a chosen option
-emits the expected env var, or that a guard message appears. The generic
-framework tests live in ``test_config_wizard_smoke.py`` (template-owned) and
-must not be edited here.
-
-See ``test_config_wizard_smoke.py`` for the page/browser fixtures to import.
+``_skip_if_exists``). Add assertions here that depend on *this project's*
+``wizard-spec.json`` — browser assertions (a field renders, an option emits the
+expected env var, a guard message appears; import the page/browser fixtures from
+``test_config_wizard_smoke.py``), or pure-spec assertions like the coverage
+invariant below. The generic framework tests live in
+``test_config_wizard_smoke.py`` (template-owned) and must not be edited here.
 """
 
 from __future__ import annotations
 
-import pytest
+import inspect
+import json
+from pathlib import Path
+
+from image_generation_mcp.config import ProjectConfig
+
+_ENV_PREFIX = "IMAGE_GENERATION_MCP"
+_WIZARD_SPEC = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "javascripts"
+    / "config-wizard"
+    / "wizard-spec.json"
+)
 
 
-def test_domain_placeholder() -> None:
-    # Placeholder: the template seeds this file with one skipped test so the
-    # path exists and is kept across copier updates, while neither failing CI
-    # on an empty file nor reporting a hollow "passing" test. Replace this skip
-    # with real domain assertions (field renders, option emits the expected env
-    # var, guard message appears).
-    pytest.skip("No domain-specific wizard tests yet -- add them here.")
+def _offered_vars() -> set[str]:
+    """Every env var the wizard can set: question ``var``s + option ``emit`` keys."""
+    spec = json.loads(_WIZARD_SPEC.read_text(encoding="utf-8"))
+    out: set[str] = set()
+    for q in spec["questions"]:
+        if q.get("var"):
+            out.add(q["var"])
+        for opt in q.get("options", []):
+            out.update((opt.get("emit") or {}).keys())
+    return out
+
+
+def test_deprecated_a1111_aliases_not_offered_but_still_read() -> None:
+    """Pin the ``A1111_*`` ``_COVERED_BY_INFERENCE`` exemption to deliberate intent.
+
+    The drift test exempts ``A1111_HOST``/``A1111_MODEL`` from wizard coverage
+    because they are deprecated aliases of ``SD_WEBUI_HOST``/``SD_WEBUI_MODEL``.
+    This asserts the exemption corresponds to a real, intentional state rather
+    than coincidence: the wizard offers the canonical ``SD_WEBUI_*`` controls and
+    never the deprecated names, while ``ProjectConfig.from_env`` still reads the
+    aliases for back-compat. It fails (catching rot) if a wizard control for a
+    deprecated alias is ever added, the canonical control is dropped, or the
+    back-compat read is removed without retiring the exemption.
+    """
+    offered = _offered_vars()
+    from_env_src = inspect.getsource(ProjectConfig.from_env)
+
+    for legacy, canonical in (
+        ("A1111_HOST", "SD_WEBUI_HOST"),
+        ("A1111_MODEL", "SD_WEBUI_MODEL"),
+    ):
+        assert f"{_ENV_PREFIX}_{legacy}" not in offered, (
+            f"deprecated {legacy} must not be a wizard control"
+        )
+        assert f"{_ENV_PREFIX}_{canonical}" in offered, (
+            f"canonical {canonical} must be offered by the wizard"
+        )
+        assert f'"{legacy}"' in from_env_src, (
+            f"{legacy} must still be read by from_env for back-compat "
+            f"(or the _COVERED_BY_INFERENCE exemption should be retired)"
+        )

--- a/tests/test_config_wizard_drift.py
+++ b/tests/test_config_wizard_drift.py
@@ -1,0 +1,264 @@
+"""Drift guards between the config-wizard spec and the env surface it mirrors.
+
+Two directions, both fail CI:
+
+* Orphan — a wizard ``var`` (or option ``emit`` key) that no read site consumes.
+* Coverage — a core (``ServerConfig``) or domain (``ProjectConfig``) env setting
+  with no wizard ``var``/``emit``.
+
+Runs in the main lane. On the scaffold the domain surface is empty (every
+``ProjectConfig.from_env`` domain read is a commented example), so this reduces
+to "the seed covers core"; downstream it checks core + the project's domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import re
+import textwrap
+from pathlib import Path
+from typing import Any, cast
+
+from fastmcp_pvl_core import server_config_env_suffixes
+
+from image_generation_mcp.config import ProjectConfig
+
+_ENV_PREFIX = "IMAGE_GENERATION_MCP"
+_WIZARD_SPEC = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "javascripts"
+    / "config-wizard"
+    / "wizard-spec.json"
+)
+
+# Core ServerConfig suffixes with no dedicated wizard control by design.
+# AUTH_MODE: ServerConfig infers the auth mode from which auth vars are set (the
+# ``auth`` select is a no-var routing key — see the Config wizard section of
+# CLAUDE.md), so there is no AUTH_MODE control to offer.
+_COVERED_BY_INFERENCE = frozenset({"AUTH_MODE"})
+
+
+def _spec() -> dict[str, Any]:
+    return cast("dict[str, Any]", json.loads(_WIZARD_SPEC.read_text(encoding="utf-8")))
+
+
+def _wizard_emitted_vars(spec: dict[str, Any]) -> set[str]:
+    """Every env var the wizard can emit: question ``var``s + option ``emit`` keys."""
+    out: set[str] = set()
+    for q in spec["questions"]:
+        if q.get("var"):
+            out.add(q["var"])
+        for opt in q.get("options", []):
+            out.update((opt.get("emit") or {}).keys())
+    return out
+
+
+def _suffix(var: str) -> str | None:
+    """The part after ``{PREFIX}_``, or None if ``var`` is not prefixed."""
+    prefix = _ENV_PREFIX + "_"
+    return var[len(prefix) :] if var.startswith(prefix) else None
+
+
+def _suffixes_in_source(src: str) -> set[str]:
+    """Literal suffixes read by ``env``/``env_int``/``env_float`` calls in ``src``.
+
+    Only string-literal second positional args are seen; a suffix built from a
+    variable, passed by keyword, or read through a non-``env`` helper is
+    invisible — keep reads in the ``env(_ENV_PREFIX, "LITERAL")`` form.
+    """
+    funcs = {"env", "env_int", "env_float"}
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(textwrap.dedent(src))):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in funcs
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            found.add(node.args[1].value)
+    return found
+
+
+def _domain_suffixes() -> set[str]:
+    """Suffixes ``ProjectConfig.from_env`` reads beyond ``ServerConfig``.
+
+    The ``server=ServerConfig.from_env(_ENV_PREFIX)`` call passes no suffix
+    literal, so it contributes nothing. Vacuous on the scaffold (domain reads
+    are commented examples), live downstream.
+    """
+    return _suffixes_in_source(inspect.getsource(ProjectConfig.from_env))
+
+
+def _surface() -> set[str]:
+    """The config surface the wizard must COVER: core (ServerConfig) + domain.
+
+    This is the coverage target. The orphan check uses a broader read set (it
+    also accepts scaffold-direct reads — see ``_src_text``), because the wizard
+    may legitimately offer a var the scaffold reads outside ServerConfig (e.g.
+    ``HTTP_PATH`` is read in ``cli.py``).
+    """
+    return set(server_config_env_suffixes()) | _domain_suffixes()
+
+
+def _src_text() -> str:
+    """Concatenated text of the project's ``src/**/*.py``.
+
+    Used by :func:`_read_in_src` to accept wizard vars read directly in the
+    scaffold (e.g. ``HTTP_PATH`` in ``cli.py``) that are not
+    ``ServerConfig``/``ProjectConfig`` fields and would otherwise be flagged as
+    orphans.
+    """
+    src = Path(__file__).resolve().parent.parent / "src"
+    return "\n".join(p.read_text(encoding="utf-8") for p in sorted(src.rglob("*.py")))
+
+
+def _read_in_src(suffix: str, src_text: str) -> bool:
+    """True if ``suffix`` appears as an env-read *token* in src, not a bare match.
+
+    Matches the two scaffold read idioms: ``env(_ENV_PREFIX, "SUFFIX")`` (the
+    quoted literal ``"SUFFIX"``) and ``os.environ.get(f"{_ENV_PREFIX}_SUFFIX")``
+    (the ``_SUFFIX`` fragment). The fragment arm anchors a trailing
+    word-boundary so a short suffix does not match inside a longer fragment
+    (``_HOST`` must not clear via ``_HOSTNAME``). Requiring one of these — rather
+    than a bare ``suffix in src_text`` substring — avoids clearing a real orphan
+    just because its suffix happens to appear in an unrelated comment or
+    identifier.
+    """
+    return (
+        f'"{suffix}"' in src_text
+        or re.search(rf"_{re.escape(suffix)}(?![A-Z0-9_])", src_text) is not None
+    )
+
+
+def _orphan_vars(spec: dict[str, Any]) -> list[str]:
+    """Wizard vars/emits that resolve to no read site (excluding FASTMCP_* natives)."""
+    core_domain = _surface()
+    src_text = _src_text()
+    out: list[str] = []
+    for var in sorted(_wizard_emitted_vars(spec)):
+        if var.startswith("FASTMCP_"):
+            continue  # native, read by FastMCP / configure_logging_from_env
+        suffix = _suffix(var)
+        if suffix is None:
+            out.append(f"{var} (not {_ENV_PREFIX}_-prefixed and not FASTMCP_*)")
+        elif suffix not in core_domain and not _read_in_src(suffix, src_text):
+            out.append(f"{var} (no read site consumes {suffix})")
+    return out
+
+
+def test_no_orphan_wizard_vars() -> None:
+    """Every wizard var/emit resolves to a read site (or is a FASTMCP_* native)."""
+    orphans = _orphan_vars(_spec())
+    assert not orphans, "wizard offers vars nothing reads: " + "; ".join(orphans)
+
+
+def test_orphan_guard_flags_unread_var() -> None:
+    """A wizard var whose suffix no read site consumes is reported."""
+    spec: dict[str, Any] = {
+        "questions": [{"id": "x", "var": f"{_ENV_PREFIX}_NONSENSE_XYZ"}]
+    }
+    orphans = _orphan_vars(spec)
+    assert any("NONSENSE_XYZ" in o for o in orphans)
+
+
+def test_domain_scan_extracts_literal_env_reads() -> None:
+    """The domain scan picks literal env*-read suffixes and ignores the rest."""
+    src = textwrap.dedent(
+        """
+        @classmethod
+        def from_env(cls):
+            other = some_var
+            return cls(
+                server=ServerConfig.from_env(_ENV_PREFIX),
+                vault_path=env(_ENV_PREFIX, "VAULT_PATH", "/data/vault"),
+                max_n=env_int(_ENV_PREFIX, "MAX_N", 5),
+                skip=env(_ENV_PREFIX, other),
+            )
+        """
+    )
+    assert _suffixes_in_source(src) == {"VAULT_PATH", "MAX_N"}
+
+
+def _missing_suffixes(surface: set[str], emitted_suffixes: set[str]) -> list[str]:
+    """Surface suffixes not covered by a wizard var/emit and not inference-excepted."""
+    return sorted(
+        s
+        for s in surface
+        if s not in emitted_suffixes and s not in _COVERED_BY_INFERENCE
+    )
+
+
+def test_wizard_covers_full_env_surface() -> None:
+    """Every core/domain setting is covered by a wizard var/emit (advanced ok).
+
+    Hiding a setting is done with ``advancedGroup``, never by omission. A
+    setting with no dedicated control by design goes in ``_COVERED_BY_INFERENCE``.
+    """
+    emitted_suffixes = {
+        s for v in _wizard_emitted_vars(_spec()) if (s := _suffix(v)) is not None
+    }
+    missing = _missing_suffixes(_surface(), emitted_suffixes)
+    assert not missing, (
+        "env settings the server reads but the wizard does not offer "
+        "(add a question/emit, or _COVERED_BY_INFERENCE if inferred by design): "
+        + ", ".join(missing)
+    )
+
+
+def test_coverage_guard_flags_missing_suffix() -> None:
+    """A surface suffix with no wizard var/emit is reported as missing."""
+    assert _missing_suffixes({"VAULT_PATH"}, set()) == ["VAULT_PATH"]
+
+
+def test_inference_exception_suppresses_auth_mode() -> None:
+    """AUTH_MODE is in the surface and not emitted, yet not reported missing
+    (the _COVERED_BY_INFERENCE exception, not coincidence, keeps it green)."""
+    assert "AUTH_MODE" in _surface()
+    emitted = {
+        s for v in _wizard_emitted_vars(_spec()) if (s := _suffix(v)) is not None
+    }
+    assert "AUTH_MODE" not in emitted
+    assert "AUTH_MODE" not in _missing_suffixes(_surface(), emitted)
+
+
+def test_transport_covered_via_option_emit() -> None:
+    """TRANSPORT is covered through the deployment option `emit`, not a question var."""
+    emitted = _wizard_emitted_vars(_spec())
+    assert f"{_ENV_PREFIX}_TRANSPORT" in emitted
+    emitted_suffixes = {s for v in emitted if (s := _suffix(v)) is not None}
+    assert "TRANSPORT" not in _missing_suffixes(_surface(), emitted_suffixes)
+
+
+def test_orphan_guard_exempts_fastmcp_native() -> None:
+    """A FASTMCP_* wizard var is exempt from the orphan check (read by FastMCP)."""
+    assert _orphan_vars({"questions": [{"id": "x", "var": "FASTMCP_LOG_LEVEL"}]}) == []
+
+
+def test_orphan_guard_accepts_scaffold_direct_read() -> None:
+    """A wizard var read directly in src (not a ServerConfig/domain field) is not
+    an orphan. HTTP_PATH is the case: read in cli.py, absent from the core/domain
+    surface, cleared only by the ``_read_in_src`` token match.
+    """
+    assert "HTTP_PATH" not in _surface()
+    assert _read_in_src("HTTP_PATH", _src_text())
+    # The token match does not clear a suffix that is merely a coincidental
+    # substring (no ``"ZZZNONSENSE"`` literal or ``_ZZZNONSENSE`` fragment).
+    assert not _read_in_src("ZZZNONSENSE", _src_text())
+
+
+def test_read_in_src_quoted_literal_arm() -> None:
+    """The quoted-literal arm matches an ``env(prefix, "SUFFIX")`` read."""
+    assert _read_in_src("WIDGET", 'x = env(_ENV_PREFIX, "WIDGET")\n')
+    assert not _read_in_src("WIDGET", "x = widget_count  # WIDGET in a comment\n")
+
+
+def test_read_in_src_fragment_arm_anchors_word_boundary() -> None:
+    """The ``_SUFFIX`` arm matches an f-string read but not a longer fragment."""
+    assert _read_in_src("HOST", 'os.environ.get(f"{_ENV_PREFIX}_HOST")\n')
+    # ``_HOST`` inside ``_HOSTNAME`` must NOT clear HOST as read.
+    assert not _read_in_src("HOST", 'os.environ.get(f"{_ENV_PREFIX}_HOSTNAME")\n')

--- a/tests/test_config_wizard_drift.py
+++ b/tests/test_config_wizard_drift.py
@@ -38,7 +38,11 @@ _WIZARD_SPEC = (
 # AUTH_MODE: ServerConfig infers the auth mode from which auth vars are set (the
 # ``auth`` select is a no-var routing key — see the Config wizard section of
 # CLAUDE.md), so there is no AUTH_MODE control to offer.
-_COVERED_BY_INFERENCE = frozenset({"AUTH_MODE"})
+# A1111_HOST / A1111_MODEL: deprecated aliases of SD_WEBUI_HOST / SD_WEBUI_MODEL
+# (ProjectConfig.from_env reads them only for back-compat, with a deprecation
+# warning); the wizard offers the canonical SD_WEBUI_* controls and never the
+# deprecated names by design.
+_COVERED_BY_INFERENCE = frozenset({"AUTH_MODE", "A1111_HOST", "A1111_MODEL"})
 
 
 def _spec() -> dict[str, Any]:

--- a/tests/test_config_wizard_smoke.py
+++ b/tests/test_config_wizard_smoke.py
@@ -334,3 +334,62 @@ def test_compose_quotes_yaml_typed_env_values(page: Page) -> None:
     assert 'DEMO_FLAG: "true"' in result
     assert "DEMO_FLAG: true\n" not in result
     assert 'DEMO_PORT: "8080"' in result
+
+
+# A two-level showIf chain (child gates on `auth`, `auth` gates on `deployment`)
+# mirrors the auth/OIDC structure every shipped spec uses. These two tests pin
+# the runtime behaviour the spec-level cascade test (in
+# test_config_wizard_spec_schema.py) is a static proxy for: isVisible does NOT
+# cascade, so buildEnvMap emits a child's var whenever the child's own showIf is
+# satisfied by the raw answers — even if the gating question is itself hidden by
+# a stale answer. A self-contained child showIf is what closes the leak.
+def _cascade_spec(child_showif: str) -> str:
+    return (
+        "{ version: 1,"
+        " meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },"
+        " secretKeys: [],"
+        " questions: ["
+        "   { id: 'deployment', label: 'D', type: 'select',"
+        "     options: [{ value: 'local', label: 'L' }, { value: 'server', label: 'S' }] },"
+        "   { id: 'auth', label: 'A', type: 'select', showIf: { deployment: ['server'] },"
+        "     options: [{ value: 'none', label: 'N' }, { value: 'oidc', label: 'O' }] },"
+        "   { id: 'oidc_url', label: 'U', type: 'text', var: 'DEMO_OIDC_CONFIG_URL',"
+        "     showIf: " + child_showif + " },"
+        " ],"
+        " guards: [] }"
+    )
+
+
+# Stale state from configuring OIDC under deployment='server' (the auth answer
+# AND a filled-in oidc_url value), then flipping deployment back to 'local'.
+_STALE = "{ deployment: 'local', auth: 'oidc', oidc_url: 'https://auth.example.com' }"
+
+
+def test_buildenvmap_leaks_without_self_contained_showif(page: Page) -> None:
+    # Child gated ONLY on auth (the pre-fix shape). The stale auth answer keeps
+    # the child visible, so its filled-in value is still emitted after deployment
+    # flips back to 'local'. This documents the leak the cascade gate prevents.
+    result = _eval_generators(
+        page,
+        "(g) => {"
+        "  const spec = " + _cascade_spec("{ auth: ['oidc'] }") + ";"
+        "  return g.buildEnvMap(spec, " + _STALE + ");"
+        "}",
+    )
+    assert result.get("DEMO_OIDC_CONFIG_URL") == "https://auth.example.com"
+
+
+def test_buildenvmap_self_contained_showif_blocks_stale_answer(page: Page) -> None:
+    # Child gated on BOTH deployment and auth (the fixed shape). The same stale
+    # state no longer leaks because deployment='local' fails the child's own
+    # deployment gate, so isVisible is false and the var is not emitted.
+    result = _eval_generators(
+        page,
+        "(g) => {"
+        "  const spec = "
+        + _cascade_spec("{ deployment: ['server'], auth: ['oidc'] }")
+        + ";"
+        "  return g.buildEnvMap(spec, " + _STALE + ");"
+        "}",
+    )
+    assert "DEMO_OIDC_CONFIG_URL" not in result

--- a/tests/test_config_wizard_spec_schema.py
+++ b/tests/test_config_wizard_spec_schema.py
@@ -80,6 +80,93 @@ def test_showif_references_existing_ids(spec: dict[str, Any]) -> None:
             assert key in ids, f"showIf references unknown question id: {key}"
 
 
+def _assert_gates_self_contained(
+    gates: dict[str, Any], by_id: dict[str, Any], owner: str
+) -> None:
+    """Assert a ``showIf``/``when`` map carries its referenced questions' gates.
+
+    Both ``isVisible`` and the guard evaluator (generators.js / wizard.js) check
+    raw ``answers[k]`` with no cascade. So if ``gates`` references question B and
+    B is itself gated on C, ``gates`` must also gate on C — with a value set no
+    wider than B's — or it stays active when B is hidden but B's stale answer
+    lingers.
+    """
+    for parent_id in gates:
+        parent_gates = by_id.get(parent_id, {}).get("showIf") or {}
+        for grand_id, grand_allowed in parent_gates.items():
+            assert grand_id in gates, (
+                f"{owner} gates on {parent_id!r} but not on {parent_id!r}'s own "
+                f"gate {grand_id!r}; it stays active when {parent_id!r} is hidden"
+            )
+            assert set(gates[grand_id]) <= set(grand_allowed), (
+                f"{owner} allows {grand_id!r} values {gates[grand_id]} wider than "
+                f"{parent_id!r}'s {grand_allowed}; it can be active when "
+                f"{parent_id!r} is not"
+            )
+
+
+def test_showif_and_guard_gates_cascade(spec: dict[str, Any]) -> None:
+    """Question ``showIf`` and guard ``when`` must stay self-contained.
+
+    Neither ``isVisible`` (which gates ``buildEnvMap``'s var emission) nor the
+    guard evaluator cascades — each checks raw ``answers[k]`` only. A question
+    gated only on ``auth`` keeps emitting its ``var`` after the user flips
+    ``deployment`` back to a value that hides the ``auth`` control, because the
+    stale ``auth`` answer persists; a guard gated only on ``auth`` fires its
+    warning the same way. So whenever a ``showIf``/``when`` gates on B and B
+    itself gates on C, it must also gate on C (values no wider than B's). This
+    asserts that transitive closure for every question and every guard.
+    """
+    by_id = {q["id"]: q for q in spec["questions"]}
+    for q in spec["questions"]:
+        _assert_gates_self_contained(
+            q.get("showIf") or {}, by_id, f"question {q['id']!r}"
+        )
+    for i, guard in enumerate(spec.get("guards", [])):
+        _assert_gates_self_contained(guard.get("when") or {}, by_id, f"guard[{i}]")
+
+
+def _chain_spec(questions: list[dict[str, Any]]) -> dict[str, Any]:
+    base = _minimal_valid_spec()
+    base["questions"] = questions
+    return base
+
+
+def _sel(qid: str, show_if: dict[str, Any] | None = None) -> dict[str, Any]:
+    q: dict[str, Any] = {
+        "id": qid,
+        "label": qid.upper(),
+        "type": "select",
+        "options": [{"value": "on", "label": "On"}, {"value": "off", "label": "Off"}],
+    }
+    if show_if is not None:
+        q["showIf"] = show_if
+    return q
+
+
+def test_cascade_check_enforces_full_transitive_closure() -> None:
+    """The one-level-per-question check composes to full transitive closure.
+
+    A 3-level chain d <- c <- b <- a: `a` correctly carries b and c but omits
+    d's gate. The check must still reject it, because `a` gates on c and c gates
+    on d, so c's gate (d) is re-checked against `a`. This pins the docstring's
+    "transitive closure" claim — the single-level check is not merely a
+    one-hop guard.
+    """
+    chain = [
+        _sel("d"),
+        _sel("c", {"d": ["on"]}),
+        _sel("b", {"c": ["on"], "d": ["on"]}),
+    ]
+    # Fully closed: a carries every ancestor gate -> passes.
+    good = _chain_spec([*chain, _sel("a", {"b": ["on"], "c": ["on"], "d": ["on"]})])
+    test_showif_and_guard_gates_cascade(good)
+    # a omits the transitive gate d -> must be rejected.
+    bad = _chain_spec([*chain, _sel("a", {"b": ["on"], "c": ["on"]})])
+    with pytest.raises(AssertionError):
+        test_showif_and_guard_gates_cascade(bad)
+
+
 def test_guard_when_references_existing_ids(spec: dict[str, Any]) -> None:
     ids = {q["id"] for q in spec["questions"]}
     for guard in spec.get("guards", []):

--- a/uv.lock
+++ b/uv.lock
@@ -807,15 +807,15 @@ tasks = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "4.0.1"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/05/7e3410fd62a35ed178544744e0c89b08228035a66e543864cab27a426ef8/fastmcp_pvl_core-4.0.1.tar.gz", hash = "sha256:2321481c93d559c4a272b90b81627965a0e0c78873533ba4ed53650a3b2f04be", size = 353049, upload-time = "2026-06-20T11:33:10.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/60/951e65b2eb7771060126b9f1c8d4ffdd3d5edde5f0698f37bfdce03010be/fastmcp_pvl_core-4.2.0.tar.gz", hash = "sha256:4d5009d5838f2789adbb64e5e5ebcfe7d12c5c3afa182b11a71855eab83c00b4", size = 354550, upload-time = "2026-06-27T17:40:34.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/de/e6491b2a9cc5e72f20c6e073a4fc8ff45869a40e33938fc57b8868745c27/fastmcp_pvl_core-4.0.1-py3-none-any.whl", hash = "sha256:8228ca4a88b49855c5c8b0ef50cdd5479a62e1f06564960fc046867ecc200cfe", size = 52208, upload-time = "2026-06-20T11:33:09.203Z" },
+    { url = "https://files.pythonhosted.org/packages/01/55/7b702ad686c984ebcafae44481caf15ecdd1b9ea71b4af023502e8c0f2b4/fastmcp_pvl_core-4.2.0-py3-none-any.whl", hash = "sha256:97e8c6997e8d375e3731dea32bc32c201d813ed7675d92f195a9eb0cf9e0c086", size = 52962, upload-time = "2026-06-27T17:40:32.773Z" },
 ]
 
 [package.optional-dependencies]
@@ -1133,7 +1133,7 @@ docs = [
 requires-dist = [
     { name = "fastmcp", extras = ["tasks"], marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", extras = ["tasks"], marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
-    { name = "fastmcp-pvl-core", specifier = ">=4.0.0,<5" },
+    { name = "fastmcp-pvl-core", specifier = ">=4.2.0,<5" },
     { name = "fastmcp-pvl-core", extras = ["debug"], marker = "extra == 'debug'" },
     { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0" },
     { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.0" },


### PR DESCRIPTION
## Summary

Mechanical half of the v2.5.3 → v2.6.0 copier update (#279). **The de-fork/conformance epic (#274–#278) paid off**: only **3 conflicts** (vs 4 in the reactive attempt at the epic's start), all resolved — `cli.py`, `config.py`, `_server_deps.py` now merge cleanly.

## ⚠️ Knowingly red — merges as a unit with the wizard PR

`tests/test_config_wizard_drift.py` (new v2.6.0 gate) has **2 failing checks**: the gate exposes **pre-existing** drift — `wizard-spec.json` covers only 7 of the ~32 env vars the server reads. The fix (restore the template's deployment/auth wizard sections + author ~9 domain questions) is substantial domain work and lands in the **stacked follow-up PR**, which makes this gate green. This PR + that one are one unit. ruff, mypy, and the other **920 tests are green**.

## Conflict resolutions

- **`ci.yml`** — gitleaks `@v3.0.0` tag → template's SHA-pinned `@e0c47…# v3.0.0` (re-align; the repo's tag-edit was the divergence).
- **`pyproject.toml`** — kept the transitive-deps comment; adopted `fastmcp-pvl-core>=4.2.0` (the drift test needs `server_config_env_suffixes` from 4.2.0). `uv.lock` regenerated → pvl-core 4.2.0.
- **`server.py`** *(domain `make_server`)* — adopted the new **`INSTRUCTIONS` env-override** (folding in our rich domain_line + `read_only=config.read_only`); dropped the template's redundant env-based `server_name` (`config.server_name` honours `make_server(config=…)`); **kept** `icons` + `lifespan=_lifespan` (template's `server_lifespan` isn't imported here and would re-introduce the #280 double-load); kept the `mode=` log line.

New template files: `.github/workflows/bootstrap.yml`, `tests/test_config_wizard_drift.py`.

Refs #279. (The stacked wizard-spec PR `Closes #279`.)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
