### PR TITLE
feat(tools): ingest_base64_image — inline base64 → gallery via decode_base64_capped (closes #309)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -535,6 +535,44 @@ Tool call: fetch_image
 
 ---
 
+## ingest_base64_image
+
+Add an inline base64-encoded image to the gallery as an imported entry you can then show, edit, or transform.
+
+| Property | Value |
+|----------|-------|
+| **Tags** | `write` (hidden in read-only mode) |
+| **Annotations** | `readOnlyHint: false`, `destructiveHint: false`, `openWorldHint: false` |
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `data` | str | *(required)* | The base64-encoded image bytes. Raw base64, a `data:<type>;base64,...` URI, or line-wrapped base64 are all accepted. |
+
+### Return value
+
+Text confirmation with the gallery URI on success:
+
+```
+Ingested image into the gallery: image://a1b2c3d4e5f6/view
+```
+
+On failure, a message describing why the image could not be ingested: invalid base64 or an oversized image, or bytes that don't decode as an image.
+
+The decoded size is capped at `IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES` (default 20 MiB); oversized or invalid base64 is rejected.
+
+### Example
+
+```
+User: Here's a base64 image, add it to the gallery: iVBORw0KGgoAAAANSUhEUgAA...
+
+Tool call: ingest_base64_image
+  data: "iVBORw0KGgoAAAANSUhEUgAA..."
+```
+
+---
+
 ## list_providers
 
 List available image generation providers and their status.

--- a/src/image_generation_mcp/_base64_image.py
+++ b/src/image_generation_mcp/_base64_image.py
@@ -1,0 +1,27 @@
+"""Inline base64 image ingest into the gallery (issue #309).
+
+Wraps pvl-core's ``decode_base64_capped`` (a strict, size-capped base64 decoder) and
+registers the decoded bytes as an ``imported`` gallery entry. The primitive rejects
+wrapped input (``validate=True``), so this module normalizes first — stripping a
+``data:<type>;base64,`` URI prefix and any whitespace — which is the "unwrap first" the
+primitive's contract expects of its caller.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+_DATA_URI_PREFIX = re.compile(r"^data:[^,]*;base64,", re.IGNORECASE)
+
+
+def _normalize_base64(data: str) -> str:
+    """Return *data* as raw base64: strip a ``data:<type>;base64,`` prefix and whitespace.
+
+    ``decode_base64_capped`` uses ``validate=True`` and rejects wrapped input, so a
+    data-URI wrapper or line-wrapped (MIME) base64 must be unwrapped before decoding.
+    """
+    without_prefix = _DATA_URI_PREFIX.sub("", data, count=1)
+    return "".join(without_prefix.split())

--- a/src/image_generation_mcp/_base64_image.py
+++ b/src/image_generation_mcp/_base64_image.py
@@ -52,7 +52,8 @@ def base64_into_gallery(
         ValueError: Invalid base64, or a decoded size over *max_bytes* (from
             ``decode_base64_capped``).
         InvalidInputImage: The decoded bytes are not a decodable image.
-        InputImageTooLarge: The decoded bytes exceed *max_bytes* at registration.
+        InputImageTooLarge: Defensive re-check at registration; unreachable while
+            the decode cap and the registration cap are the same ``max_bytes``.
     """
     decoded = decode_base64_capped(_normalize_base64(data), max_bytes=max_bytes)
     record = service.register_imported_image(

--- a/src/image_generation_mcp/_base64_image.py
+++ b/src/image_generation_mcp/_base64_image.py
@@ -1,16 +1,24 @@
 """Inline base64 image ingest into the gallery (issue #309).
 
 Wraps pvl-core's ``decode_base64_capped`` (a strict, size-capped base64 decoder) and
-registers the decoded bytes as an ``imported`` gallery entry. The primitive rejects
-wrapped input (``validate=True``), so this module normalizes first — stripping a
+registers the decoded bytes as an ``imported`` gallery entry via
+``ImageService.register_imported_image``. The primitive rejects wrapped input
+(``validate=True``), so this module normalizes first — stripping a
 ``data:<type>;base64,`` URI prefix and any whitespace — which is the "unwrap first" the
-primitive's contract expects of its caller.
+primitive's contract expects of its caller. ``base64_into_gallery`` composes
+normalize -> decode -> register into the single entry point tools call.
 """
 
 from __future__ import annotations
 
 import logging
 import re
+from typing import TYPE_CHECKING
+
+from fastmcp_pvl_core import decode_base64_capped
+
+if TYPE_CHECKING:
+    from image_generation_mcp.domain import ImageRecord, ImageService
 
 logger = logging.getLogger(__name__)
 
@@ -25,3 +33,30 @@ def _normalize_base64(data: str) -> str:
     """
     without_prefix = _DATA_URI_PREFIX.sub("", data, count=1)
     return "".join(without_prefix.split())
+
+
+def base64_into_gallery(
+    service: ImageService, data: str, *, max_bytes: int
+) -> ImageRecord:
+    """Decode inline base64 *data* under a size cap and register it as an imported image.
+
+    Args:
+        service: The live ImageService.
+        data: Inline base64 — raw, ``data:<type>;base64,`` URI, or whitespace-wrapped.
+        max_bytes: Cap on the decoded byte size (also re-checked at registration).
+
+    Returns:
+        The created ImageRecord (``origin="imported"``, ``origin_source="base64"``).
+
+    Raises:
+        ValueError: Invalid base64, or a decoded size over *max_bytes* (from
+            ``decode_base64_capped``).
+        InvalidInputImage: The decoded bytes are not a decodable image.
+        InputImageTooLarge: The decoded bytes exceed *max_bytes* at registration.
+    """
+    decoded = decode_base64_capped(_normalize_base64(data), max_bytes=max_bytes)
+    record = service.register_imported_image(
+        decoded, origin_source="base64", max_bytes=max_bytes
+    )
+    logger.info("base64_image_ingested image_id=%s bytes=%d", record.id, len(decoded))
+    return record

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -43,6 +43,7 @@ from mcp.types import (
 from PIL import Image as PILImage
 from pydantic import AnyUrl
 
+from ._base64_image import base64_into_gallery
 from ._fetch_image import fetch_image_into_gallery
 from ._input_images import (
     ImageReferenceNotFound,
@@ -1675,3 +1676,51 @@ def register_tools(mcp: FastMCP) -> None:
                 "Could not fetch the image: the fetched content is not a valid image."
             )
         return f"Fetched image into the gallery: image://{record.id}/view"
+
+    @mcp.tool(
+        tags={"write"},
+        annotations={
+            "title": "Ingest Base64 Image",
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "openWorldHint": False,
+        },
+        icons=[Icon(src=_LUCIDE.format("file-image"), mimeType="image/svg+xml")],
+    )
+    async def ingest_base64_image(
+        data: str,
+        service: ImageService = Depends(get_service),
+        config: ProjectConfig = Depends(get_config),
+    ) -> str:
+        """Add an inline base64-encoded image to the gallery.
+
+        Decodes *data* (raw base64, a ``data:...;base64,...`` URI, or line-wrapped
+        base64 — all accepted) under a size cap and adds it to the gallery as an
+        imported entry you can then show, edit, or transform. Hidden in read-only mode.
+
+        Args:
+            data: The base64-encoded image bytes.
+
+        Returns:
+            The gallery URI (``image://<id>/view``) on success, or a message
+            describing why the image could not be ingested.
+        """
+        try:
+            record = await asyncio.to_thread(
+                base64_into_gallery,
+                service,
+                data,
+                max_bytes=config.max_input_image_bytes,
+            )
+        except ValueError as exc:
+            logger.warning("ingest_base64_rejected error=%s", exc)
+            return f"Could not decode the image: {exc}"
+        except InputImageTooLarge as exc:
+            logger.warning("ingest_base64_too_large error=%s", exc)
+            return f"Could not decode the image: {exc}"
+        except InvalidInputImage:
+            logger.warning("ingest_base64_not_an_image")
+            return (
+                "Could not decode the image: the decoded content is not a valid image."
+            )
+        return f"Ingested image into the gallery: image://{record.id}/view"

--- a/tests/test_base64_image.py
+++ b/tests/test_base64_image.py
@@ -10,9 +10,6 @@ from PIL import Image
 
 from image_generation_mcp._base64_image import _normalize_base64, base64_into_gallery
 from image_generation_mcp._input_images import InvalidInputImage
-from image_generation_mcp.config import (
-    ProjectConfig,  # noqa: F401  (kept for parity with sibling tests)
-)
 from image_generation_mcp.domain import ImageService
 
 

--- a/tests/test_base64_image.py
+++ b/tests/test_base64_image.py
@@ -1,0 +1,17 @@
+"""Tests for the base64 ingest helper (issue #309)."""
+
+from __future__ import annotations
+
+from image_generation_mcp._base64_image import _normalize_base64
+
+
+def test_normalize_strips_data_uri_prefix() -> None:
+    assert _normalize_base64("data:image/png;base64,aGVsbG8=") == "aGVsbG8="
+
+
+def test_normalize_strips_whitespace_and_newlines() -> None:
+    assert _normalize_base64("aGVs\n bG8=\r\n") == "aGVsbG8="
+
+
+def test_normalize_leaves_raw_base64_unchanged() -> None:
+    assert _normalize_base64("aGVsbG8=") == "aGVsbG8="

--- a/tests/test_base64_image.py
+++ b/tests/test_base64_image.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
-from image_generation_mcp._base64_image import _normalize_base64
+import base64
+import io
+
+import pytest
+from PIL import Image
+
+from image_generation_mcp._base64_image import _normalize_base64, base64_into_gallery
+from image_generation_mcp._input_images import InvalidInputImage
+from image_generation_mcp.config import (
+    ProjectConfig,  # noqa: F401  (kept for parity with sibling tests)
+)
+from image_generation_mcp.domain import ImageService
 
 
 def test_normalize_strips_data_uri_prefix() -> None:
@@ -15,3 +26,50 @@ def test_normalize_strips_whitespace_and_newlines() -> None:
 
 def test_normalize_leaves_raw_base64_unchanged() -> None:
     assert _normalize_base64("aGVsbG8=") == "aGVsbG8="
+
+
+def _png_b64() -> str:
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), "red").save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+@pytest.fixture
+def service(tmp_path) -> ImageService:
+    return ImageService(scratch_dir=tmp_path)
+
+
+async def test_ingest_success_registers_imported(service: ImageService) -> None:
+    record = base64_into_gallery(service, _png_b64(), max_bytes=1_000_000)
+    assert record.origin == "imported"
+    assert record.origin_source == "base64"
+
+
+async def test_ingest_accepts_data_uri(service: ImageService) -> None:
+    record = base64_into_gallery(
+        service, "data:image/png;base64," + _png_b64(), max_bytes=1_000_000
+    )
+    assert record.origin == "imported"
+
+
+async def test_ingest_accepts_whitespace_wrapped(service: ImageService) -> None:
+    wrapped = "\n".join(_png_b64()[i : i + 16] for i in range(0, len(_png_b64()), 16))
+    record = base64_into_gallery(service, wrapped, max_bytes=1_000_000)
+    assert record.origin == "imported"
+
+
+async def test_ingest_malformed_raises_valueerror(service: ImageService) -> None:
+    with pytest.raises(ValueError):
+        base64_into_gallery(service, "@@@@not-base64@@@@", max_bytes=1_000_000)
+
+
+async def test_ingest_oversized_raises_valueerror(service: ImageService) -> None:
+    big = base64.b64encode(b"x" * 200).decode()
+    with pytest.raises(ValueError):
+        base64_into_gallery(service, big, max_bytes=10)
+
+
+async def test_ingest_non_image_raises_invalid(service: ImageService) -> None:
+    not_image = base64.b64encode(b"this is not an image").decode()
+    with pytest.raises(InvalidInputImage):
+        base64_into_gallery(service, not_image, max_bytes=1_000_000)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1102,6 +1102,14 @@ class TestToolAnnotations:
                     "openWorldHint": True,
                 },
             ),
