### PR TITLE
feat(config-wizard): cover full env surface — fix v2.6.0 drift gate (closes #279)

### DIFF
--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -8,7 +8,9 @@
   "secretKeys": [
     "IMAGE_GENERATION_MCP_BEARER_TOKEN",
     "IMAGE_GENERATION_MCP_OPENAI_API_KEY",
-    "IMAGE_GENERATION_MCP_GOOGLE_API_KEY"
+    "IMAGE_GENERATION_MCP_GOOGLE_API_KEY",
+    "IMAGE_GENERATION_MCP_OIDC_CLIENT_SECRET",
+    "IMAGE_GENERATION_MCP_OIDC_JWT_SIGNING_KEY"
   ],
   "questions": [
     {
@@ -17,17 +19,171 @@
       "help": "Local stdio for Claude Desktop/Code, or an HTTP server for Docker/systemd.",
       "type": "select",
       "options": [
-        { "value": "local", "label": "Local (Claude Desktop / Claude Code, stdio)" },
-        { "value": "server", "label": "Server (HTTP — Docker / Compose / systemd)" }
+        { "value": "local", "label": "Local (Claude Desktop / Claude Code, stdio)", "emit": { "IMAGE_GENERATION_MCP_TRANSPORT": "stdio" } },
+        { "value": "server", "label": "Server (HTTP — Docker / Compose / systemd)", "emit": { "IMAGE_GENERATION_MCP_TRANSPORT": "http" } }
+      ]
+    },
+    {
+      "id": "base_url",
+      "label": "Public base URL",
+      "help": "e.g. https://mcp.example.com — required for OIDC and MCP Apps.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_BASE_URL",
+      "showIf": { "deployment": ["server"] }
+    },
+    {
+      "id": "http_path",
+      "label": "HTTP endpoint path",
+      "help": "Mount path for the MCP endpoint, e.g. /mcp. Defaults to /mcp when unset.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_HTTP_PATH",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Server"
+    },
+    {
+      "id": "host",
+      "label": "Bind host",
+      "help": "Interface the HTTP server binds to. Default 127.0.0.1.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_HOST",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Server"
+    },
+    {
+      "id": "port",
+      "label": "Port",
+      "help": "TCP port for the HTTP server. Default 8000.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_PORT",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Server"
+    },
+    {
+      "id": "auth",
+      "label": "Authentication",
+      "type": "select",
+      "showIf": { "deployment": ["server"] },
+      "options": [
+        { "value": "none", "label": "None" },
+        { "value": "bearer", "label": "Bearer token" },
+        { "value": "oidc", "label": "OIDC" },
+        { "value": "both", "label": "Bearer + OIDC" }
       ]
     },
     {
       "id": "bearer_token",
       "label": "Bearer token",
-      "help": "Any non-empty string enables bearer auth. Leave blank for no authentication.",
+      "help": "Any non-empty string enables bearer auth. Browser-only.",
       "type": "text",
       "var": "IMAGE_GENERATION_MCP_BEARER_TOKEN",
-      "showIf": { "deployment": ["server"] }
+      "showIf": { "deployment": ["server"], "auth": ["bearer", "both"] }
+    },
+    {
+      "id": "oidc_config_url",
+      "label": "OIDC discovery URL",
+      "help": "e.g. https://auth.example.com/.well-known/openid-configuration",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_CONFIG_URL",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] }
+    },
+    {
+      "id": "oidc_client_id",
+      "label": "OIDC client ID",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_CLIENT_ID",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] }
+    },
+    {
+      "id": "oidc_client_secret",
+      "label": "OIDC client secret",
+      "help": "Browser-only; never in the shareable link.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_CLIENT_SECRET",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] }
+    },
+    {
+      "id": "oidc_jwt_signing_key",
+      "label": "OIDC JWT signing key",
+      "help": "Required on Linux/Docker — the default is ephemeral and invalidates tokens on restart. Generate: openssl rand -hex 32.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_JWT_SIGNING_KEY",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] }
+    },
+    {
+      "id": "oidc_audience",
+      "label": "OIDC audience",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_AUDIENCE",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "oidc_required_scopes",
+      "label": "OIDC required scopes (CSV)",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_OIDC_REQUIRED_SCOPES",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "oidc_verify_access_token",
+      "label": "Verify access token (not id token)",
+      "type": "bool",
+      "var": "IMAGE_GENERATION_MCP_OIDC_VERIFY_ACCESS_TOKEN",
+      "showIf": { "deployment": ["server"], "auth": ["oidc", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "bearer_tokens_file",
+      "label": "Bearer tokens file (TOML)",
+      "help": "Path to a TOML file of per-token subjects; overrides the single BEARER_TOKEN.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_BEARER_TOKENS_FILE",
+      "showIf": { "deployment": ["server"], "auth": ["bearer", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "bearer_default_subject",
+      "label": "Bearer default subject",
+      "help": "Subject assigned to the single bearer token. Default bearer-anon.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_BEARER_DEFAULT_SUBJECT",
+      "showIf": { "deployment": ["server"], "auth": ["bearer", "both"] },
+      "advancedGroup": "Auth"
+    },
+    {
+      "id": "kv_store_url",
+      "label": "KV store URL (HTTP session persistence)",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_KV_STORE_URL",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Persistence"
+    },
+    {
+      "id": "event_store_url",
+      "label": "Event store URL (HTTP resumability)",
+      "help": "Alternative event-store URL for HTTP resumability; prefer KV_STORE_URL for new deployments.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_EVENT_STORE_URL",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "Persistence"
+    },
+    {
+      "id": "app_domain",
+      "label": "MCP Apps domain",
+      "help": "Public domain that serves MCP Apps UI resources.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_APP_DOMAIN",
+      "showIf": { "deployment": ["server"] },
+      "advancedGroup": "MCP Apps"
+    },
+    {
+      "id": "server_name",
+      "label": "Server instance name",
+      "help": "Display name for this server instance. Defaults to image-generation-mcp.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_SERVER_NAME",
+      "advancedGroup": "Server"
     },
     {
       "id": "openai_api_key",
@@ -51,11 +207,27 @@
       "var": "IMAGE_GENERATION_MCP_SD_WEBUI_HOST"
     },
     {
+      "id": "sd_webui_model",
+      "label": "SD WebUI checkpoint",
+      "help": "Checkpoint/model name the SD WebUI provider selects before generating. Leave blank to use the instance's current model.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_SD_WEBUI_MODEL",
+      "advancedGroup": "Providers"
+    },
+    {
       "id": "default_provider",
       "label": "Default provider",
       "help": "Provider used when no keyword triggers auto-selection. \"auto\" picks the first configured provider.",
       "type": "text",
       "var": "IMAGE_GENERATION_MCP_DEFAULT_PROVIDER",
+      "advancedGroup": "Providers"
+    },
+    {
+      "id": "paid_providers",
+      "label": "Paid providers (CSV)",
+      "help": "Comma-separated provider names billed as paid (used for cost warnings). Default: openai.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_PAID_PROVIDERS",
       "advancedGroup": "Providers"
     },
     {
@@ -69,10 +241,43 @@
     {
       "id": "scratch_dir",
       "label": "Scratch directory",
-      "help": "Directory where generated images are saved. Defaults to ~/.image-generation-mcp/.",
+      "help": "Directory where generated images are saved. Defaults to ~/.image-generation-mcp/images/.",
       "type": "text",
       "var": "IMAGE_GENERATION_MCP_SCRATCH_DIR",
       "dockerPath": "/data/state/images",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "styles_dir",
+      "label": "Styles directory",
+      "help": "Directory holding style-preset files. Defaults to ~/.image-generation-mcp/styles/.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_STYLES_DIR",
+      "dockerPath": "/data/state/styles",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "transform_cache_size",
+      "label": "Transform cache size",
+      "help": "LRU cache size for image transforms. Default: 64.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "max_input_image_bytes",
+      "label": "Max input image bytes",
+      "help": "Maximum accepted input image size in bytes. Default: 20971520 (20 MiB).",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES",
+      "advancedGroup": "Behaviour"
+    },
+    {
+      "id": "allow_local_file_input",
+      "label": "Allow local file input",
+      "help": "Enable reading input images from local file paths. Default: false.",
+      "type": "bool",
+      "var": "IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT",
       "advancedGroup": "Behaviour"
     },
     {
@@ -101,6 +306,11 @@
         "google_api_key": [""],
         "sd_webui_host": [""]
       }
+    },
+    {
+      "level": "warning",
+      "message": "OIDC needs BASE_URL set and (on Linux/Docker) OIDC_JWT_SIGNING_KEY — the default key is ephemeral and invalidates tokens on restart.",
+      "when": { "deployment": ["server"], "auth": ["oidc", "both"] }
     }
   ]
 }

--- a/tests/test_config_wizard_domain.py
+++ b/tests/test_config_wizard_domain.py
@@ -1,25 +1,70 @@
 """Domain-specific config-wizard tests for Image Generation MCP.
 
 This file is owned by the generated project (kept across ``copier update`` via
-``_skip_if_exists``). The template seeds it once with a single skipped
-placeholder test; add browser assertions here that depend on *this project's*
-``wizard-spec.json`` — e.g. that a specific field renders, that a chosen option
-emits the expected env var, or that a guard message appears. The generic
-framework tests live in ``test_config_wizard_smoke.py`` (template-owned) and
-must not be edited here.
-
-See ``test_config_wizard_smoke.py`` for the page/browser fixtures to import.
+``_skip_if_exists``). Add assertions here that depend on *this project's*
+``wizard-spec.json`` — browser assertions (a field renders, an option emits the
+expected env var, a guard message appears; import the page/browser fixtures from
+``test_config_wizard_smoke.py``), or pure-spec assertions like the coverage
+invariant below. The generic framework tests live in
+``test_config_wizard_smoke.py`` (template-owned) and must not be edited here.
 """
 
 from __future__ import annotations
 
-import pytest
+import inspect
+import json
+from pathlib import Path
+
+from image_generation_mcp.config import ProjectConfig
+
+_ENV_PREFIX = "IMAGE_GENERATION_MCP"
+_WIZARD_SPEC = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "javascripts"
+    / "config-wizard"
+    / "wizard-spec.json"
+)
 
 
-def test_domain_placeholder() -> None:
-    # Placeholder: the template seeds this file with one skipped test so the
-    # path exists and is kept across copier updates, while neither failing CI
-    # on an empty file nor reporting a hollow "passing" test. Replace this skip
-    # with real domain assertions (field renders, option emits the expected env
-    # var, guard message appears).
-    pytest.skip("No domain-specific wizard tests yet -- add them here.")
+def _offered_vars() -> set[str]:
+    """Every env var the wizard can set: question ``var``s + option ``emit`` keys."""
+    spec = json.loads(_WIZARD_SPEC.read_text(encoding="utf-8"))
+    out: set[str] = set()
+    for q in spec["questions"]:
+        if q.get("var"):
+            out.add(q["var"])
+        for opt in q.get("options", []):
+            out.update((opt.get("emit") or {}).keys())
+    return out
+
+
+def test_deprecated_a1111_aliases_not_offered_but_still_read() -> None:
+    """Pin the ``A1111_*`` ``_COVERED_BY_INFERENCE`` exemption to deliberate intent.
+
+    The drift test exempts ``A1111_HOST``/``A1111_MODEL`` from wizard coverage
+    because they are deprecated aliases of ``SD_WEBUI_HOST``/``SD_WEBUI_MODEL``.
+    This asserts the exemption corresponds to a real, intentional state rather
+    than coincidence: the wizard offers the canonical ``SD_WEBUI_*`` controls and
+    never the deprecated names, while ``ProjectConfig.from_env`` still reads the
+    aliases for back-compat. It fails (catching rot) if a wizard control for a
+    deprecated alias is ever added, the canonical control is dropped, or the
+    back-compat read is removed without retiring the exemption.
+    """
+    offered = _offered_vars()
+    from_env_src = inspect.getsource(ProjectConfig.from_env)
+
+    for legacy, canonical in (
+        ("A1111_HOST", "SD_WEBUI_HOST"),
+        ("A1111_MODEL", "SD_WEBUI_MODEL"),
+    ):
+        assert f"{_ENV_PREFIX}_{legacy}" not in offered, (
+            f"deprecated {legacy} must not be a wizard control"
+        )
+        assert f"{_ENV_PREFIX}_{canonical}" in offered, (
+            f"canonical {canonical} must be offered by the wizard"
+        )
+        assert f'"{legacy}"' in from_env_src, (
+            f"{legacy} must still be read by from_env for back-compat "
+            f"(or the _COVERED_BY_INFERENCE exemption should be retired)"
+        )

--- a/tests/test_config_wizard_drift.py
+++ b/tests/test_config_wizard_drift.py
@@ -38,7 +38,11 @@ _WIZARD_SPEC = (
 # AUTH_MODE: ServerConfig infers the auth mode from which auth vars are set (the
 # ``auth`` select is a no-var routing key — see the Config wizard section of
 # CLAUDE.md), so there is no AUTH_MODE control to offer.
-_COVERED_BY_INFERENCE = frozenset({"AUTH_MODE"})
+# A1111_HOST / A1111_MODEL: deprecated aliases of SD_WEBUI_HOST / SD_WEBUI_MODEL
+# (ProjectConfig.from_env reads them only for back-compat, with a deprecation
+# warning); the wizard offers the canonical SD_WEBUI_* controls and never the
+# deprecated names by design.
+_COVERED_BY_INFERENCE = frozenset({"AUTH_MODE", "A1111_HOST", "A1111_MODEL"})
 
 
 def _spec() -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Wizard half of the v2.6.0 copier update (#279), **stacked on #286** (the mechanical update). This makes #286's red drift gate (`tests/test_config_wizard_drift.py`) green by completing the config-wizard's env coverage. Together with #286 this closes #279; they merge as a unit.

> **Base = `copier/update-v260`** (PR #286), not `main` — review this PR's diff alone (the 3 files below). #286 carries the copier mechanics.

## The gap

The v2.6.0 drift gate requires the browser config-wizard to offer **every** env setting the server reads (`ServerConfig` ∪ `ProjectConfig.from_env`). The repo's `wizard-spec.json` covered only **7 of ~32**.

## What changed

- **`wizard-spec.json`** — 10 → 34 questions. Restored the template's generic sections (`deployment` with the `TRANSPORT` emit + `base_url`/`http_path`/`host`/`port`; the `auth` routing question + bearer/OIDC controls; `kv_store_url`/`event_store_url`/`app_domain`) and added **7 domain questions** (`server_name`, `sd_webui_model`, `paid_providers`, `styles_dir`, `transform_cache_size`, `max_input_image_bytes`, `allow_local_file_input`) — niche ones under `advancedGroup`s, never by omission. `secretKeys` now also lists `OIDC_CLIENT_SECRET` + `OIDC_JWT_SIGNING_KEY`.
- **`test_config_wizard_drift.py`** — added `A1111_HOST`/`A1111_MODEL` to `_COVERED_BY_INFERENCE`: deprecated aliases of `SD_WEBUI_HOST`/`SD_WEBUI_MODEL` that `from_env` reads only for back-compat (with a warning); the wizard offers the canonical `SD_WEBUI_*`, never the deprecated names. This escape hatch is template-owned with no domain seam — filed upstream as **pvliesdonk/fastmcp-server-template#217**.
- **`test_config_wizard_domain.py`** (domain-owned placeholder, now filled) — a self-contained regression test pinning the A1111 exemption to deliberate intent (aliases not offered, canonical offered, aliases still read by `from_env`), so it fails if any of those rot.

## Verification

- Full suite **923 passed**, 1 skipped (playwright not installed); ruff + mypy (67 files) green.
- Local preflight (7 lenses) clean: coverage has no orphans, every secret is in `secretKeys`, all `showIf` gates are self-contained, all help-text defaults match `config.py` (the diff even corrects a wrong `scratch_dir` default), and the A1111 deprecation claim is verified against `config.py`.

Closes #279.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
