### PR TITLE
feat(tools): fetch_image — SSRF-hardened URL → gallery via fetch_url (closes #308)

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -14,8 +14,10 @@ Traefik
 
 # --- HTTP / URL terminology ---
 hostname
+loopback
 subpath
 URIs
+userinfo
 
 # --- OAuth / OIDC token fields ---
 access_token
@@ -54,6 +56,7 @@ delete_style
 denoising
 downscaled
 edit_image
+fetch_image
 frontmatter
 gallery_full_image
 generate_image
@@ -97,6 +100,7 @@ content_type
 Danbooru
 dataclass
 dataclasses
+decodable
 deprioritize
 deprioritized
 Dev

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ All domain environment variables use the `IMAGE_GENERATION_MCP_` prefix.
 |---|---|---|---|
 | `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT` | `false` | No | Enable local filesystem paths as `transform_image` reference images. **Security:** grants callers server-filesystem read access via path; enable only for trusted callers or local single-user deployments. |
 | `IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES` | `20971520` | No | Per-reference maximum byte size for input images (default 20 MiB). |
+| `IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S` | `30.0` | No | HTTP fetch timeout in seconds, used when fetching remote image URLs. |
 
 ### Capability-link transfer (HTTP downloads/uploads)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ instructions without editing template-owned code:
 |----------|------|---------|-------------|
 | `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT` | bool | `false` | Enable local filesystem paths as `transform_image` reference images. When `false` (default), only gallery `image_id` values and `image://` URIs are accepted. |
 | `IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES` | int | `20971520` | Per-reference maximum byte size for input images (default: 20 MiB). Applies to every reference, whether resolved from the gallery or a local file. References exceeding this limit are rejected before the provider call. |
+| `IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S` | float | `30.0` | HTTP fetch timeout in seconds, used when fetching remote image URLs. |
 
 !!! warning "Security: local file input"
     Setting `ALLOW_LOCAL_FILE_INPUT=true` grants callers read access to any file readable by the server process (they can pass arbitrary paths). Enable only for trusted callers, such as a local single-user Claude Desktop installation. Leave disabled on shared or network-accessible deployments.

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -273,6 +273,14 @@
       "advancedGroup": "Behaviour"
     },
     {
+      "id": "fetch_timeout_s",
+      "label": "Fetch timeout (s)",
+      "help": "HTTP fetch timeout in seconds, used when fetching remote image URLs. Default: 30.0.",
+      "type": "text",
+      "var": "IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S",
+      "advancedGroup": "Behaviour"
+    },
+    {
       "id": "transfer_ttl_default_s",
       "label": "Transfer link default TTL (s)",
       "help": "Default lifetime of a create_download_link/create_upload_link URL when the caller omits one. HTTP transports only. Default: 3600 (1 h).",

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -522,7 +522,7 @@ Fetched image into the gallery: image://a1b2c3d4e5f6/view
 
 On failure, a message describing why the fetch was rejected, such as an SSRF-blocked target, an HTTP error, a timeout, an oversized body, or content that is not a decodable image.
 
-The fetch is SSRF-hardened: URLs targeting private, loopback, link-local, or cloud-metadata addresses are refused, and redirects are not followed. The download is capped at `IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES` (default 20 MiB) with a request timeout of `IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S` (default 30 seconds). The stored provenance is the fetched URL with userinfo and query stripped, so a secret-bearing URL never persists to the image's sidecar metadata.
+The fetch is SSRF-hardened: URLs targeting private, loopback, link-local, or cloud-metadata addresses are refused, and redirects are not followed. The download is capped at `IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES` (default 20 MiB) with a request timeout of `IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S` (default 30 seconds). The stored provenance is the fetched URL with userinfo, query, and fragment stripped, so a secret-bearing URL never persists to the image's sidecar metadata.
 
 ### Example
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -497,6 +497,44 @@ Raises an error if the style is not found.
 
 ---
 
+## fetch_image
+
+Fetch an image from an `http`/`https` URL into the gallery as an imported entry you can then show, edit, or transform.
+
+| Property | Value |
+|----------|-------|
+| **Tags** | `write` (hidden in read-only mode) |
+| **Annotations** | `readOnlyHint: false`, `destructiveHint: false`, `openWorldHint: true` |
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | str | *(required)* | The `http(s)` URL of the image to fetch. |
+
+### Return value
+
+Text confirmation with the gallery URI on success:
+
+```
+Fetched image into the gallery: image://a1b2c3d4e5f6/view
+```
+
+On failure, a message describing why the fetch was rejected, such as an SSRF-blocked target, an HTTP error, a timeout, an oversized body, or content that is not a decodable image.
+
+The fetch is SSRF-hardened: URLs targeting private, loopback, link-local, or cloud-metadata addresses are refused, and redirects are not followed. The download is capped at `IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES` (default 20 MiB) with a request timeout of `IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S` (default 30 seconds). The stored provenance is the fetched URL with userinfo and query stripped, so a secret-bearing URL never persists to the image's sidecar metadata.
+
+### Example
+
+```
+User: Fetch this image and add it to the gallery: https://example.com/photo.png
+
+Tool call: fetch_image
+  url: "https://example.com/photo.png"
+```
+
+---
+
 ## list_providers
 
 List available image generation providers and their status.

--- a/src/image_generation_mcp/_fetch_image.py
+++ b/src/image_generation_mcp/_fetch_image.py
@@ -1,0 +1,30 @@
+"""Fetch a caller-supplied image URL into the gallery (issue #308).
+
+Wraps pvl-core's SSRF-hardened ``fetch_url``: pull the bytes at an http(s) URL
+(private/loopback/metadata targets rejected, redirects refused, size-capped) and
+register them as an ``imported`` gallery entry. Stored provenance is redacted
+(userinfo + query dropped) so a secret-bearing URL never persists to the sidecar.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+
+def _redact_fetch_url(url: str) -> str:
+    """Return *url* with userinfo, query, and fragment stripped.
+
+    Provenance must not persist secrets (``user:pass@`` / ``?token=…``); keep
+    only ``scheme://host[:port]/path``. An IPv6-literal host is re-bracketed
+    (``urlparse`` hands it back unbracketed).
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if ":" in host:  # IPv6 literal
+        host = f"[{host}]"
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    return urlunparse((parsed.scheme, host, parsed.path, "", "", ""))

--- a/src/image_generation_mcp/_fetch_image.py
+++ b/src/image_generation_mcp/_fetch_image.py
@@ -8,8 +8,17 @@ register them as an ``imported`` gallery entry. Stored provenance is redacted
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
+
+from fastmcp_pvl_core import fetch_url
+
+if TYPE_CHECKING:
+    import httpx
+
+    from image_generation_mcp.domain import ImageRecord, ImageService
 
 logger = logging.getLogger(__name__)
 
@@ -28,3 +37,53 @@ def _redact_fetch_url(url: str) -> str:
     if parsed.port is not None:
         host = f"{host}:{parsed.port}"
     return urlunparse((parsed.scheme, host, parsed.path, "", "", ""))
+
+
+async def fetch_image_into_gallery(
+    service: ImageService,
+    url: str,
+    *,
+    max_bytes: int,
+    timeout_s: float,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> ImageRecord:
+    """Fetch *url* (SSRF-hardened) and register the bytes as an imported image.
+
+    Args:
+        service: The live ImageService.
+        url: Caller-supplied http(s) URL.
+        max_bytes: Size cap; the fetch aborts past it and the bytes are
+            re-checked at registration.
+        timeout_s: Overall fetch timeout in seconds.
+        transport: Optional httpx transport (test injection); ``None`` = real
+            networking.
+
+    Returns:
+        The created ImageRecord (``origin="imported"``,
+        ``origin_source="fetch:<redacted-url>"``).
+
+    Raises:
+        ValueError: SSRF-blocked / bad scheme / missing host / refused redirect
+            / body over *max_bytes* (from ``fetch_url``).
+        httpx.HTTPStatusError: On a 4xx/5xx response status.
+        httpx.TransportError: On timeout / connection failure.
+        InvalidInputImage: When the fetched bytes are not a decodable image.
+        InputImageTooLarge: When the fetched bytes exceed *max_bytes*.
+    """
+    result = await fetch_url(
+        url, max_bytes=max_bytes, timeout_s=timeout_s, transport=transport
+    )
+    redacted = _redact_fetch_url(url)
+    record = await asyncio.to_thread(
+        service.register_imported_image,
+        result.body,
+        origin_source=f"fetch:{redacted}",
+        max_bytes=max_bytes,
+    )
+    logger.info(
+        "fetch_image_ingested image_id=%s url=%s bytes=%d",
+        record.id,
+        redacted,
+        result.size,
+    )
+    return record

--- a/src/image_generation_mcp/_fetch_image.py
+++ b/src/image_generation_mcp/_fetch_image.py
@@ -3,7 +3,8 @@
 Wraps pvl-core's SSRF-hardened ``fetch_url``: pull the bytes at an http(s) URL
 (private/loopback/metadata targets rejected, redirects refused, size-capped) and
 register them as an ``imported`` gallery entry. Stored provenance is redacted
-(userinfo + query dropped) so a secret-bearing URL never persists to the sidecar.
+(userinfo, query, and fragment dropped) so a secret-bearing URL never persists to
+the sidecar.
 """
 
 from __future__ import annotations

--- a/src/image_generation_mcp/config.py
+++ b/src/image_generation_mcp/config.py
@@ -46,6 +46,7 @@ class ProjectConfig:
     allow_local_file_input: bool = False
     max_input_image_bytes: int = 20 * 1024 * 1024
     transfer: TransferConfig = field(default_factory=TransferConfig)
+    fetch_timeout_s: float = 30.0
     # CONFIG-FIELDS-END
 
     @classmethod
@@ -69,6 +70,8 @@ class ProjectConfig:
         - ``IMAGE_GENERATION_MCP_TRANSFER_*``: capability-link transfer tuning
           (``TTL_DEFAULT_S``, ``TTL_MAX_S``, ``GRACE_TTL_S``, ``LEASE_S``,
           ``MAX_UPLOAD_BYTES``) read via ``TransferConfig.from_env``.
+        - ``IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S``: HTTP fetch timeout in
+          seconds (float, default ``30.0``).
 
         Plus all generic ``ServerConfig`` env vars (BASE_URL, BEARER_TOKEN,
         OIDC_*, EVENT_STORE_URL, SERVER_NAME, INSTRUCTIONS) — see
@@ -148,6 +151,18 @@ class ProjectConfig:
                     max_input_image_bytes,
                 )
 
+        raw_fetch_timeout = env(_ENV_PREFIX, "FETCH_TIMEOUT_S")
+        fetch_timeout_s = 30.0
+        if raw_fetch_timeout:
+            try:
+                fetch_timeout_s = float(raw_fetch_timeout)
+            except ValueError:
+                logger.warning(
+                    "Invalid FETCH_TIMEOUT_S=%r — using default %s",
+                    raw_fetch_timeout,
+                    fetch_timeout_s,
+                )
+
         config = cls(
             server=server,
             server_name=server_name,
@@ -164,6 +179,7 @@ class ProjectConfig:
             allow_local_file_input=allow_local_file_input,
             max_input_image_bytes=max_input_image_bytes,
             transfer=TransferConfig.from_env(_ENV_PREFIX),
+            fetch_timeout_s=fetch_timeout_s,
         )
         # CONFIG-FROM-ENV-END
 

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -1655,19 +1655,19 @@ def register_tools(mcp: FastMCP) -> None:
                 timeout_s=config.fetch_timeout_s,
             )
         except ValueError as exc:
-            logger.warning("fetch_image_rejected: %s", exc)
+            logger.warning("fetch_image_rejected error=%s", exc)
             return f"Could not fetch the image: {exc}"
         except httpx.HTTPStatusError as exc:
-            logger.warning("fetch_image_http_error: %s", exc)
+            logger.warning("fetch_image_http_error error=%s", exc)
             return f"Could not fetch the image: {exc}"
         except httpx.TransportError as exc:
-            logger.warning("fetch_image_transport_error: %s", type(exc).__name__)
+            logger.warning("fetch_image_transport_error error=%s", type(exc).__name__)
             return (
                 "Could not fetch the image: the request timed out or the "
                 "connection failed."
             )
         except InputImageTooLarge as exc:
-            logger.warning("fetch_image_too_large: %s", exc)
+            logger.warning("fetch_image_too_large error=%s", exc)
             return f"Could not fetch the image: {exc}"
         except InvalidInputImage:
             logger.warning("fetch_image_not_an_image")

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -25,6 +25,7 @@ from urllib.parse import parse_qs, urlparse
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+import httpx
 from fastmcp import FastMCP
 from fastmcp.apps import AppConfig
 from fastmcp.dependencies import CurrentContext, Depends
@@ -42,6 +43,7 @@ from mcp.types import (
 from PIL import Image as PILImage
 from pydantic import AnyUrl
 
+from ._fetch_image import fetch_image_into_gallery
 from ._input_images import (
     ImageReferenceNotFound,
     InputImageTooLarge,
@@ -1614,3 +1616,62 @@ def register_tools(mcp: FastMCP) -> None:
 
         result = {"name": name, "deleted": True}
         return json.dumps(result, indent=2)
+
+    @mcp.tool(
+        tags={"write"},
+        annotations={
+            "title": "Fetch Image",
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "openWorldHint": True,
+        },
+        icons=[Icon(src=_LUCIDE.format("link"), mimeType="image/svg+xml")],
+    )
+    async def fetch_image(
+        url: str,
+        service: ImageService = Depends(get_service),
+        config: ProjectConfig = Depends(get_config),
+    ) -> str:
+        """Fetch an image from a URL into the gallery.
+
+        Downloads the image at *url* (http/https only) and adds it to the
+        gallery as an imported entry you can then show, edit, or transform. The
+        fetch is SSRF-hardened: URLs targeting private, loopback, link-local, or
+        cloud-metadata addresses are refused, redirects are not followed, and the
+        download is size-capped. Hidden in read-only mode.
+
+        Args:
+            url: The http(s) URL of the image to fetch.
+
+        Returns:
+            The gallery URI (``image://<id>/view``) on success, or a message
+            describing why the fetch failed.
+        """
+        try:
+            record = await fetch_image_into_gallery(
+                service,
+                url,
+                max_bytes=config.max_input_image_bytes,
+                timeout_s=config.fetch_timeout_s,
+            )
+        except ValueError as exc:
+            logger.warning("fetch_image_rejected: %s", exc)
+            return f"Could not fetch the image: {exc}"
+        except httpx.HTTPStatusError as exc:
+            logger.warning("fetch_image_http_error: %s", exc)
+            return f"Could not fetch the image: {exc}"
+        except httpx.TransportError as exc:
+            logger.warning("fetch_image_transport_error: %s", type(exc).__name__)
+            return (
+                "Could not fetch the image: the request timed out or the "
+                "connection failed."
+            )
+        except InputImageTooLarge as exc:
+            logger.warning("fetch_image_too_large: %s", exc)
+            return f"Could not fetch the image: {exc}"
+        except InvalidInputImage:
+            logger.warning("fetch_image_not_an_image")
+            return (
+                "Could not fetch the image: the fetched content is not a valid image."
+            )
+        return f"Fetched image into the gallery: image://{record.id}/view"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -276,3 +276,16 @@ def test_max_input_image_bytes_invalid_falls_back(
 ) -> None:
     monkeypatch.setenv("IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES", "notanumber")
     assert ProjectConfig.from_env().max_input_image_bytes == 20 * 1024 * 1024
+
+
+def test_fetch_timeout_default() -> None:
+    from image_generation_mcp.config import ProjectConfig
+
+    assert ProjectConfig().fetch_timeout_s == 30.0
+
+
+def test_fetch_timeout_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from image_generation_mcp.config import ProjectConfig
+
+    monkeypatch.setenv("IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S", "12.5")
+    assert ProjectConfig.from_env().fetch_timeout_s == 12.5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -289,3 +289,10 @@ def test_fetch_timeout_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setenv("IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S", "12.5")
     assert ProjectConfig.from_env().fetch_timeout_s == 12.5
+
+
+def test_fetch_timeout_invalid_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    from image_generation_mcp.config import ProjectConfig
+
+    monkeypatch.setenv("IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S", "notafloat")
+    assert ProjectConfig.from_env().fetch_timeout_s == 30.0

--- a/tests/test_fetch_image.py
+++ b/tests/test_fetch_image.py
@@ -2,7 +2,118 @@
 
 from __future__ import annotations
 
-from image_generation_mcp._fetch_image import _redact_fetch_url
+import io
+
+import httpx
+import pytest
+from PIL import Image
+
+from image_generation_mcp._fetch_image import (
+    _redact_fetch_url,
+    fetch_image_into_gallery,
+)
+from image_generation_mcp._input_images import InvalidInputImage
+from image_generation_mcp.domain import ImageService
+
+
+def _png_bytes(color: str = "red") -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def service(tmp_path) -> ImageService:
+    return ImageService(scratch_dir=tmp_path)
+
+
+def _png_transport(status: int = 200, body: bytes | None = None) -> httpx.MockTransport:
+    payload = _png_bytes() if body is None else body
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status, content=payload, headers={"content-type": "image/png"}
+        )
+
+    return httpx.MockTransport(handler)
+
+
+# A public IP literal skips DNS (hermetic); MockTransport handles the dial.
+_PUBLIC_URL = "http://93.184.216.34/img.png"
+
+
+async def test_fetch_success_registers_imported(service: ImageService) -> None:
+    record = await fetch_image_into_gallery(
+        service,
+        _PUBLIC_URL,
+        max_bytes=1_000_000,
+        timeout_s=5,
+        transport=_png_transport(),
+    )
+    assert record.origin == "imported"
+    assert record.origin_source == "fetch:http://93.184.216.34/img.png"
+
+
+async def test_fetch_redacts_secret_in_provenance(service: ImageService) -> None:
+    url = "http://user:pass@93.184.216.34/img.png?token=SECRET"
+    record = await fetch_image_into_gallery(
+        service, url, max_bytes=1_000_000, timeout_s=5, transport=_png_transport()
+    )
+    assert record.origin_source is not None
+    assert "SECRET" not in record.origin_source
+    assert "pass" not in record.origin_source
+    assert record.origin_source == "fetch:http://93.184.216.34/img.png"
+
+
+async def test_fetch_ssrf_blocked_raises_valueerror(service: ImageService) -> None:
+    # Link-local literal: rejected pre-connect, no transport needed.
+    with pytest.raises(ValueError, match="private, loopback"):
+        await fetch_image_into_gallery(
+            service, "http://169.254.169.254/meta", max_bytes=1000, timeout_s=5
+        )
+
+
+async def test_fetch_non_2xx_raises_status_error(service: ImageService) -> None:
+    with pytest.raises(httpx.HTTPStatusError):
+        await fetch_image_into_gallery(
+            service,
+            _PUBLIC_URL,
+            max_bytes=1_000_000,
+            timeout_s=5,
+            transport=_png_transport(status=404),
+        )
+
+
+async def test_fetch_oversized_raises_valueerror(service: ImageService) -> None:
+    with pytest.raises(ValueError):
+        await fetch_image_into_gallery(
+            service, _PUBLIC_URL, max_bytes=10, timeout_s=5, transport=_png_transport()
+        )
+
+
+async def test_fetch_timeout_raises_transport_error(service: ImageService) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("timed out", request=request)
+
+    with pytest.raises(httpx.TransportError):
+        await fetch_image_into_gallery(
+            service,
+            _PUBLIC_URL,
+            max_bytes=1_000_000,
+            timeout_s=5,
+            transport=httpx.MockTransport(handler),
+        )
+
+
+async def test_fetch_non_image_raises_invalid(service: ImageService) -> None:
+    with pytest.raises(InvalidInputImage):
+        await fetch_image_into_gallery(
+            service,
+            _PUBLIC_URL,
+            max_bytes=1_000_000,
+            timeout_s=5,
+            transport=_png_transport(body=b"not an image"),
+        )
 
 
 def test_redact_drops_userinfo_query_fragment() -> None:

--- a/tests/test_fetch_image.py
+++ b/tests/test_fetch_image.py
@@ -1,0 +1,21 @@
+"""Tests for the fetch_image helper (issue #308)."""
+
+from __future__ import annotations
+
+from image_generation_mcp._fetch_image import _redact_fetch_url
+
+
+def test_redact_drops_userinfo_query_fragment() -> None:
+    url = "https://user:pass@example.com/dir/img.png?token=SECRET#frag"
+    assert _redact_fetch_url(url) == "https://example.com/dir/img.png"
+
+
+def test_redact_keeps_explicit_port() -> None:
+    assert _redact_fetch_url("http://host:8080/a?x=1") == "http://host:8080/a"
+
+
+def test_redact_brackets_ipv6_host() -> None:
+    assert (
+        _redact_fetch_url("http://[2001:db8::1]:443/p?q=1")
+        == "http://[2001:db8::1]:443/p"
+    )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2298,6 +2298,47 @@ class TestFetchImageTool:
         )
         assert "not a valid image" in result
 
+    async def test_http_status_error_returns_generic_string(
+        self, monkeypatch, service: ImageService
+    ) -> None:
+        import httpx
+
+        import image_generation_mcp.tools as tools_mod
+
+        async def _raise(*_args, **_kwargs):
+            raise httpx.HTTPStatusError(
+                "HTTP 404 response from http://host/p",
+                request=httpx.Request("GET", "http://host/p"),
+                response=httpx.Response(404),
+            )
+
+        monkeypatch.setattr(tools_mod, "fetch_image_into_gallery", _raise)
+        tool = await self._fetch_tool()
+        result = await tool.fn(
+            url="http://93.184.216.34/x",
+            service=service,
+            config=await self._make_cfg(),
+        )
+        assert "Could not fetch the image" in result
+
+    async def test_input_image_too_large_returns_error_string(
+        self, monkeypatch, service: ImageService
+    ) -> None:
+        import image_generation_mcp.tools as tools_mod
+        from image_generation_mcp._input_images import InputImageTooLarge
+
+        async def _raise(*_args, **_kwargs):
+            raise InputImageTooLarge("fetch", 999, 100)
+
+        monkeypatch.setattr(tools_mod, "fetch_image_into_gallery", _raise)
+        tool = await self._fetch_tool()
+        result = await tool.fn(
+            url="http://93.184.216.34/x",
+            service=service,
+            config=await self._make_cfg(),
+        )
+        assert "Could not fetch the image" in result
+
     async def test_success_returns_image_uri(
         self, monkeypatch, service: ImageService
     ) -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1094,6 +1094,14 @@ class TestToolAnnotations:
                     "idempotentHint": False,
                 },
             ),
+            (
+                "fetch_image",
+                {
+                    "readOnlyHint": False,
+                    "destructiveHint": False,
+                    "openWorldHint": True,
+                },
+            ),
         ],
     )
     async def test_tool_annotations(
@@ -2200,3 +2208,112 @@ class TestTransformImageTool:
                 config=cfg,
                 ctx=ctx,
             )