+            (
+                "ingest_base64_image",
+                {
+                    "readOnlyHint": False,
+                    "destructiveHint": False,
+                    "openWorldHint": False,
+                },
+            ),
         ],
     )
     async def test_tool_annotations(
@@ -2358,3 +2366,83 @@ class TestFetchImageTool:
             config=await self._make_cfg(),
         )
         assert result == "Fetched image into the gallery: image://abc123def456/view"
+
+
+class TestIngestBase64Tool:
+    """ingest_base64_image maps every decode/validation failure to a user string."""
+
+    @staticmethod
+    def _make_cfg() -> object:
+        return MagicMock(max_input_image_bytes=20 * 1024 * 1024)
+
+    async def _tool(self):
+        from fastmcp import FastMCP
+
+        from image_generation_mcp.tools import register_tools
+
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("ingest_base64_image")
+        assert tool is not None
+        return tool
+
+    async def test_registered_write_tag_no_open_world(self) -> None:
+        tool = await self._tool()
+        assert "write" in tool.tags
+        assert tool.annotations is not None
+        assert tool.annotations.title == "Ingest Base64 Image"
+        assert tool.annotations.openWorldHint is False
+        assert tool.icons
+
+    async def test_malformed_returns_error_string(self, monkeypatch) -> None:
+        import image_generation_mcp.tools as tools_mod
+
+        def _raise(*_args, **_kwargs):
+            raise ValueError("invalid base64: Only base64 data is allowed")
+
+        monkeypatch.setattr(tools_mod, "base64_into_gallery", _raise)
+        tool = await self._tool()
+        result = await tool.fn(data="@@@@", service=object(), config=self._make_cfg())
+        assert "Could not decode the image" in result
+
+    async def test_too_large_returns_error_string(self, monkeypatch) -> None:
+        import image_generation_mcp.tools as tools_mod
+        from image_generation_mcp._input_images import InputImageTooLarge
+
+        def _raise(*_args, **_kwargs):
+            raise InputImageTooLarge("base64", 999, 100)
+
+        monkeypatch.setattr(tools_mod, "base64_into_gallery", _raise)
+        tool = await self._tool()
+        result = await tool.fn(data="aGk=", service=object(), config=self._make_cfg())
+        assert "Could not decode the image" in result
+
+    async def test_non_image_returns_error_string(self, monkeypatch) -> None:
+        import image_generation_mcp.tools as tools_mod
+        from image_generation_mcp._input_images import InvalidInputImage
+
+        def _raise(*_args, **_kwargs):
+            raise InvalidInputImage("input")
+
+        monkeypatch.setattr(tools_mod, "base64_into_gallery", _raise)
+        tool = await self._tool()
+        result = await tool.fn(
+            data="aGVsbG8=", service=object(), config=self._make_cfg()
+        )
+        assert "not a valid image" in result
+
+    async def test_success_returns_image_uri(self, monkeypatch) -> None:
+        import image_generation_mcp.tools as tools_mod
+
+        class _Rec:
+            id = "abcdef012345"
+
+        def _ok(*_args, **_kwargs):
+            return _Rec()
+
+        monkeypatch.setattr(tools_mod, "base64_into_gallery", _ok)
+        tool = await self._tool()
+        result = await tool.fn(
+            data="aGVsbG8=", service=object(), config=self._make_cfg()
+        )
+        assert result == "Ingested image into the gallery: image://abcdef012345/view"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2239,8 +2239,8 @@ class TestFetchImageTool:
 
     async def _make_cfg(self) -> MagicMock:
         cfg = MagicMock()
