### PR TITLE
feat(gallery): filter gallery by image origin (generated/imported/all)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -338,6 +338,7 @@ JSON with gallery data (for non-UI clients):
   "total": 42,
   "page": 1,
   "page_size": 12,
+  "origin": "generated",
   "items": [
     {
       "image_id": "a1b2c3d4e5f6",

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -325,7 +325,9 @@ Open an interactive visual gallery of all generated images. The gallery renders 
 
 ### Parameters
 
-None. The gallery loads all images automatically.
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `origin` | `generated` \| `imported` \| `all` | `generated` | Which images to show. `generated` shows images produced by `generate_image`/`edit_image` plus any in-progress generations; `imported` shows images brought in via upload, fetch, or base64 ingestion; `all` shows both. |
 
 ### Return value
 
@@ -345,7 +347,8 @@ JSON with gallery data (for non-UI clients):
       "dimensions": [1024, 1024],
       "created_at": "2026-03-24T10:00:00+00:00",
       "thumbnail_b64": "<base64-encoded 128px WebP>",
-      "content_type": "image/png"
+      "content_type": "image/png",
+      "origin": "generated"
     }
   ]
 }

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1284,6 +1284,19 @@ _IMAGE_GALLERY_HTML = """\
       <div class="empty-title">No images yet</div>
       <div class="empty-sub">Use <code>generate_image</code> to create your first image.</div>
     </div>
+    <div class="state-empty" id="error">
+      <div class="empty-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" stroke-width="1.5"
+          stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="3" width="18" height="18" rx="2"/>
+          <circle cx="8.5" cy="8.5" r="1.5"/>
+          <polyline points="21 15 16 10 5 21"/>
+        </svg>
+      </div>
+      <div class="empty-title">Couldn't load the gallery</div>
+      <div class="empty-sub">Something went wrong — try again.</div>
+    </div>
     <div class="state-grid" id="grid-container">
       <div class="pip-toolbar"><button class="pip-btn" id="pip-btn" title="Picture-in-picture">\u25a3</button></div>
       <div class="gallery-grid" id="gallery-grid"></div>
@@ -1328,6 +1341,7 @@ _IMAGE_GALLERY_HTML = """\
     const mainEl    = document.getElementById("main");
     const loadingEl = document.getElementById("loading");
     const emptyEl   = document.getElementById("empty");
+    const errorEl   = document.getElementById("error");
     const gridEl    = document.getElementById("grid-container");
     const gridItems = document.getElementById("gallery-grid");
     const pagEl     = document.getElementById("pagination");