+
+
+# ---------------------------------------------------------------------------
+# fetch_image tool
+# ---------------------------------------------------------------------------
+
+
+class TestFetchImageTool:
+    """fetch_image maps every fetch/validation failure to a user string."""
+
+    async def _fetch_tool(self):
+        from fastmcp import FastMCP
+
+        from image_generation_mcp.tools import register_tools
+
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("fetch_image")
+        assert tool is not None
+        return tool
+
+    async def _make_cfg(self) -> MagicMock:
+        cfg = MagicMock()
+        cfg.max_input_image_bytes = 20 * 1024 * 1024
+        cfg.fetch_timeout_s = 30.0
+        return cfg
+
+    async def test_registered_with_write_tag_and_open_world(self) -> None:
+        tool = await self._fetch_tool()
+        assert "write" in tool.tags
+        assert tool.annotations is not None
+        assert tool.annotations.title == "Fetch Image"
+        assert tool.annotations.openWorldHint is True
+        assert tool.icons
+
+    async def test_ssrf_blocked_returns_error_string(
+        self, monkeypatch, service: ImageService
+    ) -> None:
+        import image_generation_mcp.tools as tools_mod
+
+        async def _raise(*_args, **_kwargs):
+            raise ValueError("URLs targeting private, loopback, ... are not allowed.")
+
+        monkeypatch.setattr(tools_mod, "fetch_image_into_gallery", _raise)
+        tool = await self._fetch_tool()
+        result = await tool.fn(
+            url="http://169.254.169.254/x",
+            service=service,
+            config=await self._make_cfg(),
+        )
+        assert "Could not fetch the image" in result
+        assert "not allowed" in result
+
+    async def test_transport_error_returns_generic_string(
+        self, monkeypatch, service: ImageService
+    ) -> None:
+        import httpx
+
+        import image_generation_mcp.tools as tools_mod
+
+        async def _raise(*_args, **_kwargs):
+            raise httpx.TimeoutException("timed out")
+
+        monkeypatch.setattr(tools_mod, "fetch_image_into_gallery", _raise)
+        tool = await self._fetch_tool()
+        result = await tool.fn(
+            url="http://93.184.216.34/x",
+            service=service,
+            config=await self._make_cfg(),
+        )
+        assert "timed out or the connection failed" in result
+
+    async def test_non_image_returns_error_string(
+        self, monkeypatch, service: ImageService
+    ) -> None:
+        import image_generation_mcp.tools as tools_mod
+        from image_generation_mcp._input_images import InvalidInputImage
+
+        async def _raise(*_args, **_kwargs):
+            raise InvalidInputImage("input")
+
+        monkeypatch.setattr(tools_mod, "fetch_image_into_gallery", _raise)
+        tool = await self._fetch_tool()
+        result = await tool.fn(
+            url="http://93.184.216.34/x",
+            service=service,
+            config=await self._make_cfg(),
+        )
+        assert "not a valid image" in result
+
+    async def test_success_returns_image_uri(
+        self, monkeypatch, service: ImageService
+    ) -> None:
+        import image_generation_mcp.tools as tools_mod
+
+        class _Rec:
+            id = "abc123def456"
+
+        async def _ok(*_args, **_kwargs):
+            return _Rec()
+
+        monkeypatch.setattr(tools_mod, "fetch_image_into_gallery", _ok)
+        tool = await self._fetch_tool()
+        result = await tool.fn(
+            url="http://93.184.216.34/x",
+            service=service,
+            config=await self._make_cfg(),
+        )
+        assert result == "Fetched image into the gallery: image://abc123def456/view"