-        cfg.max_input_image_bytes = 20 * 1024 * 1024
-        cfg.fetch_timeout_s = 30.0
+        cfg.max_input_image_bytes = 6_666_666
+        cfg.fetch_timeout_s = 44.5
         return cfg
 
     async def test_registered_with_write_tag_and_open_world(self) -> None:
@@ -2355,7 +2355,10 @@ class TestFetchImageTool:
         class _Rec:
             id = "abc123def456"
 
-        async def _ok(*_args, **_kwargs):
+        captured = {}
+
+        async def _ok(*_args, **kwargs):
+            captured.update(kwargs)
             return _Rec()
 
         monkeypatch.setattr(tools_mod, "fetch_image_into_gallery", _ok)
@@ -2366,6 +2369,8 @@ class TestFetchImageTool:
             config=await self._make_cfg(),
         )
         assert result == "Fetched image into the gallery: image://abc123def456/view"
+        assert captured["max_bytes"] == 6_666_666
+        assert captured["timeout_s"] == 44.5
 
 
 class TestIngestBase64Tool:
@@ -2373,7 +2378,7 @@ class TestIngestBase64Tool:
 
     @staticmethod
     def _make_cfg() -> object:
-        return MagicMock(max_input_image_bytes=20 * 1024 * 1024)
+        return MagicMock(max_input_image_bytes=7_777_777)
 
     async def _tool(self):
         from fastmcp import FastMCP
