### PR TITLE
feat: reference-image gallery foundation — origin field + register_imported_image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ site/
 .mcp.json
 .repowise/
 docs/superpowers/
+
+# Editor / IDE tooling (e.g. codex plugin writes .vscode/mcp.json)
+.vscode/

--- a/docs/decisions/0006-image-asset-model.md
+++ b/docs/decisions/0006-image-asset-model.md
@@ -98,6 +98,34 @@ each image (`{id}-original.{ext}`). The in-memory registry is a cache rebuilt
 from sidecar files on startup. This ensures provenance survives server
 restarts without introducing database dependencies.
 
+### Origin Provenance (`origin` / `origin_source`)
+
+`ImageRecord` carries an `origin` discriminator (`"generated"` — produced by a
+provider — vs `"imported"` — brought into the gallery from an external source)
+plus an `origin_source` provenance string (e.g. `"upload"`, `"fetch:<url>"`, an
+original filename). This lets a single gallery hold both provider-generated and
+externally-imported images while keeping them distinguishable; an imported
+record carries an empty `provider`/`prompt`, so `origin` is the sole
+discriminator. Introduced with the reference-image ingestion epic (issue #300).
+
+Decisions:
+
+- **`origin` is stored, not derived.** Although today `origin` is a pure
+  function of `origin_source` (imported iff a source is present), it is stored
+  as an explicit, serialized sidecar field so the discriminator is stable if a
+  future origin kind is added that is **not** source-derived (e.g. a locally
+  edited variant).
+- **Coupling invariant, single definition.** `origin="imported"` iff a truthy
+  `origin_source`; `origin="generated"` iff `origin_source is None`. One
+  canonicalizer (`_origin_pair`) defines the rule and is used at both
+  enforcement sites — strict validation at `ImageRecord` construction, lenient
+  coercion when loading persisted sidecars.
+- **Corrupt sidecar degrades, not drops.** A persisted record whose pair is
+  inconsistent (e.g. hand-edited) is coerced to a valid `("generated", None)`
+  on reload rather than raising and dropping the image from the gallery.
+- **Back-compatible.** Sidecars predating these fields have neither key and
+  load as `("generated", None)`.
+
 ### Resolution as a Read-Time Concern
 
 The `generate_image` tool generates at the provider's native resolution.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -276,10 +276,14 @@ List all registered images and pending generations.
 
 Each item includes a `status` field: `"completed"` for registered images, `"generating"` or `"failed"` for pending background generations.
 
+Completed images also carry an `origin` field: `"generated"` for images produced by a provider (the case today), or `"imported"` for images added to the gallery from an external source. For imported images, `origin_source` records provenance and `provider`/`prompt` are empty; generated images have `origin_source: null`.
+
 ```json
 [
   {
     "image_id": "a1b2c3d4e5f6",
+    "origin": "generated",
+    "origin_source": null,
     "provider": "openai",
     "prompt": "a watercolor painting of mountains at sunset",
     "aspect_ratio": "16:9",

--- a/src/image_generation_mcp/_input_images.py
+++ b/src/image_generation_mcp/_input_images.py
@@ -81,13 +81,18 @@ def _parse_gallery_id(ref: str) -> str | None:
     return None
 
 
-def _validate(ref: str, data: bytes, max_bytes: int) -> str:
-    """Validate size and decodability; return the resolved MIME type.
+def validate_image_bytes(
+    data: bytes, *, max_bytes: int, ref: str = "<imported>"
+) -> str:
+    """Validate size and decodability of image bytes; return the resolved MIME.
+
+    Shared by reference resolution (:func:`resolve_reference`) and gallery
+    import (:meth:`ImageService.register_imported_image`).
 
     Args:
-        ref: The original reference string (used in error messages).
         data: Raw image bytes to validate.
         max_bytes: Maximum allowed byte size.
+        ref: Label for error messages (a reference string or ``"<imported>"``).
 
     Returns:
         The MIME type derived from the PIL-detected image format.
@@ -140,7 +145,7 @@ def resolve_reference(
             data, _content_type = loader(gallery_id)
         except KeyError as exc:
             raise ImageReferenceNotFound(ref) from exc
-        resolved_type = _validate(ref, data, max_bytes)
+        resolved_type = validate_image_bytes(data, max_bytes=max_bytes, ref=ref)
         return InputImage(data=data, content_type=resolved_type, source_id=gallery_id)
 
     if not allow_local_files:
@@ -149,7 +154,7 @@ def resolve_reference(
     if not path.is_file():
         raise ImageReferenceNotFound(ref)
     data = path.read_bytes()
-    resolved_type = _validate(ref, data, max_bytes)
+    resolved_type = validate_image_bytes(data, max_bytes=max_bytes, ref=ref)
     logger.debug("resolved_file_reference path=%s bytes=%d", ref, len(data))
     return InputImage(data=data, content_type=resolved_type, source_id=None)
 

--- a/src/image_generation_mcp/domain.py
+++ b/src/image_generation_mcp/domain.py
@@ -20,10 +20,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, ClassVar, TypeAlias
+from typing import Any, ClassVar, Literal, TypeAlias
 
 from PIL import Image as PILImage
 
+from image_generation_mcp._input_images import validate_image_bytes
 from image_generation_mcp.processing import (
     convert_format,
     crop_region,
@@ -48,9 +49,45 @@ from image_generation_mcp.styles import StyleEntry, scan_styles
 logger = logging.getLogger(__name__)
 
 
+ImageOrigin: TypeAlias = Literal["generated", "imported"]
+"""How an image entered the gallery: produced by a provider, or imported.
+
+Stored explicitly on :class:`ImageRecord` (not derived from ``origin_source``)
+so the provenance discriminator is an explicit, serialized sidecar field and
+stays stable if a future origin kind is added that is not source-derived.
+"""
+
+
+def _origin_pair(
+    raw_origin: str | None, raw_source: str | None
+) -> tuple[ImageOrigin, str | None]:
+    """Canonical ``(origin, origin_source)`` pair — the single coupling rule.
+
+    A record is ``"imported"`` only when it is **both** labeled
+    ``origin="imported"`` **and** carries a truthy ``origin_source`` (its
+    provenance); every other combination — including a stray source on a
+    ``"generated"`` record — canonicalizes to ``("generated", None)``. Both
+    conditions are load-bearing: dropping the ``raw_origin`` guard would flip a
+    generated record that picked up a stray source to ``"imported"`` on reload.
+
+    This is the one definition of the coupling, used both to validate at
+    construction (:meth:`ImageRecord.__post_init__`) and to coerce persisted
+    sidecar data on reload, so the two sites can never drift.
+    """
+    if raw_origin == "imported" and raw_source:
+        return "imported", raw_source
+    return "generated", None
+
+
 @dataclass(frozen=True)
 class ImageRecord:
-    """Metadata for a registered image in the scratch directory."""
+    """Metadata for a registered image in the scratch directory.
+
+    Invariant: ``origin`` and ``origin_source`` are a coupled pair —
+    ``origin="imported"`` carries a (truthy) ``origin_source`` (its
+    provenance), and ``origin="generated"`` carries ``origin_source=None``.
+    See :func:`_origin_pair`.
+    """
 
     id: str
     original_path: Path
@@ -66,6 +103,43 @@ class ImageRecord:
     ]  # treat as read-only; frozen prevents reassignment
     created_at: float
     source_image_ids: list[str] = field(default_factory=list)
+    origin: ImageOrigin = "generated"
+    origin_source: str | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce the origin/origin_source pairing invariant.
+
+        A record is consistent iff its pair equals its own canonical form
+        (see :func:`_origin_pair`).
+        """
+        if (self.origin, self.origin_source) != _origin_pair(
+            self.origin, self.origin_source
+        ):
+            raise ValueError(
+                f"origin={self.origin!r} inconsistent with "
+                f"origin_source={self.origin_source!r}"
+            )
+
+
+@dataclass(frozen=True)
+class _PersistMeta:
+    """Metadata bundle for :meth:`ImageService._persist_image`.
+
+    Groups the domain fields shared by generated and imported images so the
+    persist helper stays under the parameter ceiling.
+    """
+
+    content_type: str
+    provider: str
+    prompt: str
+    negative_prompt: str | None
+    aspect_ratio: str
+    quality: str
+    background: str  # persisted to the sidecar only; not a field on ImageRecord
+    provider_metadata: dict[str, Any]
+    source_image_ids: list[str]
+    origin: ImageOrigin
+    origin_source: str | None
 
 
 _PENDING_TTL_S = 600  # 10 minutes — clean up stale pending entries
@@ -657,40 +731,121 @@ class ImageService:
         Returns:
             The created ImageRecord.
         """
-        self._scratch_dir.mkdir(parents=True, exist_ok=True)
-
         # Use pre-allocated ID or derive from content
         if image_id is None:
             image_id = hashlib.sha256(result.image_data).hexdigest()[:12]
+        return self._persist_image(
+            image_id=image_id,
+            data=result.image_data,
+            meta=_PersistMeta(
+                content_type=result.content_type,
+                provider=provider_name,
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                aspect_ratio=aspect_ratio,
+                quality=quality,
+                background=background,
+                provider_metadata=result.provider_metadata,
+                source_image_ids=list(source_image_ids or []),
+                origin="generated",
+                origin_source=None,
+            ),
+        )
 
-        # Extract original dimensions via Pillow
-        img = PILImage.open(io.BytesIO(result.image_data))
-        original_dimensions = img.size  # (width, height)
+    def register_imported_image(
+        self,
+        data: bytes,
+        *,
+        origin_source: str,
+        max_bytes: int,
+    ) -> ImageRecord:
+        """Register externally-sourced bytes as a first-class gallery entry.
 
-        # Save original
-        ext = _mime_to_ext(result.content_type)
+        The image gets a content-addressed ID (so re-importing identical
+        bytes is idempotent) and is marked ``origin="imported"`` — it has an
+        empty provider and prompt, so ``origin`` is the sole generated/imported
+        discriminator. Every existing tool, resource, and ``transform_image``
+        reference then works on it unchanged.
+
+        Args:
+            data: Raw image bytes (from an upload, URL fetch, or base64 body).
+            origin_source: Provenance detail (e.g. ``"upload"``,
+                ``"fetch:<url>"``, or an original filename).
+            max_bytes: Maximum allowed byte size. Callers pass the configured
+                ``max_input_image_bytes`` so the cap stays uniform across every
+                input surface (no separate default here to drift from it).
+
+        Returns:
+            The created ImageRecord.
+
+        Raises:
+            InputImageTooLarge: When ``len(data) > max_bytes``.
+            InvalidInputImage: When the bytes are not a decodable image, or the
+                format is not one of PNG/JPEG/WEBP.
+            ValueError: When ``origin_source`` is empty/falsy — an imported
+                image must carry a provenance (enforced by ImageRecord's
+                origin pairing invariant).
+        """
+        content_type = validate_image_bytes(data, max_bytes=max_bytes)
+        return self._persist_image(
+            image_id=hashlib.sha256(data).hexdigest()[:12],
+            data=data,
+            meta=_PersistMeta(
+                content_type=content_type,
+                provider="",
+                prompt="",
+                negative_prompt=None,
+                aspect_ratio="",
+                quality="",
+                background="opaque",
+                provider_metadata={},
+                source_image_ids=[],
+                origin="imported",
+                origin_source=origin_source,
+            ),
+        )
+
+    def _persist_image(
+        self,
+        *,
+        image_id: str,
+        data: bytes,
+        meta: _PersistMeta,
+    ) -> ImageRecord:
+        """Persist image bytes + sidecar + registry entry; return the record.
+
+        Shared by :meth:`register_image` (generated) and
+        :meth:`register_imported_image` (imported).
+        """
+        self._scratch_dir.mkdir(parents=True, exist_ok=True)
+
+        original_dimensions = PILImage.open(io.BytesIO(data)).size  # (w, h)
+
+        ext = _mime_to_ext(meta.content_type)
         original_filename = f"{image_id}-original{ext}"
         original_path = self._scratch_dir / original_filename
-        original_path.write_bytes(result.image_data)
 
-        # Build record
-        ids = list(source_image_ids or [])
+        # Build (and thereby validate, via __post_init__) the record BEFORE
+        # writing the image file or sidecar, so an inconsistent origin pair
+        # raises without leaving an orphaned image file behind.
         record = ImageRecord(
             id=image_id,
             original_path=original_path,
-            content_type=result.content_type,
-            provider=provider_name,
-            prompt=prompt,
-            negative_prompt=negative_prompt,
-            aspect_ratio=aspect_ratio,
-            quality=quality,
+            content_type=meta.content_type,
+            provider=meta.provider,
+            prompt=meta.prompt,
+            negative_prompt=meta.negative_prompt,
+            aspect_ratio=meta.aspect_ratio,
+            quality=meta.quality,
             original_dimensions=original_dimensions,
-            provider_metadata=result.provider_metadata,
+            provider_metadata=meta.provider_metadata,
             created_at=time.time(),
-            source_image_ids=ids,
+            source_image_ids=meta.source_image_ids,
+            origin=meta.origin,
+            origin_source=meta.origin_source,
         )
+        original_path.write_bytes(data)
 
-        # Write sidecar JSON
         sidecar_path = self._scratch_dir / f"{image_id}.json"
         sidecar_data = {
             "id": record.id,
@@ -699,25 +854,27 @@ class ImageService:
             "provider": record.provider,
             "aspect_ratio": record.aspect_ratio,
             "quality": record.quality,
-            "background": background,
+            "background": meta.background,
             "content_type": record.content_type,
             "original_filename": original_filename,
-            "original_size_bytes": result.size_bytes,
+            "original_size_bytes": len(data),
             "original_dimensions": list(record.original_dimensions),
             "provider_metadata": record.provider_metadata,
             "created_at": datetime.fromtimestamp(record.created_at, tz=UTC).isoformat(),
             "source_image_ids": record.source_image_ids,
+            "origin": record.origin,
+            "origin_source": record.origin_source,
         }
         sidecar_path.write_text(json.dumps(sidecar_data, indent=2))
 
-        # Store in registry
         self._images[image_id] = record
 
         logger.info(
-            "Registered image %s from %s (%d bytes)",
+            "registered_image image_id=%s origin=%s provider=%s bytes=%d",
             image_id,
-            provider_name,
-            result.size_bytes,
+            meta.origin,
+            meta.provider,
+            len(data),
         )
         return record
 
@@ -944,6 +1101,18 @@ class ImageService:
                 if source_ids is None:
                     legacy = data.get("source_image_id")
                     source_ids = [legacy] if legacy else []
+                # Normalize the origin pair as a unit so a corrupted sidecar
+                # can never trip ImageRecord's pairing invariant on reload: an
+                # "imported" record without a source degrades to "generated"
+                # rather than dropping the whole image.
+                origin, origin_source = _origin_pair(
+                    data.get("origin"), data.get("origin_source")
+                )
+                if data.get("origin") == "imported" and origin == "generated":
+                    logger.warning(
+                        "origin_coerced image_id=%s reason=imported_without_source",
+                        image_id,
+                    )
                 record = ImageRecord(
                     id=image_id,
                     original_path=original_path,
@@ -957,6 +1126,8 @@ class ImageService:
                     provider_metadata=data.get("provider_metadata", {}),
                     created_at=created_at,
                     source_image_ids=source_ids,
+                    origin=origin,
+                    origin_source=origin_source,
                 )
                 self._images[image_id] = record
                 count += 1

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -2019,9 +2019,9 @@ def register_resources(mcp: FastMCP) -> None:
         "image://list",
         mime_type="application/json",
         description=(
-            "List all generated images with their IDs, resource URIs, "
-            "and prompts. Read this to find image_ids for use with "
-            "image://*/view and image://*/metadata resources."
+            "List all gallery images (generated and imported) with their "
+            "IDs, resource URIs, and prompts. Read this to find image_ids "
+            "for use with image://*/view and image://*/metadata resources."
         ),
         icons=[
             Icon(
@@ -2046,6 +2046,8 @@ def register_resources(mcp: FastMCP) -> None:
             {
                 "image_id": img.id,
                 "status": "completed",
+                "origin": img.origin,
+                "origin_source": img.origin_source,
                 "provider": img.provider,
                 "content_type": img.content_type,
                 "original_dimensions": list(img.original_dimensions),

--- a/tests/test_imported_images.py
+++ b/tests/test_imported_images.py
@@ -1,0 +1,328 @@
+"""Tests for imported-image gallery foundation (issue #306).
+
+An imported image (uploaded/fetched/base64 bytes) becomes a persistent,
+first-class gallery entry via ``ImageService.register_imported_image``,
+distinguished from a generated one by the ``origin`` field.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+from PIL import Image
+
+from image_generation_mcp._input_images import InputImageTooLarge, InvalidInputImage
+from image_generation_mcp.domain import ImageRecord, ImageService
+from image_generation_mcp.providers.types import ImageResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_MAX = 20 * 1024 * 1024  # byte cap callers pass; matches config default
+
+
+def _png_bytes(color: str = "red", size: tuple[int, int] = (4, 4)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_register_imported_image_sets_origin(tmp_path: Path) -> None:
+    """An imported image is marked origin='imported' with its source detail."""
+    svc = ImageService(scratch_dir=tmp_path)
+    record = svc.register_imported_image(
+        _png_bytes(), origin_source="upload", max_bytes=_MAX
+    )
+    assert record.origin == "imported"
+    assert record.origin_source == "upload"
+    assert record.content_type == "image/png"
+    # No faked provider: origin is the sole generated/imported discriminator.
+    assert record.provider == ""
+
+
+def test_generated_image_origin_defaults_to_generated(tmp_path: Path) -> None:
+    """A generated image (register_image) carries origin='generated'."""
+    svc = ImageService(scratch_dir=tmp_path)
+    record = svc.register_image(
+        ImageResult(image_data=_png_bytes(), content_type="image/png"),
+        "placeholder",
+        prompt="p",
+    )
+    assert record.origin == "generated"
+    assert record.origin_source is None
+
+
+def test_imported_image_persisted_and_reloaded(tmp_path: Path) -> None:
+    """origin/origin_source round-trip through the sidecar on reload."""
+    svc = ImageService(scratch_dir=tmp_path)
+    record = svc.register_imported_image(
+        _png_bytes(),
+        origin_source="fetch:https://example.com/a.png",
+        max_bytes=_MAX,
+    )
+
+    sidecar = json.loads((tmp_path / f"{record.id}.json").read_text())
+    assert sidecar["origin"] == "imported"
+    assert sidecar["origin_source"] == "fetch:https://example.com/a.png"
+
+    reloaded = ImageService(scratch_dir=tmp_path).get_image(record.id)
+    assert reloaded.origin == "imported"
+    assert reloaded.origin_source == "fetch:https://example.com/a.png"
+
+
+def test_legacy_sidecar_without_origin_loads_as_generated(tmp_path: Path) -> None:
+    """A pre-existing sidecar with no origin keys loads as origin='generated'."""
+    svc = ImageService(scratch_dir=tmp_path)
+    record = svc.register_image(
+        ImageResult(image_data=_png_bytes(), content_type="image/png"),
+        "placeholder",
+        prompt="p",
+    )
+    sidecar_path = tmp_path / f"{record.id}.json"
+    data = json.loads(sidecar_path.read_text())
+    data.pop("origin", None)
+    data.pop("origin_source", None)
+    sidecar_path.write_text(json.dumps(data))
+
+    reloaded = ImageService(scratch_dir=tmp_path).get_image(record.id)
+    assert reloaded.origin == "generated"
+    assert reloaded.origin_source is None
+
+
+def test_import_dedup_same_bytes_same_id(tmp_path: Path) -> None:
+    """Importing identical bytes twice is idempotent (content-addressed id)."""
+    svc = ImageService(scratch_dir=tmp_path)
+    data = _png_bytes()
+    first = svc.register_imported_image(data, origin_source="upload", max_bytes=_MAX)
+    second = svc.register_imported_image(data, origin_source="upload", max_bytes=_MAX)
+    assert first.id == second.id
+    assert len(svc.list_images()) == 1  # single registry entry, not a duplicate
+
+
+def test_import_distinct_bytes_distinct_ids(tmp_path: Path) -> None:
+    """Different images get different ids."""
+    svc = ImageService(scratch_dir=tmp_path)
+    a = svc.register_imported_image(
+        _png_bytes("red"), origin_source="upload", max_bytes=_MAX
+    )
+    b = svc.register_imported_image(
+        _png_bytes("blue"), origin_source="upload", max_bytes=_MAX
+    )
+    assert a.id != b.id
+
+
+def test_import_empty_origin_source_rejected_no_orphan(tmp_path: Path) -> None:
+    """Empty origin_source is rejected before any write — no orphaned file."""
+    svc = ImageService(scratch_dir=tmp_path)
+    with pytest.raises(ValueError, match="inconsistent"):
+        svc.register_imported_image(_png_bytes(), origin_source="", max_bytes=_MAX)
+    # Validation runs before the file write, so nothing is left on disk.
+    assert list(tmp_path.glob("*")) == []
+
+
+def test_import_rejects_non_image_bytes(tmp_path: Path) -> None:
+    """Non-image bytes are rejected with the typed error."""
+    svc = ImageService(scratch_dir=tmp_path)
+    with pytest.raises(InvalidInputImage):
+        svc.register_imported_image(
+            b"not an image", origin_source="upload", max_bytes=_MAX
+        )
+
+
+def test_import_rejects_oversized(tmp_path: Path) -> None:
+    """Bytes exceeding the cap are rejected before registration."""
+    svc = ImageService(scratch_dir=tmp_path)
+    with pytest.raises(InputImageTooLarge):
+        svc.register_imported_image(
+            _png_bytes(size=(64, 64)), origin_source="upload", max_bytes=10
+        )
+
+
+@pytest.mark.parametrize(
+    ("origin", "origin_source"),
+    [("imported", None), ("imported", ""), ("generated", "stray-source")],
+)
+def test_imagerecord_rejects_inconsistent_pairing(
+    tmp_path: Path, origin: str, origin_source: str | None
+) -> None:
+    """ImageRecord enforces the origin/origin_source pairing at construction."""
+    with pytest.raises(ValueError, match="inconsistent"):
+        ImageRecord(
+            id="abc123",
+            original_path=tmp_path / "x.png",
+            content_type="image/png",
+            provider="",
+            prompt="",
+            negative_prompt=None,
+            aspect_ratio="",
+            quality="",
+            original_dimensions=(4, 4),
+            provider_metadata={},
+            created_at=0.0,
+            origin=origin,  # type: ignore[arg-type]
+            origin_source=origin_source,
+        )
+
+
+def test_reload_coerces_inconsistent_origin_pairing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A sidecar violating the pairing is coerced to a valid record, not dropped.
+
+    An "imported" sidecar missing its origin_source degrades to "generated"
+    on reload so the image stays visible rather than silently vanishing, and
+    the anomaly is logged at WARNING.
+    """
+    svc = ImageService(scratch_dir=tmp_path)
+    record = svc.register_imported_image(
+        _png_bytes(), origin_source="upload", max_bytes=_MAX
+    )
+    sidecar_path = tmp_path / f"{record.id}.json"
+    data = json.loads(sidecar_path.read_text())
+    data["origin_source"] = None  # inconsistent: imported with no source
+    sidecar_path.write_text(json.dumps(data))
+
+    with caplog.at_level(logging.WARNING):
+        reloaded = ImageService(scratch_dir=tmp_path).get_image(record.id)
+    assert reloaded.origin == "generated"
+    assert reloaded.origin_source is None
+    assert "origin_coerced" in caplog.text
+
+
+def test_reload_skips_sidecar_with_missing_original(tmp_path: Path) -> None:
+    """A sidecar whose original image file is gone is skipped on reload."""
+    svc = ImageService(scratch_dir=tmp_path)
+    record = svc.register_imported_image(
+        _png_bytes(), origin_source="upload", max_bytes=_MAX
+    )
+    record.original_path.unlink()  # remove the image, leave the sidecar
+
+    reloaded = ImageService(scratch_dir=tmp_path)
+    assert record.id not in {r.id for r in reloaded.list_images()}
+
+
+def test_reload_strips_stray_source_from_generated(tmp_path: Path) -> None:
+    """The mirror arm: a generated sidecar with a stray origin_source is coerced.
+
+    The stray source is dropped (not carried, not dropping the whole image) so
+    the record loads as a valid generated pair.
+    """
+    svc = ImageService(scratch_dir=tmp_path)
+    record = svc.register_image(
+        ImageResult(image_data=_png_bytes(), content_type="image/png"),
+        "placeholder",
+        prompt="p",
+    )
+    sidecar_path = tmp_path / f"{record.id}.json"
+    data = json.loads(sidecar_path.read_text())
+    data["origin_source"] = "stray"  # inconsistent: generated with a source
+    sidecar_path.write_text(json.dumps(data))
+
+    reloaded = ImageService(scratch_dir=tmp_path).get_image(record.id)
+    assert reloaded.origin == "generated"
+    assert reloaded.origin_source is None
+
+
+def test_import_of_generated_bytes_collides_last_writer_wins(tmp_path: Path) -> None:
+    """Content-addressed IDs mean identical bytes are one entry; import wins.
+
+    Re-importing the exact bytes of an already-generated image resolves to the
+    same id, so the import overwrites the entry (origin flips to imported).
+    """
+    svc = ImageService(scratch_dir=tmp_path)
+    data = _png_bytes()
+    generated = svc.register_image(
+        ImageResult(image_data=data, content_type="image/png"),
+        "placeholder",
+        prompt="p",
+    )
+    imported = svc.register_imported_image(data, origin_source="upload", max_bytes=_MAX)
+
+    assert imported.id == generated.id
+    assert len(svc.list_images()) == 1
+    winner = svc.get_image(generated.id)
+    assert winner.origin == "imported"
+    assert winner.origin_source == "upload"
+    assert winner.provider == ""
+
+
+async def test_image_list_surfaces_origin(tmp_path: Path) -> None:
+    """image://list includes the origin field for completed images."""
+    import asyncio
+
+    from fastmcp import Client, FastMCP
+    from mcp.types import TextContent, TextResourceContents
+
+    from image_generation_mcp.config import ProjectConfig
+    from image_generation_mcp.resources import register_resources
+    from image_generation_mcp.tools import register_tools
+    from tests._helpers import service_lifespan
+
+    config = ProjectConfig(scratch_dir=tmp_path, read_only=False)
+    mcp = FastMCP("test-origin-list", lifespan=service_lifespan(config))
+    register_tools(mcp)
+    register_resources(mcp)
+
+    async with Client(mcp) as client:
+        gen = await client.call_tool(
+            "generate_image", {"prompt": "origin surfacing", "provider": "placeholder"}
+        )
+        meta = json.loads(next(c for c in gen.content if c.type == "text").text)
+        image_id = meta["image_id"]
+
+        for _ in range(50):
+            await asyncio.sleep(0.05)
+            show = await client.call_tool(
+                "show_image", {"uri": f"image://{image_id}/view"}
+            )
+            show_text = [c for c in show.content if isinstance(c, TextContent)]
+            if json.loads(show_text[0].text).get("status") != "generating":
+                break
+
+        listing = await client.read_resource("image://list")
+
+    contents = listing[0]
+    assert isinstance(contents, TextResourceContents)
+    entries = json.loads(contents.text)
+    completed = [e for e in entries if e.get("status") == "completed"]
+    assert completed, "expected at least one completed image"
+    assert all(e["origin"] == "generated" for e in completed)
+
+
+async def test_image_list_surfaces_imported_origin(tmp_path: Path) -> None:
+    """image://list reports origin='imported' and origin_source for imports."""
+    from fastmcp import Client, FastMCP
+    from mcp.types import TextResourceContents
+
+    from image_generation_mcp.config import ProjectConfig
+    from image_generation_mcp.resources import register_resources
+    from image_generation_mcp.tools import register_tools
+    from tests._helpers import service_lifespan
+
+    # Pre-populate the scratch dir; the lifespan service loads it on startup.
+    seed = ImageService(scratch_dir=tmp_path)
+    record = seed.register_imported_image(
+        _png_bytes(),
+        origin_source="fetch:https://example.com/a.png",
+        max_bytes=_MAX,
+    )
+
+    config = ProjectConfig(scratch_dir=tmp_path, read_only=False)
+    mcp = FastMCP("test-imported-list", lifespan=service_lifespan(config))
+    register_tools(mcp)
+    register_resources(mcp)
+
+    async with Client(mcp) as client:
+        listing = await client.read_resource("image://list")
+
+    contents = listing[0]
+    assert isinstance(contents, TextResourceContents)
+    entries = json.loads(contents.text)
+    entry = next(e for e in entries if e.get("image_id") == record.id)
+    assert entry["origin"] == "imported"
+    assert entry["origin_source"] == "fetch:https://example.com/a.png"

--- a/uv.lock
+++ b/uv.lock
@@ -1080,7 +1080,7 @@ wheels = [
 
 [[package]]
 name = "image-generation-mcp"
-version = "1.10.1"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Closes #306. First slice of epic #300 (external images into the gallery). **No pvl-core dependency** — this is the domain-glue foundation the ingestion tools (#307 upload, #308 fetch, #309 base64) build on.

## What

An externally-sourced image can become a **persistent, first-class gallery entry**, distinguished from a provider-generated one by a new `origin` field. Ingestion is decoupled — a "reference image" is just any gallery image — so `transform_image` needs no changes.

- `ImageRecord` gains `origin: Literal["generated","imported"]` + `origin_source`, with a `__post_init__` pairing invariant. A single `_origin_pair()` canonicalizer is the one definition of the coupling, used strictly at construction and leniently when loading sidecars (a corrupt/inconsistent sidecar degrades to `generated` rather than dropping the image, and logs `origin_coerced` when a claimed-imported record loses its source).
- `ImageService.register_imported_image(data, *, origin_source, max_bytes)` — content-addressed id (dedup), reuses the shared `validate_image_bytes` (extracted from `_input_images`), records `provider`/`prompt` as empty so `origin` is the sole discriminator. `max_bytes` is required (no local default) so the cap stays uniform with `IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES` once the tools wire it.
- `register_image` + `register_imported_image` share a `_persist_image` helper that **validates before writing** (no orphaned file on an invalid pair).
- `image://list` surfaces `origin`/`origin_source`; the resource description now says "generated and imported".

## Docs

- `docs/resources.md` — the new `image://list` fields.
- `docs/decisions/0006-image-asset-model.md` — new "Origin Provenance" section (the stored-not-derived decision, the coupling invariant, degrade-not-drop reload, back-compat).

## Verification

- `uv run pytest` — 955 passed; **patch coverage 100%**.
- mypy clean; ruff check + format clean; structural diff-gate 100%; Vale clean.
- Local pre-flight review (five-lens + code-reviewer/type-design/pr-test/comment-analyzer) run to convergence before opening.

Follow-ups (tracked, not in this PR): the ingestion tools #307–#309; the presentational grouping #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._