@@ -1558,6 +1572,7 @@ _IMAGE_GALLERY_HTML = """\
       if (which === "empty") updateEmptyState();
       loadingEl.style.display = which === "loading" ? "flex" : "none";
       emptyEl.style.display   = which === "empty"   ? "block" : "none";
+      errorEl.style.display   = which === "error"   ? "block" : "none";
       gridEl.style.display    = which === "grid"    ? "block" : "none";
       // For "grid", renderGrid/renderPipStrip call updateSize after populating
       if (which !== "grid") updateSize();
@@ -1696,9 +1711,9 @@ _IMAGE_GALLERY_HTML = """\
       show("loading");
       try {
         const result = await app.callServerTool({ name: "gallery_page", arguments: { page, page_size: ps, origin: currentOrigin } });
-        if (result.isError) { show("empty"); return; }
+        if (result.isError) { show("error"); return; }
         const text = result.content?.find(c => c.type === "text")?.text;
-        if (!text) { show("empty"); return; }
+        if (!text) { show("error"); return; }
         const data = JSON.parse(text);
         if (data.origin) syncOrigin(data.origin);
         currentPage = data.page || 1;
@@ -1707,7 +1722,7 @@ _IMAGE_GALLERY_HTML = """\
         renderGrid(data);
       } catch (e) {
         console.warn("gallery_page failed", e);
-        show("empty");
+        show("error");
       }
     }
 
@@ -1844,10 +1859,10 @@ _IMAGE_GALLERY_HTML = """\
 
     app.ontoolresult = ({ content }) => {
       const text = content?.find(c => c.type === "text");
-      if (!text) { show("empty"); return; }
+      if (!text) { show("error"); return; }
       try {
         const data = JSON.parse(text.text);
-        if (typeof data.total !== "number") { show("empty"); return; }
+        if (typeof data.total !== "number") { show("error"); return; }
         if (data.origin) syncOrigin(data.origin);
         currentPage = data.page || 1;
         currentTotal = data.total;
@@ -1855,7 +1870,7 @@ _IMAGE_GALLERY_HTML = """\
         renderGrid(data);
       } catch (e) {
         console.warn("Failed to parse gallery data", e);
-        show("empty");
+        show("error");
       }
     };
 

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1175,6 +1175,7 @@ _IMAGE_GALLERY_HTML = """\
     .main.pip-mode .card { aspect-ratio: 1; border-radius: 4px; }
     .main.pip-mode .card-overlay { display: none; }
     .main.pip-mode .pagination { display: none; }
+    .main.pip-mode .origin-filter { display: none; }
 
     /* Pagination */
     .pagination {
@@ -1262,6 +1263,11 @@ _IMAGE_GALLERY_HTML = """\
 </head>
 <body>
   <div class="main" id="main">
+    <div class="origin-filter" id="origin-filter">
+      <button class="seg active" data-origin="generated">Generated</button>
+      <button class="seg" data-origin="imported">Imported</button>
+      <button class="seg" data-origin="all">All</button>
+    </div>
     <div class="state-loading" id="loading">
       <div class="spinner"></div>Loading gallery\u2026
     </div>
@@ -1280,11 +1286,6 @@ _IMAGE_GALLERY_HTML = """\
     </div>
     <div class="state-grid" id="grid-container">
       <div class="pip-toolbar"><button class="pip-btn" id="pip-btn" title="Picture-in-picture">\u25a3</button></div>
-      <div class="origin-filter" id="origin-filter">
-        <button class="seg active" data-origin="generated">Generated</button>
-        <button class="seg" data-origin="imported">Imported</button>
-        <button class="seg" data-origin="all">All</button>
-      </div>
       <div class="gallery-grid" id="gallery-grid"></div>
       <div class="pagination" id="pagination"></div>
     </div>

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1284,19 +1284,6 @@ _IMAGE_GALLERY_HTML = """\
       <div class="empty-title">No images yet</div>
       <div class="empty-sub">Use <code>generate_image</code> to create your first image.</div>
     </div>
-    <div class="state-empty" id="error">
-      <div class="empty-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24"
-          fill="none" stroke="currentColor" stroke-width="1.5"
-          stroke-linecap="round" stroke-linejoin="round">
-          <rect x="3" y="3" width="18" height="18" rx="2"/>
-          <circle cx="8.5" cy="8.5" r="1.5"/>
-          <polyline points="21 15 16 10 5 21"/>
-        </svg>
-      </div>
-      <div class="empty-title">Couldn't load the gallery</div>
-      <div class="empty-sub">Something went wrong — try again.</div>
-    </div>
     <div class="state-grid" id="grid-container">
       <div class="pip-toolbar"><button class="pip-btn" id="pip-btn" title="Picture-in-picture">\u25a3</button></div>
       <div class="gallery-grid" id="gallery-grid"></div>
@@ -1341,7 +1328,6 @@ _IMAGE_GALLERY_HTML = """\
     const mainEl    = document.getElementById("main");
     const loadingEl = document.getElementById("loading");
     const emptyEl   = document.getElementById("empty");
-    const errorEl   = document.getElementById("error");
     const gridEl    = document.getElementById("grid-container");
     const gridItems = document.getElementById("gallery-grid");
     const pagEl     = document.getElementById("pagination");
@@ -1569,10 +1555,8 @@ _IMAGE_GALLERY_HTML = """\
 
     // --- Display states ---
     function show(which) {
-      if (which === "empty") updateEmptyState();
       loadingEl.style.display = which === "loading" ? "flex" : "none";
       emptyEl.style.display   = which === "empty"   ? "block" : "none";
-      errorEl.style.display   = which === "error"   ? "block" : "none";
       gridEl.style.display    = which === "grid"    ? "block" : "none";
       // For "grid", renderGrid/renderPipStrip call updateSize after populating
       if (which !== "grid") updateSize();
@@ -1653,7 +1637,7 @@ _IMAGE_GALLERY_HTML = """\
       lbPageItems = (items || []).filter(i => i.status === "completed" && i.image_id);
 
       if (!items || items.length === 0) {
-        if (total === 0) { show("empty"); return; }
+        if (total === 0) { updateEmptyState(); show("empty"); return; }
         show("grid");
         if (!pipActive) renderPagination();
         return;
@@ -1711,9 +1695,9 @@ _IMAGE_GALLERY_HTML = """\
       show("loading");
       try {
         const result = await app.callServerTool({ name: "gallery_page", arguments: { page, page_size: ps, origin: currentOrigin } });
-        if (result.isError) { show("error"); return; }
+        if (result.isError) { setGenericEmptyCopy(); show("empty"); return; }
         const text = result.content?.find(c => c.type === "text")?.text;
-        if (!text) { show("error"); return; }
+        if (!text) { setGenericEmptyCopy(); show("empty"); return; }
         const data = JSON.parse(text);
         if (data.origin) syncOrigin(data.origin);
         currentPage = data.page || 1;
@@ -1722,7 +1706,7 @@ _IMAGE_GALLERY_HTML = """\
         renderGrid(data);
       } catch (e) {
         console.warn("gallery_page failed", e);
-        show("error");
+        setGenericEmptyCopy(); show("empty");
       }
     }
 
@@ -1743,6 +1727,14 @@ _IMAGE_GALLERY_HTML = """\
         titleEl.textContent = "No images yet";
         subEl.innerHTML = 'Use <code>generate_image</code> to create your first image.';
       }
+    }
+
+    function setGenericEmptyCopy() {
+      const titleEl = document.querySelector("#empty .empty-title");
+      const subEl = document.querySelector("#empty .empty-sub");
+      if (!titleEl || !subEl) return;
+      titleEl.textContent = "No images yet";
+      subEl.innerHTML = 'Use <code>generate_image</code> to create your first image.';
     }
 
     document.getElementById("origin-filter").addEventListener("click", (e) => {
@@ -1859,10 +1851,10 @@ _IMAGE_GALLERY_HTML = """\
 
     app.ontoolresult = ({ content }) => {
       const text = content?.find(c => c.type === "text");
-      if (!text) { show("error"); return; }
+      if (!text) { setGenericEmptyCopy(); show("empty"); return; }
       try {
         const data = JSON.parse(text.text);
-        if (typeof data.total !== "number") { show("error"); return; }
+        if (typeof data.total !== "number") { setGenericEmptyCopy(); show("empty"); return; }
         if (data.origin) syncOrigin(data.origin);
         currentPage = data.page || 1;
         currentTotal = data.total;
@@ -1870,7 +1862,7 @@ _IMAGE_GALLERY_HTML = """\
         renderGrid(data);
       } catch (e) {
         console.warn("Failed to parse gallery data", e);
-        show("error");
+        setGenericEmptyCopy(); show("empty");
       }
     };
 

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1555,6 +1555,7 @@ _IMAGE_GALLERY_HTML = """\
 
     // --- Display states ---
     function show(which) {
+      if (which === "empty") updateEmptyState();
       loadingEl.style.display = which === "loading" ? "flex" : "none";
       emptyEl.style.display   = which === "empty"   ? "block" : "none";
       gridEl.style.display    = which === "grid"    ? "block" : "none";
@@ -1637,7 +1638,7 @@ _IMAGE_GALLERY_HTML = """\
       lbPageItems = (items || []).filter(i => i.status === "completed" && i.image_id);
 
       if (!items || items.length === 0) {
-        if (total === 0) { updateEmptyState(); show("empty"); return; }
+        if (total === 0) { show("empty"); return; }
         show("grid");
         if (!pipActive) renderPagination();
         return;

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1637,7 +1637,7 @@ _IMAGE_GALLERY_HTML = """\
       lbPageItems = (items || []).filter(i => i.status === "completed" && i.image_id);
 
       if (!items || items.length === 0) {
-        if (total === 0) { show("empty"); return; }
+        if (total === 0) { updateEmptyState(); show("empty"); return; }
         show("grid");
         if (!pipActive) renderPagination();
         return;
@@ -1699,6 +1699,7 @@ _IMAGE_GALLERY_HTML = """\
         const text = result.content?.find(c => c.type === "text")?.text;
         if (!text) { show("empty"); return; }
         const data = JSON.parse(text);
+        if (data.origin) syncOrigin(data.origin);
         currentPage = data.page || 1;
         currentTotal = data.total || 0;
         currentPageSize = data.page_size || 12;
@@ -1706,6 +1707,25 @@ _IMAGE_GALLERY_HTML = """\
       } catch (e) {
         console.warn("gallery_page failed", e);
         show("empty");
+      }
+    }
+
+    function syncOrigin(o) {
+      if (!o || (o === currentOrigin && document.querySelector("#origin-filter .seg.active")?.dataset.origin === o)) return;
+      currentOrigin = o;
+      document.querySelectorAll("#origin-filter .seg").forEach(s => s.classList.toggle("active", s.dataset.origin === o));
+    }
+
+    function updateEmptyState() {
+      const titleEl = document.querySelector("#empty .empty-title");
+      const subEl = document.querySelector("#empty .empty-sub");
+      if (!titleEl || !subEl) return;
+      if (currentOrigin === "imported") {
+        titleEl.textContent = "No imported images";
+        subEl.textContent = "Use fetch_image or ingest_base64_image to add one.";
+      } else {
+        titleEl.textContent = "No images yet";
+        subEl.innerHTML = 'Use <code>generate_image</code> to create your first image.';
       }
     }
 
@@ -1827,6 +1847,7 @@ _IMAGE_GALLERY_HTML = """\
       try {
         const data = JSON.parse(text.text);
         if (typeof data.total !== "number") { show("empty"); return; }
+        if (data.origin) syncOrigin(data.origin);
         currentPage = data.page || 1;
         currentTotal = data.total;
         currentPageSize = data.page_size || 12;

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1161,6 +1161,10 @@ _IMAGE_GALLERY_HTML = """\
       color: var(--color-text-primary, #333);
     }
 
+    .origin-filter { display: flex; gap: 4px; margin: 8px 0; }
+    .seg { background: transparent; border: 1px solid var(--color-border, #444); color: var(--color-text-secondary, #aaa); border-radius: 6px; padding: 3px 10px; cursor: pointer; font-size: 12px; }
+    .seg.active { background: var(--color-background-secondary, #333); color: var(--color-text-primary, #fff); }
+
     /* PiP compact layout */
     .main.pip-mode { padding: 4px; border-radius: 0; }
     .main.pip-mode .pip-toolbar { margin-bottom: 2px; }
@@ -1276,6 +1280,11 @@ _IMAGE_GALLERY_HTML = """\
     </div>
     <div class="state-grid" id="grid-container">
       <div class="pip-toolbar"><button class="pip-btn" id="pip-btn" title="Picture-in-picture">\u25a3</button></div>
+      <div class="origin-filter" id="origin-filter">
+        <button class="seg active" data-origin="generated">Generated</button>
+        <button class="seg" data-origin="imported">Imported</button>
+        <button class="seg" data-origin="all">All</button>
+      </div>
       <div class="gallery-grid" id="gallery-grid"></div>
       <div class="pagination" id="pagination"></div>
     </div>
@@ -1349,6 +1358,7 @@ _IMAGE_GALLERY_HTML = """\
     }
 
     let currentPage = 1;
+    let currentOrigin = "generated";
     let currentTotal = 0;
     let currentPageSize = 12;
     let dlMode = null; // "downloadFile" | "openLink" | null
@@ -1445,7 +1455,7 @@ _IMAGE_GALLERY_HTML = """\
         lbMeta.setAttribute("hidden", "");
         try {
           const ps = currentPageSize;
-          const result = await app.callServerTool({ name: "gallery_page", arguments: { page: targetPage, page_size: ps } });
+          const result = await app.callServerTool({ name: "gallery_page", arguments: { page: targetPage, page_size: ps, origin: currentOrigin } });
           if (result.isError) { lbLoading.style.display = "none"; return; }
           const text = result.content?.find(c => c.type === "text")?.text;
           if (!text) { lbLoading.style.display = "none"; return; }
@@ -1683,7 +1693,7 @@ _IMAGE_GALLERY_HTML = """\
       const ps = currentPageSize;
       show("loading");
       try {
-        const result = await app.callServerTool({ name: "gallery_page", arguments: { page, page_size: ps } });
+        const result = await app.callServerTool({ name: "gallery_page", arguments: { page, page_size: ps, origin: currentOrigin } });
         if (result.isError) { show("empty"); return; }
         const text = result.content?.find(c => c.type === "text")?.text;
         if (!text) { show("empty"); return; }
@@ -1697,6 +1707,17 @@ _IMAGE_GALLERY_HTML = """\
         show("empty");
       }
     }
+
+    document.getElementById("origin-filter").addEventListener("click", (e) => {
+      const btn = e.target.closest(".seg");
+      if (!btn) return;
+      const next = btn.dataset.origin;
+      if (next === currentOrigin) return;
+      currentOrigin = next;
+      document.querySelectorAll("#origin-filter .seg").forEach(s => s.classList.toggle("active", s === btn));
+      currentPage = 1;
+      goTo(1);
+    });
 
     // --- Download ---
     gridItems.addEventListener("click", async (e) => {

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -1096,7 +1096,7 @@ def register_tools(mcp: FastMCP) -> None:
         scratch directory.
 
         For non-UI clients the response is a JSON object with ``total``,
-        ``page``, ``page_size``, and ``items``.  Each completed item includes
+        ``page``, ``page_size``, ``origin``, and ``items``.  Each completed item includes
         ``image_id``, ``prompt``, ``provider``, ``dimensions``,
         ``created_at``, ``thumbnail_b64`` (128 px WebP, base64-encoded),
         ``content_type``, and ``origin``.  Pending/generating items include
@@ -1210,7 +1210,8 @@ def register_tools(mcp: FastMCP) -> None:
                 upload/fetch/base64 ingestion. ``"all"`` shows both.
 
         Returns:
-            JSON with ``total``, ``page``, ``page_size``, and ``items``.
+            JSON with ``total``, ``page``, ``page_size``, ``origin``, and
+            ``items``.
             Each completed item includes ``thumbnail_b64`` (128 px WebP) and
             ``origin``. Pending/generating items omit the thumbnail.
         """

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -1092,8 +1092,8 @@ def register_tools(mcp: FastMCP) -> None:
     ) -> ToolResult:
         """Browse all generated images in an interactive visual gallery.
 
-        Opens a gallery view showing thumbnail previews of every image in the
-        scratch directory.
+        Opens a gallery view showing thumbnail previews of images in the
+        scratch directory, filtered by ``origin`` (generated images by default).
 
         For non-UI clients the response is a JSON object with ``total``,
         ``page``, ``page_size``, ``origin``, and ``items``.  Each completed item includes

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -1168,6 +1168,7 @@ def register_tools(mcp: FastMCP) -> None:
             "total": total,
             "page": 1,
             "page_size": page_size,
+            "origin": origin,
             "items": all_items,
         }
 
@@ -1267,7 +1268,13 @@ def register_tools(mcp: FastMCP) -> None:
                 )
 
         return json.dumps(
-            {"total": total, "page": page, "page_size": page_size, "items": items}
+            {
+                "total": total,
+                "page": page,
+                "page_size": page_size,
+                "origin": origin,
+                "items": items,
+            }
         )
 
     _LIGHTBOX_MAX_BYTES = 1 * 1024 * 1024  # 1 MB size cap for lightbox images

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -19,7 +19,7 @@ import logging
 import re
 import time
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import parse_qs, urlparse
 
 if TYPE_CHECKING:
@@ -83,6 +83,30 @@ _THUMBNAIL_MAX_PX = 512
 _GALLERY_THUMBNAIL_MAX_PX = 128
 _GALLERY_PAGE_SIZE = 12
 _BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _origin_filtered(
+    images: list[ImageRecord],
+    pending: list[PendingGeneration],
+    origin: Literal["generated", "imported", "all"],
+) -> tuple[list[ImageRecord], list[PendingGeneration]]:
+    """Filter gallery records by ``origin`` (a pending generation counts as generated).
+
+    Args:
+        images: Completed image records (already sorted by the caller).
+        pending: In-progress generations.
+        origin: ``"generated"`` keeps generated images + all pending;
+            ``"imported"`` keeps imported images and drops pending;
+            ``"all"`` keeps everything.
+
+    Returns:
+        The filtered ``(images, pending)`` lists.
+    """
+    if origin == "all":
+        return images, pending
+    if origin == "imported":
+        return [i for i in images if i.origin == "imported"], []
+    return [i for i in images if i.origin == "generated"], pending
 
 
 def _any_provider_supports_image_input(service: ImageService) -> bool:

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -1087,6 +1087,7 @@ def register_tools(mcp: FastMCP) -> None:
         app=AppConfig(resource_uri=_IMAGE_GALLERY_URI),
     )
     async def browse_gallery(
+        origin: Literal["generated", "imported", "all"] = "generated",
         service: ImageService = Depends(get_service),
     ) -> ToolResult:
         """Browse all generated images in an interactive visual gallery.
@@ -1098,12 +1099,20 @@ def register_tools(mcp: FastMCP) -> None:
         ``page``, ``page_size``, and ``items``.  Each completed item includes
         ``image_id``, ``prompt``, ``provider``, ``dimensions``,
         ``created_at``, ``thumbnail_b64`` (128 px WebP, base64-encoded),
-        and ``content_type``.  Pending/generating items include ``status``,
-        ``progress``, and ``progress_message`` instead of a thumbnail.
+        ``content_type``, and ``origin``.  Pending/generating items include
+        ``status``, ``progress``, and ``progress_message`` instead of a
+        thumbnail.
 
         Use ``browse_gallery`` to see all images; use
         ``show_image(uri="image://{image_id}/view")`` to view one
         image at full resolution.
+
+        Args:
+            origin: Which images to include. ``"generated"`` (default) shows
+                images produced by ``generate_image``/``edit_image`` plus all
+                pending generations (a pending generation always counts as
+                generated). ``"imported"`` shows images brought in via
+                upload/fetch/base64 ingestion. ``"all"`` shows both.
 
         Returns:
             JSON with gallery data (total count, page metadata, thumbnail
@@ -1113,6 +1122,7 @@ def register_tools(mcp: FastMCP) -> None:
         pending = sorted(
             service.list_pending(), key=lambda p: p.created_at, reverse=True
         )
+        images, pending = _origin_filtered(images, pending, origin)
         total = len(images) + len(pending)
 
         # Build page-1 items: pending first (newest), then completed
@@ -1150,6 +1160,7 @@ def register_tools(mcp: FastMCP) -> None:
                     ).isoformat(),
                     "thumbnail_b64": base64.b64encode(thumb_bytes).decode(),
                     "content_type": img.content_type,
+                    "origin": img.origin,
                 }
             )
 
@@ -1180,6 +1191,7 @@ def register_tools(mcp: FastMCP) -> None:
     async def gallery_page(
         page: int = 1,
         page_size: int = _GALLERY_PAGE_SIZE,
+        origin: Literal["generated", "imported", "all"] = "generated",
         service: ImageService = Depends(get_service),
     ) -> str:
         """Return a page of image thumbnails for the gallery UI.
@@ -1190,16 +1202,22 @@ def register_tools(mcp: FastMCP) -> None:
         Args:
             page: 1-based page number.
             page_size: Number of items per page (1-24, default 12).
+            origin: Which images to include. ``"generated"`` (default) shows
+                images produced by ``generate_image``/``edit_image`` plus all
+                pending generations (a pending generation always counts as
+                generated). ``"imported"`` shows images brought in via
+                upload/fetch/base64 ingestion. ``"all"`` shows both.
 
         Returns:
             JSON with ``total``, ``page``, ``page_size``, and ``items``.
-            Each completed item includes ``thumbnail_b64`` (128 px WebP).
-            Pending/generating items omit the thumbnail.
+            Each completed item includes ``thumbnail_b64`` (128 px WebP) and
+            ``origin``. Pending/generating items omit the thumbnail.
         """
         images = sorted(service.list_images(), key=lambda r: r.created_at, reverse=True)
         pending = sorted(
             service.list_pending(), key=lambda p: p.created_at, reverse=True
         )
+        images, pending = _origin_filtered(images, pending, origin)
         total = len(images) + len(pending)
 
         page = max(1, page)
@@ -1244,6 +1262,7 @@ def register_tools(mcp: FastMCP) -> None:
                         ).isoformat(),
                         "thumbnail_b64": base64.b64encode(thumb_bytes).decode(),
                         "content_type": record.content_type,
+                        "origin": record.origin,
                     }
                 )
 

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -828,3 +828,12 @@ class TestGalleryOriginControl:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
         assert "No imported images" in text
+
+    async def test_show_refreshes_empty_copy_on_every_path(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # show() must refresh the origin-aware empty copy itself, so every
+        # show("empty") call site (including error/degenerate paths that
+        # never call updateEmptyState() directly) gets copy that matches
+        # currentOrigin instead of stale text from a previous origin.
+        assert 'if (which === "empty") updateEmptyState();' in text

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -729,3 +729,60 @@ class TestOriginFiltered:
         imgs, pends = _origin_filtered([gen, imp], [pend], "all")
         assert {i.id for i in imgs} == {gen.id, imp.id}
         assert pends == [pend]
+
+
+class TestGalleryOriginFilter:
+    async def _browse(self, service, **kwargs):
+        import json
+
+        from fastmcp import FastMCP
+
+        from image_generation_mcp.tools import register_tools
+
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("browse_gallery")
+        result = await tool.fn(service=service, **kwargs)
+        text = result.content[0].text
+        return json.loads(text)
+
+    async def test_default_is_generated_only(self, service: ImageService) -> None:
+        gen = _add_image(service, 10)
+        _add_imported(service, 10)
+        data = await self._browse(service)  # no origin arg -> default "generated"
+        ids = {i["image_id"] for i in data["items"]}
+        assert ids == {gen.id}
+        assert data["total"] == 1
+        assert all(i.get("origin") == "generated" for i in data["items"])
+
+    async def test_imported_only(self, service: ImageService) -> None:
+        _add_image(service, 11)
+        imp = _add_imported(service, 11)
+        data = await self._browse(service, origin="imported")
+        assert {i["image_id"] for i in data["items"]} == {imp.id}
+        assert data["total"] == 1
+        assert data["items"][0]["origin"] == "imported"
+
+    async def test_all_includes_both(self, service: ImageService) -> None:
+        gen = _add_image(service, 12)
+        imp = _add_imported(service, 12)
+        data = await self._browse(service, origin="all")
+        assert {i["image_id"] for i in data["items"]} == {gen.id, imp.id}
+        assert data["total"] == 2
+
+    async def test_gallery_page_respects_origin(self, service: ImageService) -> None:
+        import json
+
+        from fastmcp import FastMCP
+
+        from image_generation_mcp.tools import register_tools
+
+        _add_image(service, 13)
+        imp = _add_imported(service, 13)
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("gallery_page")
+        text = await tool.fn(service=service, origin="imported")
+        data = json.loads(text)
+        assert {i["image_id"] for i in data["items"]} == {imp.id}
+        assert data["total"] == 1

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -829,44 +829,66 @@ class TestGalleryOriginControl:
         text = result.contents[0].content
         assert "No imported images" in text
 
-    async def test_show_refreshes_empty_copy_on_every_path(self, server) -> None:
+    async def test_show_does_not_centralize_empty_copy(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        # show() must refresh the origin-aware empty copy itself, so every
-        # show("empty") call site (including error/degenerate paths that
-        # never call updateEmptyState() directly) gets copy that matches
-        # currentOrigin instead of stale text from a previous origin.
-        assert 'if (which === "empty") updateEmptyState();' in text
+        # show() itself must NOT decide the empty copy — callers are
+        # responsible for calling updateEmptyState() (genuine empty) or
+        # setGenericEmptyCopy() (error/degenerate) before show("empty").
+        assert 'if (which === "empty") updateEmptyState();' not in text
+        expected_show_body = (
+            "function show(which) {\n"
+            '      loadingEl.style.display = which === "loading" ? "flex" : "none";\n'
+            '      emptyEl.style.display   = which === "empty"   ? "block" : "none";\n'
+            '      gridEl.style.display    = which === "grid"    ? "block" : "none";\n'
+            '      // For "grid", renderGrid/renderPipStrip call updateSize after populating\n'
+            '      if (which !== "grid") updateSize();\n'
+            "    }"
+        )
+        assert expected_show_body in text
 
 
-class TestGalleryErrorState:
-    async def test_error_state_container_present(self, server) -> None:
+class TestGalleryEmptyCopyRouting:
+    async def test_genuine_empty_uses_origin_aware_copy(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        assert 'id="error"' in text
-        assert "Couldn't load the gallery" in text
-        assert "try again" in text
+        # The total === 0 branch in renderGrid must call updateEmptyState()
+        # itself before show("empty") so genuine-empty gets origin-aware copy.
+        assert 'updateEmptyState(); show("empty")' in text
 
-    async def test_show_toggles_error_element(self, server) -> None:
+    async def test_set_generic_empty_copy_defined(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        assert 'which === "error"' in text
+        assert "function setGenericEmptyCopy" in text
+        assert '"No images yet"' in text
+        assert "generate_image" in text
 
-    async def test_goto_page_error_fallback_uses_error_state(self, server) -> None:
+    async def test_error_and_degenerate_paths_use_generic_copy(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # All six error/degenerate paths route through setGenericEmptyCopy()
+        # then show("empty") — never the removed show("error").
+        assert text.count('setGenericEmptyCopy(); show("empty")') == 6
+
+    async def test_goto_page_error_fallback_uses_generic_copy(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
         assert 'console.warn("gallery_page failed"' in text
-        assert 'show("error")' in text
 
-    async def test_tool_result_parse_failure_uses_error_state(self, server) -> None:
+    async def test_tool_result_parse_failure_uses_generic_copy(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
         assert 'console.warn("Failed to parse gallery data"' in text
-        assert 'show("error")' in text
+
+    async def test_error_state_removed(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'show("error")' not in text
+        assert 'id="error"' not in text
 
     async def test_genuine_empty_still_uses_origin_aware_copy(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        # Regression guard: the empty path must remain unchanged — the error
-        # state must NOT call updateEmptyState().
-        assert 'if (which === "empty") updateEmptyState();' in text
+        # Regression guard for the imported-origin copy set by
+        # updateEmptyState(), still reachable via the genuine-empty path.
+        assert "No imported images" in text

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -754,6 +754,7 @@ class TestGalleryOriginFilter:
         assert ids == {gen.id}
         assert data["total"] == 1
         assert all(i.get("origin") == "generated" for i in data["items"])
+        assert data["origin"] == "generated"
 
     async def test_imported_only(self, service: ImageService) -> None:
         _add_image(service, 11)
@@ -762,6 +763,7 @@ class TestGalleryOriginFilter:
         assert {i["image_id"] for i in data["items"]} == {imp.id}
         assert data["total"] == 1
         assert data["items"][0]["origin"] == "imported"
+        assert data["origin"] == "imported"
 
     async def test_all_includes_both(self, service: ImageService) -> None:
         gen = _add_image(service, 12)
@@ -786,6 +788,7 @@ class TestGalleryOriginFilter:
         data = json.loads(text)
         assert {i["image_id"] for i in data["items"]} == {imp.id}
         assert data["total"] == 1
+        assert data["origin"] == "imported"
 
 
 class TestGalleryOriginControl:
@@ -813,3 +816,15 @@ class TestGalleryOriginControl:
         # The origin control must live above the grid container, which the
         # empty state hides — otherwise a zero-result filter would trap the user.
         assert text.index('id="origin-filter"') < text.index('id="grid-container"')
+
+    async def test_control_syncs_from_payload_origin(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # The segmented control must reflect the origin echoed by the tool
+        # payload, both on initial render and on pagination.
+        assert "if (data.origin) syncOrigin(data.origin);" in text
+
+    async def test_empty_state_has_origin_aware_copy(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "No imported images" in text

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -786,3 +786,23 @@ class TestGalleryOriginFilter:
         data = json.loads(text)
         assert {i["image_id"] for i in data["items"]} == {imp.id}
         assert data["total"] == 1
+
+
+class TestGalleryOriginControl:
+    async def test_segmented_control_present(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'data-origin="generated"' in text
+        assert 'data-origin="imported"' in text
+        assert 'data-origin="all"' in text
+
+    async def test_default_origin_is_generated(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'currentOrigin = "generated"' in text
+
+    async def test_origin_threaded_into_page_fetch(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # gallery_page fetch passes the active origin
+        assert "origin: currentOrigin" in text

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -790,6 +790,42 @@ class TestGalleryOriginFilter:
         assert data["total"] == 1
         assert data["origin"] == "imported"
 
+    async def test_gallery_page_imported_filter_across_page_boundary(
+        self, service: ImageService
+    ) -> None:
+        """Filtering must happen before pagination, not after.
+
+        Six imported images alone span more than one page at page_size=4, plus
+        five generated images that must never leak into the imported result.
+        Page 2 of the *filtered* (imported-only) set holds the remaining 2
+        items with total=6. A paginate-then-filter regression would instead
+        slice the unfiltered 11-item list at [4:8] and filter afterward,
+        producing a different/short/mixed result and total=11.
+        """
+        import json
+
+        from fastmcp import FastMCP
+
+        from image_generation_mcp.tools import register_tools
+
+        for i in range(5):
+            _add_image(service, i)
+        imported_ids = {_add_imported(service, i).id for i in range(6)}
+
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("gallery_page")
+        text = await tool.fn(service=service, page=2, page_size=4, origin="imported")
+        data = json.loads(text)
+
+        assert data["total"] == 6
+        assert data["page"] == 2
+        assert data["page_size"] == 4
+        assert len(data["items"]) == 2
+        for item in data["items"]:
+            assert item["origin"] == "imported"
+            assert item["image_id"] in imported_ids
+
 
 class TestGalleryOriginControl:
     async def test_segmented_control_present(self, server) -> None:

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -806,3 +806,10 @@ class TestGalleryOriginControl:
         text = result.contents[0].content
         # gallery_page fetch passes the active origin
         assert "origin: currentOrigin" in text
+
+    async def test_control_outside_hideable_grid(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # The origin control must live above the grid container, which the
+        # empty state hides — otherwise a zero-result filter would trap the user.
+        assert text.index('id="origin-filter"') < text.index('id="grid-container"')

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -837,3 +837,36 @@ class TestGalleryOriginControl:
         # never call updateEmptyState() directly) gets copy that matches
         # currentOrigin instead of stale text from a previous origin.
         assert 'if (which === "empty") updateEmptyState();' in text
+
+
+class TestGalleryErrorState:
+    async def test_error_state_container_present(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'id="error"' in text
+        assert "Couldn't load the gallery" in text
+        assert "try again" in text
+
+    async def test_show_toggles_error_element(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'which === "error"' in text
+
+    async def test_goto_page_error_fallback_uses_error_state(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'console.warn("gallery_page failed"' in text
+        assert 'show("error")' in text
+
+    async def test_tool_result_parse_failure_uses_error_state(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'console.warn("Failed to parse gallery data"' in text
+        assert 'show("error")' in text
+
+    async def test_genuine_empty_still_uses_origin_aware_copy(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # Regression guard: the empty path must remain unchanged — the error
+        # state must NOT call updateEmptyState().
+        assert 'if (which === "empty") updateEmptyState();' in text

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -685,3 +685,47 @@ class TestPipModeHTML:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
         assert "sendSizeChanged" in text
+
+
+def _add_imported(service: ImageService, idx: int) -> ImageRecord:
+    """Register a synthetic imported image and return its record."""
+    png = _make_png_bytes(width=64 + idx, height=64 + idx)
+    return service.register_imported_image(
+        png, origin_source="base64", max_bytes=10_000_000
+    )
+
+
+class TestOriginFiltered:
+    def test_generated_keeps_generated_and_pending(self, service: ImageService) -> None:
+        from image_generation_mcp.domain import PendingGeneration
+        from image_generation_mcp.tools import _origin_filtered
+
+        gen = _add_image(service, 1)
+        imp = _add_imported(service, 1)
+        pend = PendingGeneration(id="p0", provider="placeholder", prompt="x")
+        images = [gen, imp]
+        imgs, pends = _origin_filtered(images, [pend], "generated")
+        assert [i.id for i in imgs] == [gen.id]
+        assert pends == [pend]
+
+    def test_imported_keeps_imported_drops_pending(self, service: ImageService) -> None:
+        from image_generation_mcp.domain import PendingGeneration
+        from image_generation_mcp.tools import _origin_filtered
+
+        gen = _add_image(service, 2)
+        imp = _add_imported(service, 2)
+        pend = PendingGeneration(id="p1", provider="placeholder", prompt="x")
+        imgs, pends = _origin_filtered([gen, imp], [pend], "imported")
+        assert [i.id for i in imgs] == [imp.id]
+        assert pends == []
+
+    def test_all_keeps_everything(self, service: ImageService) -> None:
+        from image_generation_mcp.domain import PendingGeneration
+        from image_generation_mcp.tools import _origin_filtered
+
+        gen = _add_image(service, 3)
+        imp = _add_imported(service, 3)
+        pend = PendingGeneration(id="p2", provider="placeholder", prompt="x")
+        imgs, pends = _origin_filtered([gen, imp], [pend], "all")
+        assert {i.id for i in imgs} == {gen.id, imp.id}
+        assert pends == [pend]


### PR DESCRIPTION
## Summary

Adds a presentational `origin` filter to the gallery so imported and generated images can be viewed separately. Last child of epic #300.

- **Server** — new `_origin_filtered` helper + `origin: Literal["generated","imported","all"]` param on `browse_gallery` and `gallery_page`, applied **before** pagination so `total`/pages stay correct. Default `"generated"`. A pending generation counts as generated (kept under `generated`/`all`, dropped under `imported`). Both the top-level payload and each completed item echo `origin`.
- **Viewer** — a segmented control (Generated · Imported · All) above the grid, kept visible in the empty state (so a zero-result filter never traps the user) and hidden in PiP mode; `syncOrigin` reconciles the active segment with the server-echoed `origin`. The empty-state copy is origin-aware **only** on a genuinely-empty result; load failures show the generic copy.
- **Docs** — `docs/tools.md` `browse_gallery` parameter table and return example updated.

## Scope — presentational only

Per the design decision, this PR is strictly a filter (not physical grouping) and does not change error-handling behaviour. Review surfaced that the gallery viewer lacks a coherent load-error state — a load failure renders as a generic empty gallery, discards the server's error text, and offers no retry — plus a pre-existing rapid-switch request-sequencing race. Both are **pre-existing and out of scope**, tracked in #317. This PR deliberately does not worsen them: origin-aware copy appears only on a genuine empty result, so error paths never show origin-specific "go import one" remediation.

## Testing

- `_origin_filtered` unit tests — all three modes plus the pending-generation semantics.
- Tool-level filtering for both `browse_gallery` and `gallery_page` — default→generated, imported-only, all→both; top-level and per-item `origin` echo; filtered `total`; and a **filter-before-pagination regression guard across a page boundary** (6 imported + 5 generated, page 2, page_size 4).
- Viewer string-presence tests — control present/default/threaded, control outside the hideable grid, `syncOrigin`, genuine-empty (origin-aware) vs error (generic) copy routing, and a regression assert that no distinct error state leaks.

Gates: `pytest` 1001 passed, ruff, mypy, 100% patch coverage, 100% structural diff-gate, Vale — all green locally.

Closes #305. Completes epic #300.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)