@@ -2437,7 +2442,10 @@ class TestIngestBase64Tool:
         class _Rec:
             id = "abcdef012345"
 
-        def _ok(*_args, **_kwargs):
+        captured = {}
+
+        def _ok(*_args, **kwargs):
+            captured.update(kwargs)
             return _Rec()
 
         monkeypatch.setattr(tools_mod, "base64_into_gallery", _ok)
@@ -2446,3 +2454,4 @@ class TestIngestBase64Tool:
             data="aGVsbG8=", service=object(), config=self._make_cfg()
         )
         assert result == "Ingested image into the gallery: image://abcdef012345/view"
+        assert captured["max_bytes"] == 7_777_777


### PR DESCRIPTION
Closes #309. Part of epic #300 (get external images into the gallery). Sibling of the merged #308 (fetch_image).

Adds `ingest_base64_image(data)` — decode inline base64 image bytes under a size cap via pvl-core's `decode_base64_capped` and register them as an `imported` gallery entry (`origin_source="base64"`).

## What changed

- **`_base64_image.py`** (new): `_normalize_base64(data)` strips a `data:<type>;base64,` URI prefix and all whitespace (the strict `validate=True` primitive rejects wrapped input, so the caller must unwrap first); `base64_into_gallery(service, data, *, max_bytes)` (sync) — normalize → `decode_base64_capped` → `register_imported_image`.
- **`ingest_base64_image` tool** (`tools.py`): `{"write"}`-tagged (hidden in read-only), **`openWorldHint=False`** (no network — inline decode, unlike fetch_image), Lucide `file-image` icon, Google-style docstring. Runs the sync helper via `asyncio.to_thread`, maps `ValueError` / `InvalidInputImage` / `InputImageTooLarge` to user strings (none propagates), returns `image://<id>/view`.
- Cap reuses `max_input_image_bytes` (20 MiB) as the decoded-size cap — no new config. Accepts raw base64, a `data:...;base64,...` URI, or line-wrapped base64.
- Docs: `docs/tools.md` tool section.