### PR DESCRIPTION
Closes #308. Part of epic #300 (get external images into the gallery).

Adds `fetch_image(url)` — pull an image from a caller-supplied `http`/`https` URL into the gallery via pvl-core's SSRF-hardened `fetch_url` primitive, landing an `imported` gallery entry with **redacted** provenance.

## What changed

- **`_fetch_image.py`** (new): `_redact_fetch_url(url)` (drops userinfo + query + fragment, re-brackets IPv6 hosts) and `async fetch_image_into_gallery(service, url, *, max_bytes, timeout_s, transport=None)` — `await fetch_url(...)` → `to_thread(register_imported_image, ..., origin_source="fetch:<redacted>")`. The `transport=` seam lets tests drive real `fetch_url` via `httpx.MockTransport`.
- **`config.fetch_timeout_s`** (`IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S`, default `30.0`). Size cap reuses `max_input_image_bytes` (20 MiB) — the fetch aborts at the domain image cap rather than downloading up to `fetch_url`'s 100 MiB default then rejecting.
- **`fetch_image` tool** (`tools.py`): `{"write"}`-tagged (hidden in read-only), `openWorldHint=True`, Lucide `link` icon, Google-style docstring. Works on all transports. Maps every fetch/validation exception to a user-facing string (`ValueError` / `httpx.HTTPStatusError` / `httpx.TransportError` / `InvalidInputImage` / `InputImageTooLarge`) — none propagates.
- Docs: `docs/tools.md` tool section, README + `docs/configuration.md` + config-wizard entry for `FETCH_TIMEOUT_S`.

