### PR TITLE
feat(gallery): WAI-ARIA radiogroup keyboard nav for the origin control (#320)

### DIFF
--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1264,9 +1264,9 @@ _IMAGE_GALLERY_HTML = """\
 <body>
   <div class="main" id="main">
     <div class="origin-filter" id="origin-filter" role="radiogroup" aria-label="Filter by image origin">
-      <button class="seg active" data-origin="generated" role="radio" aria-checked="true">Generated</button>
-      <button class="seg" data-origin="imported" role="radio" aria-checked="false">Imported</button>
-      <button class="seg" data-origin="all" role="radio" aria-checked="false">All</button>
+      <button class="seg active" data-origin="generated" role="radio" aria-checked="true" tabindex="0">Generated</button>
+      <button class="seg" data-origin="imported" role="radio" aria-checked="false" tabindex="-1">Imported</button>
+      <button class="seg" data-origin="all" role="radio" aria-checked="false" tabindex="-1">All</button>
     </div>
     <div class="state-loading" id="loading">
       <div class="spinner"></div>Loading gallery\u2026
@@ -1730,14 +1730,27 @@ _IMAGE_GALLERY_HTML = """\
       }
     }
 
-    function syncOrigin(o) {
-      if (!o || (o === currentOrigin && document.querySelector("#origin-filter .seg.active")?.dataset.origin === o)) return;
-      currentOrigin = o;
+    function reflectOrigin(o) {
       document.querySelectorAll("#origin-filter .seg").forEach(s => {
         const on = s.dataset.origin === o;
         s.classList.toggle("active", on);
         s.setAttribute("aria-checked", on ? "true" : "false");
+        s.setAttribute("tabindex", on ? "0" : "-1");
       });
+    }
+
+    function selectOrigin(o) {
+      if (o === currentOrigin) return;
+      currentOrigin = o;
+      reflectOrigin(o);
+      currentPage = 1;
+      goTo(1);
+    }
+
+    function syncOrigin(o) {
+      if (!o || (o === currentOrigin && document.querySelector("#origin-filter .seg.active")?.dataset.origin === o)) return;
+      currentOrigin = o;
+      reflectOrigin(o);
     }
 
     function updateEmptyState() {
@@ -1756,16 +1769,25 @@ _IMAGE_GALLERY_HTML = """\
     document.getElementById("origin-filter").addEventListener("click", (e) => {
       const btn = e.target.closest(".seg");
       if (!btn) return;
-      const next = btn.dataset.origin;
-      if (next === currentOrigin) return;
-      currentOrigin = next;
-      document.querySelectorAll("#origin-filter .seg").forEach(s => {
-        const on = s === btn;
-        s.classList.toggle("active", on);
-        s.setAttribute("aria-checked", on ? "true" : "false");
-      });
-      currentPage = 1;
-      goTo(1);
+      selectOrigin(btn.dataset.origin);
+    });
+
+    document.getElementById("origin-filter").addEventListener("keydown", (e) => {
+      const segs = [...document.querySelectorAll("#origin-filter .seg")];
+      const i = segs.indexOf(document.activeElement);
+      if (i < 0) return;
+      let j;
+      switch (e.key) {
+        case "ArrowRight": case "ArrowDown": j = (i + 1) % segs.length; break;
+        case "ArrowLeft": case "ArrowUp": j = (i - 1 + segs.length) % segs.length; break;
+        case "Home": j = 0; break;
+        case "End": j = segs.length - 1; break;
+        default: return;
+      }
+      e.preventDefault();
+      const target = segs[j];
+      selectOrigin(target.dataset.origin);
+      target.focus();
     });
 
     document.getElementById("gallery-retry").addEventListener("click", () => { goTo(currentPage || 1); });

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -943,9 +943,73 @@ class TestGallerySegmentedControlAria:
     async def test_aria_checked_synced_with_active(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        # Both the click handler and syncOrigin must set aria-checked alongside
-        # the .active class — two sync sites.
-        assert text.count('setAttribute("aria-checked"') == 2
+        # aria-checked, active, and tabindex are now maintained in ONE place —
+        # reflectOrigin — which both the selection path and syncOrigin call.
+        assert 's.setAttribute("aria-checked", on ? "true" : "false")' in text
+        assert text.count('setAttribute("aria-checked"') == 1
+        assert "function reflectOrigin" in text
+
+
+class TestGallerySegmentedControlKeyboard:
+    async def test_roving_tabindex_markup(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # Selected segment is the only tab stop; the other two are -1.
+        assert (
+            'data-origin="generated" role="radio" aria-checked="true" tabindex="0"'
+            in text
+        )
+        assert (
+            'data-origin="imported" role="radio" aria-checked="false" tabindex="-1"'
+            in text
+        )
+        assert (
+            'data-origin="all" role="radio" aria-checked="false" tabindex="-1"' in text
+        )
+
+    async def test_reflect_origin_is_single_reflection_site(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # reflectOrigin sets active + aria-checked + tabindex, and is the sole
+        # site for each — routed to by both syncOrigin and selectOrigin.
+        assert "function reflectOrigin" in text
+        assert 's.setAttribute("tabindex", on ? "0" : "-1")' in text
+        assert text.count('setAttribute("aria-checked"') == 1
+        assert text.count('setAttribute("tabindex"') == 1
+        # definition + call in syncOrigin + call in selectOrigin
+        assert text.count("reflectOrigin(o)") == 3
+
+    async def test_select_origin_shared_by_click(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        assert "function selectOrigin" in text
+        assert "selectOrigin(btn.dataset.origin)" in text
+
+    async def test_keydown_handler_navigates(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # Pin the origin-filter keydown listener specifically (a card keydown
+        # listener also exists elsewhere, so a bare "keydown" check is vacuous).
+        assert 'getElementById("origin-filter").addEventListener("keydown"' in text
+        for key in (
+            '"ArrowRight"',
+            '"ArrowLeft"',
+            '"ArrowDown"',
+            '"ArrowUp"',
+            '"Home"',
+            '"End"',
+        ):
+            assert key in text
+        # wrap-around index math for next/previous
+        assert "(i + 1) % segs.length" in text
+        assert "(i - 1 + segs.length) % segs.length" in text
+
+    async def test_keydown_selection_follows_focus(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # Arrow/Home/End select the target AND move focus to it.
+        assert "selectOrigin(target.dataset.origin)" in text
+        assert "target.focus()" in text
 
 
 class TestGalleryLoadErrorState:


### PR DESCRIPTION
## Summary

Completes the WAI-ARIA radiogroup **keyboard interaction** for the gallery origin segmented control — the follow-up #319 deferred (it delivered the selected-state ARIA; this delivers the keyboard/focus pattern). Entirely in the gallery viewer JS embedded in `src/image_generation_mcp/resources.py`.

- **Roving tabindex** — the selected segment is the single tab stop (`tabindex="0"`); the other two are `-1`. Tab enters the group onto the active filter and leaves it in one more Tab, instead of the previous three separate tab stops.
- **Arrow / Home / End navigation, selection-follows-focus** — `ArrowLeft`/`ArrowRight` (and `ArrowUp`/`ArrowDown`) move to the previous/next segment with wrap-around; `Home`/`End` jump to the first/last; each moves focus *and* selects (checks it, updates `currentOrigin`, re-fetches). Handled keys `preventDefault()` so arrows don't scroll the pane. Space/Enter still select natively (native `<button>`s).
- **DRY refactor** — extracted `reflectOrigin(o)` (the single site that sets `active` / `aria-checked` / `tabindex`) and `selectOrigin(o)` (shared by the click and keydown handlers); `syncOrigin` and the click handler now route through them. This also closes a latent gap: `syncOrigin` now maintains the roving `tabindex` when the model or pagination changes origin (previously it set only `active` + `aria-checked`).

The per-arrow re-fetch is smoothed by the existing `galleryReqSeq` request-sequencing token (#317) — stale intermediate fetches bail.

## Testing

New `TestGallerySegmentedControlKeyboard`: roving-tabindex markup; the keydown handler pinned to the `#origin-filter` listener specifically (a card keydown listener exists elsewhere, so a bare check would be vacuous) with all six keys and both wrap-around expressions; selection-follows-focus (`selectOrigin(target.dataset.origin)` + `target.focus()`); and **exact-count** assertions locking the single-reflection-site invariant — `setAttribute("aria-checked"` ×1, `setAttribute("tabindex"` ×1, `reflectOrigin(o)` ×3 (definition + the two call sites). #319's `test_aria_checked_synced_with_active` is **rewritten** (count 2→1), not deleted, to match the consolidated structure.

Full suite 1021 passed; ruff/mypy clean; structural diff-gate 100%; Vale N/A (no prose); patch coverage N/A (change is inside the JS string literal — no coverable Python lines). Full local preflight-circus (8 lenses) clean.

Closes #320.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)