## Security / robustness

- **Size-cap safety:** `decode_base64_capped` rejects an over-cap payload *before* materialising it (size computed from encoded length, with a padding-clamp guard against `"AB"+"="*N` estimate-underflow), so an oversized payload never fully decodes into memory. The same cap is threaded to the decoder and the registration re-check.
- No URL/secret concern (the base64 *is* the content; provenance is the fixed string `"base64"`).

## Preflight findings addressed (fix-the-class)

The circus flagged that the tool tests didn't assert the `config.max_input_image_bytes → max_bytes` **cap wiring** (a DoS control that could silently break via a renamed attribute or hardcoded value while tests stayed green). Fixed with a sentinel-based kwargs assertion in the success test — and, per fix-the-class, the **identical gap in the merged `fetch_image` tool's test** (same file) is hardened symmetrically (`max_bytes` + `timeout_s`). Also corrected the `base64_into_gallery` docstring: `InputImageTooLarge` is a defensive re-check that's unreachable while the decode and registration caps are equal.

## Design note

The issue assumed pvl-core `decode_base64_capped` semantics that were verified against 4.4.0: it is sync and raises payload-free `ValueError`s (safe to surface). The primitive strictly rejects wrapped/whitespace input — which is exactly why the tool normalizes.

Follow-up filed: #315 (pre-existing — no full-registry test enforcing a non-empty `annotations.title`; most tools untitled).

## Testing

TDD, hermetic (pure sync — no network): `_normalize_base64` edge cases (data-URI, whitespace, raw), and `base64_into_gallery` against a real `ImageService` (success + `origin_source="base64"`, data-URI-wrapped, whitespace-wrapped, malformed → ValueError, oversized → ValueError, non-image → InvalidInputImage). Tool tests cover all three error arms + success + the cap-wiring assertion + the annotations enforcement entry.

All gates green locally: 979 passed, ruff/format/mypy clean, structural diff-gate 100%, patch coverage 100%, Vale. Full preflight-circus (5 core + code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer) clean at the ≥80 bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
