### PR TITLE
docs: reference-image ingestion narrative + LLM-facing tool hints (#310)

### DIFF
--- a/docs/guides/image-input.md
+++ b/docs/guides/image-input.md
@@ -19,12 +19,45 @@ Every reference is a string in the `reference_images` list (and the optional
    `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true` (off by default). See
    [Configuration](../configuration.md).
 
+A gallery `image_id` may itself be an **imported** image: one brought into the
+gallery from outside rather than produced by `generate_image` or
+`transform_image`. See [Getting an external image into the gallery](#getting-an-external-image-into-the-gallery)
+below.
+
 `transform_image` runs as a background task. It returns immediately with a
 `status: "generating"` response and an `image_id`. Poll
 `check_generation_status(image_id)` until completion, then call
 `show_image(uri=original_uri)` once to display the result. Provenance is
 recorded: the response and the finished record carry `source_image_ids`
 listing every reference (and mask) the result derived from.
+
+## Getting an external image into the gallery
+
+An image the model did not generate (a URL, a user-supplied file, or inline
+bytes) becomes a first-class gallery entry through one of three ingestion
+tools, after which its `image_id` is referenced by `transform_image` exactly
+like a generated image:
+
+- [`fetch_image(url)`](../tools.md#fetch_image): download a remote
+  `http`/`https` image into the gallery (SSRF-hardened, size-capped).
+- [`ingest_base64_image(data)`](../tools.md#ingest_base64_image): decode inline
+  base64 bytes (raw, a `data:` URI, or line-wrapped) into the gallery.
+- [`create_upload_link()`](../tools.md#create_upload_link): mint a one-time
+  HTTP upload link for a caller to POST bytes to (HTTP/SSE transport only, with
+  `IMAGE_GENERATION_MCP_BASE_URL` set).
+
+A reference image is just a gallery image, so an imported image works as a
+`transform_image` reference with no provider-specific handling. Imported entries
+carry `origin: "imported"` with an `origin_source` recording where they came
+from (see [image metadata](../resources.md#origin)); generated images are
+`origin: "generated"`. The gallery viewer's origin filter groups imported and
+generated images separately.
+
+The decoded/downloaded size is bounded by
+`IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES`, remote fetches time out after
+`IMAGE_GENERATION_MCP_FETCH_TIMEOUT_S`, and upload-link lifetime is governed by
+the `IMAGE_GENERATION_MCP_TRANSFER_*` knobs, all documented on the
+[Configuration](../configuration.md) page.
 
 ## Capability matrix
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -277,6 +277,7 @@ List all registered images and pending generations.
 Each item includes a `status` field: `"completed"` for registered images, `"generating"` or `"failed"` for pending background generations.
 
 Completed images also carry an `origin` field: `"generated"` for images produced by a provider (the case today), or `"imported"` for images added to the gallery from an external source. For imported images, `origin_source` records provenance and `provider`/`prompt` are empty; generated images have `origin_source: null`.
+{ #origin }
 
 ```json
 [

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -130,6 +130,11 @@ Each entry in `reference_images` is resolved in order:
 2. **`image://` URI**: a full resource URI, such as `"image://a1b2c3d4e5f6/view"`.
 3. **Local file path**: absolute path on the server host, such as `"/home/user/photo.png"`. Only accepted when `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT=true`; rejected with an error otherwise.
 
+A gallery `image_id` may itself be an **imported** image, brought into the
+gallery from a URL, an upload, or inline bytes via `fetch_image`,
+`ingest_base64_image`, or `create_upload_link`, not only a `generate_image` /
+`transform_image` output. See [Image input](guides/image-input.md#getting-an-external-image-into-the-gallery).
+
 Call `list_providers` and inspect `supports_image_input` and `max_input_images` on each model to confirm which provider can handle your input count. Reference-count limits vary by model: SD WebUI is limited to a single reference, while Gemini supports several (more on the Gemini 3 models) and OpenAI's gpt-image family supports the most for multi-image composition. `max_input_images` carries the authoritative per-model value; `dall-e-3` and `dall-e-2` do not accept reference images. See the [Image input guide](guides/image-input.md) for the current capability matrix.
 
 ### Return value
@@ -503,7 +508,7 @@ Raises an error if the style is not found.
 
 ## fetch_image
 
-Fetch an image from an `http`/`https` URL into the gallery as an imported entry you can then show, edit, or transform.
+Fetch an image from an `http`/`https` URL into the gallery as an imported entry you can then show, edit, or reference in `transform_image`.
 
 | Property | Value |
 |----------|-------|
@@ -541,7 +546,7 @@ Tool call: fetch_image
 
 ## ingest_base64_image
 
-Add an inline base64-encoded image to the gallery as an imported entry you can then show, edit, or transform.
+Add an inline base64-encoded image to the gallery as an imported entry you can then show, edit, or reference in `transform_image`.
 
 | Property | Value |
 |----------|-------|

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -576,7 +576,10 @@ def register_tools(mcp: FastMCP) -> None:
 
         Supply one or more reference images (gallery ``image_id``, an
         ``image://`` URI, or — when enabled — a local file path) plus a
-        prompt describing the change.  Served by any provider that reports
+        prompt describing the change.  A reference ``image_id`` may be any
+        gallery image, including one brought in from outside via ``fetch_image``,
+        ``ingest_base64_image``, or ``create_upload_link``.  Served by any
+        provider that reports
         ``supports_image_input`` in ``list_providers``; each provider's
         ``max_input_images`` there gives its reference-image limit (some
         accept one, others up to 16 for multi-image composition).
@@ -1687,8 +1690,9 @@ def register_tools(mcp: FastMCP) -> None:
         """Fetch an image from a URL into the gallery.
 
         Downloads the image at *url* (http/https only) and adds it to the
-        gallery as an imported entry you can then show, edit, or transform. The
-        fetch is SSRF-hardened: URLs targeting private, loopback, link-local, or
+        gallery as an imported entry you can then show, edit, or reference in
+        ``transform_image``. The fetch is SSRF-hardened: URLs targeting
+        private, loopback, link-local, or
         cloud-metadata addresses are refused, redirects are not followed, and the
         download is size-capped. Hidden in read-only mode.
 
@@ -1747,7 +1751,8 @@ def register_tools(mcp: FastMCP) -> None:
 
         Decodes *data* (raw base64, a ``data:...;base64,...`` URI, or line-wrapped
         base64 — all accepted) under a size cap and adds it to the gallery as an
-        imported entry you can then show, edit, or transform. Hidden in read-only mode.
+        imported entry you can then show, edit, or reference in ``transform_image``.
+        Hidden in read-only mode.
 
         Args:
             data: The base64-encoded image bytes.

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -219,9 +219,11 @@ class TestToolDescriptionIngestionHints:
         assert tool is not None
         doc = tool.description
         assert doc is not None
-        # A reference image_id can be an externally-imported image.
+        # A reference image_id can be an externally-imported image; the hint
+        # names all three ingestion tools, so pin all three against removal.
         assert "fetch_image" in doc
         assert "ingest_base64_image" in doc
+        assert "create_upload_link" in doc
 
     async def test_fetch_image_description_names_transform_image(self) -> None:
         mcp = FastMCP("test")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -209,6 +209,39 @@ class TestGenerateImageRegistration:
         assert "warnings" in doc
 
 
+class TestToolDescriptionIngestionHints:
+    """Tool descriptions must point the LLM at the ingestion round-trip."""
+
+    async def test_transform_image_description_names_ingestion_tools(self) -> None:
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("transform_image")
+        assert tool is not None
+        doc = tool.description
+        assert doc is not None
+        # A reference image_id can be an externally-imported image.
+        assert "fetch_image" in doc
+        assert "ingest_base64_image" in doc
+
+    async def test_fetch_image_description_names_transform_image(self) -> None:
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("fetch_image")
+        assert tool is not None
+        doc = tool.description
+        assert doc is not None
+        assert "transform_image" in doc
+
+    async def test_ingest_base64_image_description_names_transform_image(self) -> None:
+        mcp = FastMCP("test")
+        register_tools(mcp)
+        tool = await mcp.get_tool("ingest_base64_image")
+        assert tool is not None
+        doc = tool.description
+        assert doc is not None
+        assert "transform_image" in doc
+
+
 # ---------------------------------------------------------------------------
 # show_image: tool registration properties
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The cross-cutting documentation closeout for epic #300 (getting external images into the gallery) — its last child. Per-child docs already landed with each child (the ingestion tools in `docs/tools.md`; the transfer/fetch/input env vars in `docs/configuration.md` + the README + the config-wizard; the `origin` field in `docs/resources.md`), so this adds the connecting **narrative** the site was missing plus **LLM-facing hints**.

- **Narrative** (`docs/guides/image-input.md`) — a new "Getting an external image into the gallery" section: how `fetch_image` (a URL), `ingest_base64_image` (inline base64), and `create_upload_link` (an HTTP upload link) bring an external image in as a first-class gallery entry, after which its `image_id` is referenced by `transform_image` exactly like a generated image (a reference image is just a gallery image — no provider-specific handling); imported vs generated via `origin`/`origin_source`; cross-links to the ingestion tools, the `origin` field, and the config knobs. The "three forms" reference list is amended to note a reference `image_id` may itself be an *imported* image.
- **LLM-facing hints** (`src/image_generation_mcp/tools.py` docstrings, which FastMCP surfaces as tool descriptions — the reliable model-facing channel; mirrored in `docs/tools.md`) — `transform_image` now tells the model a reference can be an externally-imported image (via the three ingestion tools); `fetch_image`/`ingest_base64_image` name `transform_image` as where the imported image is referenced. Guarded by `TestToolDescriptionIngestionHints`, which pins all three tool names the `transform_image` hint contains.
- **Anchor fix** (`docs/resources.md`) — added a `{ #origin }` anchor so the `origin` cross-link resolves (`mkdocs --strict` validates page existence, not fragment anchors).

Deliverable 2 (env vars) was already satisfied by the per-child docs — completeness-verified, no new tables. Deliverable 3 (provider/prompt guidance) folds into the narrative (an imported image is provider-agnostic once in the gallery). `create_upload_link`'s upstream (pvl-core) description is intentionally not edited.

## Testing
Full suite 1016 passed; ruff/mypy clean; Vale clean on all changed docs; structural diff-gate 100%; patch coverage N/A (docstring-only production change — no coverable Python lines). Full local preflight-circus (8 lenses × 2 rounds) clean.

Closes #310. Completes epic #300.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)