## Security — URL/secret redaction on every emit path

A caller URL can carry `user:pass@` / `?token=…`. Redaction holds everywhere:
- **Provenance** stores `fetch:<scheme>://host[:port]/path` (userinfo + query + fragment dropped) — a `?token=SECRET` never persists to the sidecar (asserted by test).
- **`HTTPStatusError`** — pvl-core re-raises it with a redacted message (`from None` suppresses the un-redacted context); the tool renders `str(exc)`, never `exc.request.url`.
- **`ValueError`** messages are userinfo+query-redacted by `fetch_url`; **`TransportError`** logs only `type(exc).__name__` and returns a generic string.

## Design notes

- The verified pvl-core API diverged from the issue's assumptions: the issue's `TRANSFER_FETCH_MAX_BYTES` / `TRANSFER_FETCH_TIMEOUT_S` env vars don't exist (`fetch_url` takes plain args; `TransferConfig` has no fetch fields). Resolved by reusing `max_input_image_bytes` for the cap and adding one `FETCH_TIMEOUT_S` field.
- Follow-up filed: #313 (pre-existing stale "four domain tools" count in `docs/tools.md`, unrelated to this PR).

## Testing

TDD throughout, hermetic (`httpx.MockTransport`; a public IP-literal host skips DNS): success, SSRF-block, non-2xx, oversize, timeout, non-image, secret-non-persistence, and `_redact_fetch_url` edge cases (userinfo/query/fragment, explicit port, IPv6). Tool tests cover all five error-arm mappings + success + the annotations enforcement entry. Config: default / env-override / bad-input fallback.

All gates green locally: 964 passed, ruff/format/mypy clean, structural diff-gate 100%, patch coverage 100%, Vale, config-wizard drift. A full preflight-circus (5 core lenses + code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer) is clean at the ≥80 bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
