### PR TITLE
fix(gallery): bump galleryReqSeq on host reload + recover from cancelled loads (#322)

### DIFF
--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1891,7 +1891,7 @@ _IMAGE_GALLERY_HTML = """\
     }
 
     // --- Lifecycle handlers (ALL before connect) ---
-    app.ontoolinput = () => { show("loading"); };
+    app.ontoolinput = () => { ++galleryReqSeq; show("loading"); };
 
     app.ontoolresult = ({ content }) => {
       ++galleryReqSeq;

--- a/src/image_generation_mcp/resources.py
+++ b/src/image_generation_mcp/resources.py
@@ -1911,6 +1911,10 @@ _IMAGE_GALLERY_HTML = """\
       }
     };
 
+    // A cancelled host tool call fires ontoolcancelled (not ontoolresult), so
+    // leave the loading spinner for the recoverable error state (retry button).
+    app.ontoolcancelled = () => { show("error"); };
+
     function handleHostContext(ctx) {
       if (ctx.theme) applyDocumentTheme(ctx.theme);
       if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -1101,3 +1101,12 @@ class TestGalleryRequestSequencing:
         # A host reload STARTING (ontoolinput) must bump the token so a stale
         # in-flight goTo bails instead of rendering over the loading state.
         assert 'app.ontoolinput = () => { ++galleryReqSeq; show("loading"); };' in text
+
+    async def test_ontoolcancelled_recovers_to_error_state(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # A cancelled host load fires ontoolcancelled (not ontoolresult). Without
+        # a handler the gallery would stick on the loading spinner (worsened by
+        # the ontoolinput bump, which now also bails the in-flight goTo); route
+        # to the recoverable error state (retry button) instead.
+        assert 'app.ontoolcancelled = () => { show("error"); };' in text

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -1034,9 +1034,10 @@ class TestGalleryLoadErrorState:
     async def test_failure_paths_route_to_error_state(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        # All six error/degenerate paths (goTo x3, ontoolresult x3) show the
-        # error state — never the empty state.
-        assert text.count('show("error")') == 6
+        # Seven show("error") sites: the six error/degenerate paths (goTo x3,
+        # ontoolresult x3) plus the ontoolcancelled recovery (#322) — none use
+        # the empty state.
+        assert text.count('show("error")') == 7
 
     async def test_genuine_empty_still_uses_empty_state(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")

--- a/tests/test_mcp_apps_gallery.py
+++ b/tests/test_mcp_apps_gallery.py
@@ -1090,7 +1090,14 @@ class TestGalleryRequestSequencing:
     async def test_ontoolresult_bumps_token(self, server) -> None:
         result = await server.read_resource("ui://image-gallery/view.html")
         text = result.contents[0].content
-        # A host-initiated reload supersedes any in-flight goTo. Exactly two
-        # increments exist — goTo's capture and this bump — so deleting the
-        # ontoolresult bump drops the count to 1 and fails here.
-        assert text.count("++galleryReqSeq;") == 2
+        # Three ++galleryReqSeq increments now exist — goTo's capture, the
+        # ontoolresult bump, and the ontoolinput bump (#322) — so deleting any
+        # one drops the count and fails here.
+        assert text.count("++galleryReqSeq;") == 3
+
+    async def test_ontoolinput_bumps_token(self, server) -> None:
+        result = await server.read_resource("ui://image-gallery/view.html")
+        text = result.contents[0].content
+        # A host reload STARTING (ontoolinput) must bump the token so a stale
+        # in-flight goTo bails instead of rendering over the loading state.
+        assert 'app.ontoolinput = () => { ++galleryReqSeq; show("loading"); };' in text


### PR DESCRIPTION
## Summary

Completes the gallery viewer's request-sequencing model (from #317) and fixes the stale-grid flicker #322 targets.

- **`ontoolinput` now bumps `galleryReqSeq`** before `show("loading")` — a host reload *starting* invalidates any in-flight `goTo`, so a stale `goTo` resolving before `ontoolresult` bails (`seq !== galleryReqSeq`) instead of flickering old grid over the loading state.
- **New `app.ontoolcancelled` handler** — a cancelled host load fires `ontoolcancelled` (not `ontoolresult`, as the sibling image-viewer app confirms by registering its own). The gallery had **no** such handler, so a cancelled load stuck on the loading spinner forever — and the `ontoolinput` bump widened that (it now also bails the in-flight `goTo` that would otherwise have rendered). `app.ontoolcancelled = () => { show("error"); }` routes to the recoverable error state (retry button; the origin control stays usable), closing both the new and the pre-existing stuck-spinner gap.

`ontoolresult`'s bump is preserved. The cancellation gap was surfaced by the local preflight-circus's silent-failure lens — it caught that the `ontoolinput` bump exposed the missing `ontoolcancelled` handler.

## Design note

`ontoolcancelled` deliberately does **not** bump the token (unlike the other two writers). `ontoolinput` already invalidated any pre-cancel `goTo`, and not bumping lets a user's *during-loading* origin-click `goTo` still render its valid result. In the narrow interleaving where such a `goTo` and a late cancel race, it's last-writer-wins — but both terminal states are individually valid and recoverable (grid = real data; error = retry), so there is no stuck or unrecoverable outcome.

## Testing

`test_ontoolinput_bumps_token` and `test_ontoolcancelled_recovers_to_error_state` pin the exact handlers; count guards pin the invariants (`++galleryReqSeq;` == 3 — goTo capture + ontoolresult + ontoolinput; `show("error")` == 7 — the six error/degenerate paths + the cancel recovery). Full suite 1023 passed; ruff/mypy clean; structural diff-gate 100%; patch coverage N/A (change is inside the JS string literal). Full local preflight-circus (8 lenses × 2 rounds) clean.

Closes #322.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)