### PR TITLE
feat(gallery): load-error state + segmented-control ARIA (#317, #319)

### DIFF
--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1375,6 +1375,7 @@ _IMAGE_GALLERY_HTML = """\
 
     let currentPage = 1;
     let currentOrigin = "generated";
+    let galleryReqSeq = 0;
     let currentTotal = 0;
     let currentPageSize = 12;
     let dlMode = null; // "downloadFile" | "openLink" | null
@@ -1708,9 +1709,11 @@ _IMAGE_GALLERY_HTML = """\
     // --- Paginate via app-only tool ---
     async function goTo(page) {
       const ps = currentPageSize;
+      const seq = ++galleryReqSeq;
       show("loading");
       try {
         const result = await app.callServerTool({ name: "gallery_page", arguments: { page, page_size: ps, origin: currentOrigin } });
+        if (seq !== galleryReqSeq) return;
         if (result.isError) { console.warn("gallery_page failed", result.content?.find(c => c.type === "text")?.text); show("error"); return; }
         const text = result.content?.find(c => c.type === "text")?.text;
         if (!text) { console.warn("gallery_page returned no text"); show("error"); return; }
@@ -1721,6 +1724,7 @@ _IMAGE_GALLERY_HTML = """\
         currentPageSize = data.page_size || 12;
         renderGrid(data);
       } catch (e) {
+        if (seq !== galleryReqSeq) return;
         console.warn("gallery_page failed", e);
         show("error");
       }
@@ -1868,6 +1872,7 @@ _IMAGE_GALLERY_HTML = """\
     app.ontoolinput = () => { show("loading"); };
 
     app.ontoolresult = ({ content }) => {
+      ++galleryReqSeq;
       const text = content?.find(c => c.type === "text");
       if (!text) { console.warn("gallery result had no text"); show("error"); return; }
       try {

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1284,6 +1284,20 @@ _IMAGE_GALLERY_HTML = """\
       <div class="empty-title">No images yet</div>
       <div class="empty-sub">Use <code>generate_image</code> to create your first image.</div>
     </div>
+    <div class="state-empty" id="error">
+      <div class="empty-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" stroke-width="1.5"
+          stroke-linecap="round" stroke-linejoin="round">
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+          <line x1="12" y1="9" x2="12" y2="13"/>
+          <line x1="12" y1="17" x2="12.01" y2="17"/>
+        </svg>
+      </div>
+      <div class="empty-title">Couldn't load the gallery</div>
+      <div class="empty-sub">Something went wrong — try again.</div>
+      <button class="seg" id="gallery-retry" type="button">Retry</button>
+    </div>
     <div class="state-grid" id="grid-container">
       <div class="pip-toolbar"><button class="pip-btn" id="pip-btn" title="Picture-in-picture">\u25a3</button></div>
       <div class="gallery-grid" id="gallery-grid"></div>
@@ -1328,6 +1342,7 @@ _IMAGE_GALLERY_HTML = """\
     const mainEl    = document.getElementById("main");
     const loadingEl = document.getElementById("loading");
     const emptyEl   = document.getElementById("empty");
+    const errorEl   = document.getElementById("error");
     const gridEl    = document.getElementById("grid-container");
     const gridItems = document.getElementById("gallery-grid");
     const pagEl     = document.getElementById("pagination");
@@ -1557,6 +1572,7 @@ _IMAGE_GALLERY_HTML = """\
     function show(which) {
       loadingEl.style.display = which === "loading" ? "flex" : "none";
       emptyEl.style.display   = which === "empty"   ? "block" : "none";
+      errorEl.style.display   = which === "error"   ? "block" : "none";
       gridEl.style.display    = which === "grid"    ? "block" : "none";
       // For "grid", renderGrid/renderPipStrip call updateSize after populating
       if (which !== "grid") updateSize();
@@ -1695,9 +1711,9 @@ _IMAGE_GALLERY_HTML = """\
       show("loading");
       try {
         const result = await app.callServerTool({ name: "gallery_page", arguments: { page, page_size: ps, origin: currentOrigin } });
-        if (result.isError) { setGenericEmptyCopy(); show("empty"); return; }
+        if (result.isError) { console.warn("gallery_page failed", result.content?.find(c => c.type === "text")?.text); show("error"); return; }
         const text = result.content?.find(c => c.type === "text")?.text;
-        if (!text) { setGenericEmptyCopy(); show("empty"); return; }
+        if (!text) { console.warn("gallery_page returned no text"); show("error"); return; }
         const data = JSON.parse(text);
         if (data.origin) syncOrigin(data.origin);
         currentPage = data.page || 1;
@@ -1706,7 +1722,7 @@ _IMAGE_GALLERY_HTML = """\
         renderGrid(data);
       } catch (e) {
         console.warn("gallery_page failed", e);
-        setGenericEmptyCopy(); show("empty");
+        show("error");
       }
     }
 
@@ -1733,14 +1749,6 @@ _IMAGE_GALLERY_HTML = """\
       }
     }
 
-    function setGenericEmptyCopy() {
-      const titleEl = document.querySelector("#empty .empty-title");
-      const subEl = document.querySelector("#empty .empty-sub");
-      if (!titleEl || !subEl) return;
-      titleEl.textContent = "No images yet";
-      subEl.innerHTML = 'Use <code>generate_image</code> to create your first image.';
-    }
-
     document.getElementById("origin-filter").addEventListener("click", (e) => {
       const btn = e.target.closest(".seg");
       if (!btn) return;
@@ -1755,6 +1763,8 @@ _IMAGE_GALLERY_HTML = """\
       currentPage = 1;
       goTo(1);
     });
+
+    document.getElementById("gallery-retry").addEventListener("click", () => { goTo(currentPage || 1); });
 
     // --- Download ---
     gridItems.addEventListener("click", async (e) => {
@@ -1859,10 +1869,10 @@ _IMAGE_GALLERY_HTML = """\
 
     app.ontoolresult = ({ content }) => {
       const text = content?.find(c => c.type === "text");
-      if (!text) { setGenericEmptyCopy(); show("empty"); return; }
+      if (!text) { console.warn("gallery result had no text"); show("error"); return; }
       try {
         const data = JSON.parse(text.text);
-        if (typeof data.total !== "number") { setGenericEmptyCopy(); show("empty"); return; }
+        if (typeof data.total !== "number") { console.warn("gallery result missing numeric total"); show("error"); return; }
         if (data.origin) syncOrigin(data.origin);
         currentPage = data.page || 1;
         currentTotal = data.total;
@@ -1870,7 +1880,7 @@ _IMAGE_GALLERY_HTML = """\
         renderGrid(data);
       } catch (e) {
         console.warn("Failed to parse gallery data", e);
-        setGenericEmptyCopy(); show("empty");
+        show("error");
       }
     };
 

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1263,10 +1263,10 @@ _IMAGE_GALLERY_HTML = """\
 </head>
 <body>
   <div class="main" id="main">
-    <div class="origin-filter" id="origin-filter">
-      <button class="seg active" data-origin="generated">Generated</button>
-      <button class="seg" data-origin="imported">Imported</button>
-      <button class="seg" data-origin="all">All</button>
+    <div class="origin-filter" id="origin-filter" role="radiogroup" aria-label="Filter by image origin">
+      <button class="seg active" data-origin="generated" role="radio" aria-checked="true">Generated</button>
+      <button class="seg" data-origin="imported" role="radio" aria-checked="false">Imported</button>
+      <button class="seg" data-origin="all" role="radio" aria-checked="false">All</button>
     </div>
     <div class="state-loading" id="loading">
       <div class="spinner"></div>Loading gallery\u2026
@@ -1713,7 +1713,11 @@ _IMAGE_GALLERY_HTML = """\
     function syncOrigin(o) {
       if (!o || (o === currentOrigin && document.querySelector("#origin-filter .seg.active")?.dataset.origin === o)) return;
       currentOrigin = o;
-      document.querySelectorAll("#origin-filter .seg").forEach(s => s.classList.toggle("active", s.dataset.origin === o));
+      document.querySelectorAll("#origin-filter .seg").forEach(s => {
+        const on = s.dataset.origin === o;
+        s.classList.toggle("active", on);
+        s.setAttribute("aria-checked", on ? "true" : "false");
+      });
     }
 
     function updateEmptyState() {
@@ -1743,7 +1747,11 @@ _IMAGE_GALLERY_HTML = """\
       const next = btn.dataset.origin;
       if (next === currentOrigin) return;
       currentOrigin = next;
-      document.querySelectorAll("#origin-filter .seg").forEach(s => s.classList.toggle("active", s === btn));
+      document.querySelectorAll("#origin-filter .seg").forEach(s => {
+        const on = s === btn;
+        s.classList.toggle("active", on);
+        s.setAttribute("aria-checked", on ? "true" : "false");
+      });
       currentPage = 1;
       goTo(1);
     });

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -876,6 +876,7 @@ class TestGalleryOriginControl:
             "function show(which) {\n"
             '      loadingEl.style.display = which === "loading" ? "flex" : "none";\n'
             '      emptyEl.style.display   = which === "empty"   ? "block" : "none";\n'
+            '      errorEl.style.display   = which === "error"   ? "block" : "none";\n'
             '      gridEl.style.display    = which === "grid"    ? "block" : "none";\n'
             '      // For "grid", renderGrid/renderPipStrip call updateSize after populating\n'
             '      if (which !== "grid") updateSize();\n'
@@ -892,35 +893,27 @@ class TestGalleryEmptyCopyRouting:
         # itself before show("empty") so genuine-empty gets origin-aware copy.
         assert 'updateEmptyState(); show("empty")' in text
 
-    async def test_set_generic_empty_copy_defined(self, server) -> None:
+    async def test_error_paths_do_not_use_empty_state(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        assert "function setGenericEmptyCopy" in text
-        assert '"No images yet"' in text
-        assert "generate_image" in text
+        # Only genuine-empty uses show("empty"); failures use show("error").
+        assert text.count('show("empty")') == 1
 
-    async def test_error_and_degenerate_paths_use_generic_copy(self, server) -> None:
-        result = await server.read_resource("ui://image-gallery/view.html")
-        text = result.contents[0].content
-        # All six error/degenerate paths route through setGenericEmptyCopy()
-        # then show("empty") — never the removed show("error").
-        assert text.count('setGenericEmptyCopy(); show("empty")') == 6
-
-    async def test_goto_page_error_fallback_uses_generic_copy(self, server) -> None:
+    async def test_goto_page_error_fallback_logged(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
         assert 'console.warn("gallery_page failed"' in text
 
-    async def test_tool_result_parse_failure_uses_generic_copy(self, server) -> None:
+    async def test_tool_result_parse_failure_logged(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
         assert 'console.warn("Failed to parse gallery data"' in text
 
-    async def test_error_state_removed(self, server) -> None:
+    async def test_error_state_present(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        assert 'show("error")' not in text
-        assert 'id="error"' not in text
+        assert 'show("error")' in text
+        assert 'id="error"' in text
 
     async def test_genuine_empty_still_uses_origin_aware_copy(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
@@ -953,3 +946,52 @@ class TestGallerySegmentedControlAria:
         # Both the click handler and syncOrigin must set aria-checked alongside
         # the .active class — two sync sites.
         assert text.count('setAttribute("aria-checked"') == 2
+
+
+class TestGalleryLoadErrorState:
+    async def test_error_state_div_present(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'id="error"' in text
+        assert "Couldn't load the gallery" in text
+        assert "try again" in text
+        assert 'id="gallery-retry"' in text
+
+    async def test_show_has_error_branch(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert (
+            'errorEl.style.display   = which === "error"   ? "block" : "none";' in text
+        )
+
+    async def test_failure_paths_route_to_error_state(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # All six error/degenerate paths (goTo x3, ontoolresult x3) show the
+        # error state — never the empty state.
+        assert text.count('show("error")') == 6
+
+    async def test_genuine_empty_still_uses_empty_state(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # renderGrid's total === 0 branch keeps origin-aware empty copy.
+        assert 'updateEmptyState(); show("empty")' in text
+
+    async def test_iserror_logs_server_content(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # The gallery_page isError branch logs result.content (the server's own
+        # error text) instead of discarding it.
+        assert 'console.warn("gallery_page failed", result.content' in text
+
+    async def test_retry_button_refetches_current_page(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'getElementById("gallery-retry")' in text
+        assert "goTo(currentPage || 1)" in text
+
+    async def test_set_generic_empty_copy_removed(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # setGenericEmptyCopy is dead once error paths leave the empty state.
+        assert "setGenericEmptyCopy" not in text

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -1014,6 +1014,14 @@ class TestGalleryRequestSequencing:
         # Both bail sites — the success path AND the catch — must guard, else a
         # stale error response can clobber a newer successful render.
         assert text.count("if (seq !== galleryReqSeq) return;") == 2
+        # The capture must PRECEDE the await — a refactor moving it below the
+        # await defeats the guard entirely while leaving the counts above intact.
+        assert (
+            "const seq = ++galleryReqSeq;\n"
+            '      show("loading");\n'
+            "      try {\n"
+            "        const result = await app.callServerTool"
+        ) in text
 
     async def test_ontoolresult_bumps_token(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -956,6 +956,9 @@ class TestGalleryLoadErrorState:
         assert "Couldn't load the gallery" in text
         assert "try again" in text
         assert 'id="gallery-retry"' in text
+        # Pin the errorEl declaration itself: without it show() throws on every
+        # state transition, yet the div + style-toggle assertions would still pass.
+        assert 'getElementById("error")' in text
 
     async def test_show_has_error_branch(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
@@ -1008,10 +1011,14 @@ class TestGalleryRequestSequencing:
         text = result.contents[0].content
         # goTo captures the token before awaiting and bails if superseded.
         assert "const seq = ++galleryReqSeq;" in text
-        assert "if (seq !== galleryReqSeq) return;" in text
+        # Both bail sites — the success path AND the catch — must guard, else a
+        # stale error response can clobber a newer successful render.
+        assert text.count("if (seq !== galleryReqSeq) return;") == 2
 
     async def test_ontoolresult_bumps_token(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        # A host-initiated reload supersedes any in-flight goTo.
-        assert "++galleryReqSeq;" in text
+        # A host-initiated reload supersedes any in-flight goTo. Exactly two
+        # increments exist — goTo's capture and this bump — so deleting the
+        # ontoolresult bump drops the count to 1 and fails here.
+        assert text.count("++galleryReqSeq;") == 2

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -928,3 +928,28 @@ class TestGalleryEmptyCopyRouting:
         # Regression guard for the imported-origin copy set by
         # updateEmptyState(), still reachable via the genuine-empty path.
         assert "No imported images" in text
+
+
+class TestGallerySegmentedControlAria:
+    async def test_group_is_radiogroup(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert 'id="origin-filter"' in text
+        assert 'role="radiogroup"' in text
+        assert 'aria-label="Filter by image origin"' in text
+
+    async def test_segments_are_radios_with_checked_state(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # Each segment is a radio; Generated is checked initially.
+        assert text.count('role="radio"') == 3
+        assert 'data-origin="generated" role="radio" aria-checked="true"' in text
+        assert 'data-origin="imported" role="radio" aria-checked="false"' in text
+        assert 'data-origin="all" role="radio" aria-checked="false"' in text
+
+    async def test_aria_checked_synced_with_active(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # Both the click handler and syncOrigin must set aria-checked alongside
+        # the .active class — two sync sites.
+        assert text.count('setAttribute("aria-checked"') == 2

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -995,3 +995,23 @@ class TestGalleryLoadErrorState:
         text = result.contents[0].content
         # setGenericEmptyCopy is dead once error paths leave the empty state.
         assert "setGenericEmptyCopy" not in text
+
+
+class TestGalleryRequestSequencing:
+    async def test_request_token_declared(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "let galleryReqSeq = 0;" in text
+
+    async def test_goto_captures_and_bails_on_stale(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # goTo captures the token before awaiting and bails if superseded.
+        assert "const seq = ++galleryReqSeq;" in text
+        assert "if (seq !== galleryReqSeq) return;" in text
+
+    async def test_ontoolresult_bumps_token(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # A host-initiated reload supersedes any in-flight goTo.
+        assert "++galleryReqSeq;" in text


### PR DESCRIPTION
## Summary

Two bundled follow-ups from #305, both entirely in the gallery viewer JS embedded in `src/image_generation_mcp/resources.py`, with string-presence tests.

### #317 — distinct load-error state
The viewer previously rendered every load failure as the generic *empty* state and discarded the server's error text. Now:

- A distinct `#error` state ("Couldn't load the gallery / Something went wrong — try again.") with a **Retry** button running `goTo(currentPage || 1)` — recovers both a pagination failure and an initial-load failure via the app-only `gallery_page` tool (the viewer can't re-invoke `browse_gallery`, and doesn't need to).
- All six failure paths (`goTo` and `ontoolresult`: `isError` / no-text / catch) route to `show("error")` and `console.warn`; the `isError` branches now **log `result.content`** (the server's own error text) instead of discarding it.
- A monotonic `galleryReqSeq` request-sequencing token: `goTo` captures it before its `await` and bails if superseded (in both the success and catch arms); `ontoolresult` bumps it on entry. A late-landing stale response can no longer clobber a newer render or revert the origin control — closing open question 4 of #317.
- The `setGenericEmptyCopy` scaffolding introduced in #305 is removed; genuine-empty (`renderGrid` `total === 0`) keeps its origin-aware copy.

### #319 — segmented-control ARIA
`role="radiogroup"` + per-button `role="radio"` / `aria-checked`, kept in lockstep with the `.active` class at both mutation sites (the click handler and `syncOrigin`). Exposes the active filter to assistive tech — implementing the accessibility note from #318's review.

## Testing
String-presence tests (no JS runner — the accepted repo convention), written **count/ordering-anchored** so a refactor that deletes, duplicates, or reorders a guard fails loudly rather than passing green: `show("error")` ×6, `show("empty")` ×1, both stale-guard bail sites, the seq-capture-before-`await` ordering (contiguous multi-line pin), the two token increments, the `errorEl` declaration, `role="radio"` ×3 with initial checked state, the two `aria-checked` sync sites, and the `setGenericEmptyCopy` removal.

Gates green locally: `pytest` 1013 passed, ruff, mypy, structural diff-gate 100%, Vale. Patch coverage reports no coverable lines — every production change lives inside the viewer's HTML/JS string literal (data, not executable Python). Full local preflight-circus (9 lenses, 3 rounds) clean.

## Follow-up (deliberately out of scope)
The full WAI-ARIA radiogroup **keyboard pattern** (roving `tabindex` + arrow-key navigation) is a larger interaction change beyond #319's "expose selected state" ask — tracked in #320. Native buttons remain Tab/Enter/Space operable.

Closes #317, closes #319.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)