### PR TITLE
docs: correct PAID_PROVIDERS empty-value semantics and drop stale tool count

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,7 +90,7 @@
 # IMAGE_GENERATION_MCP_DEFAULT_PROVIDER=auto
 # Maximum number of transformed image results (resize, crop, convert) kept in memory. Set 0 to disable caching.
 # IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE=64
-# Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. Set empty to disable confirmation.
+# Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. An empty value falls back to this default; to disable confirmation, set a value that names no provider (such as none).
 # IMAGE_GENERATION_MCP_PAID_PROVIDERS=openai
 # Directory for style preset files (Markdown with YAML front matter). Created automatically if it does not exist.
 # IMAGE_GENERATION_MCP_STYLES_DIR=~/.image-generation-mcp/styles

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Domain environment variables use the `IMAGE_GENERATION_MCP_` prefix:
 | `IMAGE_GENERATION_MCP_SD_WEBUI_MODEL` | (none) | No | SD WebUI checkpoint name, used for model-aware preset detection (SD 1.5 / SDXL / Lightning) and checkpoint override. Unset uses the instance's current model. |
 | `IMAGE_GENERATION_MCP_DEFAULT_PROVIDER` | `auto` | No | Provider used when no keyword triggers auto-selection: auto, openai, gemini, sd_webui, or placeholder. auto picks the first configured provider. |
 | `IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE` | `64` | No | Maximum number of transformed image results (resize, crop, convert) kept in memory. Set 0 to disable caching. |
-| `IMAGE_GENERATION_MCP_PAID_PROVIDERS` | `openai` | No | Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. Set empty to disable confirmation. |
+| `IMAGE_GENERATION_MCP_PAID_PROVIDERS` | `openai` | No | Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. An empty value falls back to this default; to disable confirmation, set a value that names no provider (such as none). |
 | `IMAGE_GENERATION_MCP_STYLES_DIR` | `~/.image-generation-mcp/styles` | No | Directory for style preset files (Markdown with YAML front matter). Created automatically if it does not exist. |
 | `IMAGE_GENERATION_MCP_ALLOW_LOCAL_FILE_INPUT` | `false` | No | Allow reading input images from local filesystem paths. Off by default: only URLs and uploads are accepted. |
 | `IMAGE_GENERATION_MCP_MAX_INPUT_IMAGE_BYTES` | `20971520` | No | Maximum accepted input image size in bytes. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ instructions, with no configuration beyond the variable itself:
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `IMAGE_GENERATION_MCP_PAID_PROVIDERS` | str | `openai` | Comma-separated list of provider names that cost money. When the MCP client supports [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/elicitation), `generate_image` asks for confirmation before using these providers. Set to empty string to disable confirmation. Gemini `quality="hd"` uses thinking tokens which are billed; consider adding `gemini` if you use `hd` quality frequently. |
+| `IMAGE_GENERATION_MCP_PAID_PROVIDERS` | str | `openai` | Comma-separated list of provider names that cost money. When the MCP client supports [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/elicitation), `generate_image` asks for confirmation before using these providers. An empty value is treated as unset and falls back to the default (`openai`); to disable confirmation entirely, set a value that names no provider (such as `none`). Gemini `quality="hd"` uses thinking tokens which are billed; consider adding `gemini` if you use `hd` quality frequently. |
 
 ## Performance
 

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -421,7 +421,7 @@
       "label": "Paid Providers",
       "type": "text",
       "var": "IMAGE_GENERATION_MCP_PAID_PROVIDERS",
-      "help": "Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. Set empty to disable confirmation."
+      "help": "Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. An empty value falls back to this default; to disable confirmation, set a value that names no provider (such as none)."
     },
     {
       "id": "styles_dir",

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # MCP Tools
 
-image-generation-mcp exposes four domain tools plus two auto-generated resource-bridge tools to MCP clients.
+image-generation-mcp exposes the domain tools documented below, plus two auto-generated resource-bridge tools, to MCP clients.
 
 ## generate_image
 

--- a/examples/bearer-auth.env
+++ b/examples/bearer-auth.env
@@ -25,7 +25,7 @@ IMAGE_GENERATION_MCP_SD_WEBUI_MODEL=
 IMAGE_GENERATION_MCP_DEFAULT_PROVIDER=auto
 # Maximum number of transformed image results (resize, crop, convert) kept in memory. Set 0 to disable caching.
 IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE=64
-# Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. Set empty to disable confirmation.
+# Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. An empty value falls back to this default; to disable confirmation, set a value that names no provider (such as none).
 IMAGE_GENERATION_MCP_PAID_PROVIDERS=openai
 # Directory for style preset files (Markdown with YAML front matter). Created automatically if it does not exist.
 IMAGE_GENERATION_MCP_STYLES_DIR=~/.image-generation-mcp/styles

--- a/examples/oidc.env
+++ b/examples/oidc.env
@@ -37,7 +37,7 @@ IMAGE_GENERATION_MCP_SD_WEBUI_MODEL=
 IMAGE_GENERATION_MCP_DEFAULT_PROVIDER=auto
 # Maximum number of transformed image results (resize, crop, convert) kept in memory. Set 0 to disable caching.
 IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE=64
-# Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. Set empty to disable confirmation.
+# Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. An empty value falls back to this default; to disable confirmation, set a value that names no provider (such as none).
 IMAGE_GENERATION_MCP_PAID_PROVIDERS=openai
 # Directory for style preset files (Markdown with YAML front matter). Created automatically if it does not exist.
 IMAGE_GENERATION_MCP_STYLES_DIR=~/.image-generation-mcp/styles

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -37,7 +37,7 @@ IMAGE_GENERATION_MCP_SD_WEBUI_MODEL=
 IMAGE_GENERATION_MCP_DEFAULT_PROVIDER=auto
 # Maximum number of transformed image results (resize, crop, convert) kept in memory. Set 0 to disable caching.
 IMAGE_GENERATION_MCP_TRANSFORM_CACHE_SIZE=64
-# Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. Set empty to disable confirmation.
+# Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. An empty value falls back to this default; to disable confirmation, set a value that names no provider (such as none).
 IMAGE_GENERATION_MCP_PAID_PROVIDERS=openai
 # Directory for style preset files (Markdown with YAML front matter). Created automatically if it does not exist.
 IMAGE_GENERATION_MCP_STYLES_DIR=~/.image-generation-mcp/styles

--- a/server.json
+++ b/server.json
@@ -101,7 +101,7 @@
         },
         {
           "name": "IMAGE_GENERATION_MCP_PAID_PROVIDERS",
-          "description": "Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. Set empty to disable confirmation.",
+          "description": "Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. An empty value falls back to this default; to disable confirmation, set a value that names no provider (such as none).",
           "default": "openai"
         },
         {
@@ -343,7 +343,7 @@
         },
         {
           "name": "IMAGE_GENERATION_MCP_PAID_PROVIDERS",
-          "description": "Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. Set empty to disable confirmation.",
+          "description": "Comma-separated provider names that cost money; generate_image asks for confirmation (client elicitation) before using them. An empty value falls back to this default; to disable confirmation, set a value that names no provider (such as none).",
           "default": "openai"
         },
         {

--- a/src/image_generation_mcp/config.py
+++ b/src/image_generation_mcp/config.py
@@ -170,7 +170,9 @@ class ProjectConfig:
             "help": (
                 "Comma-separated provider names that cost money; "
                 "generate_image asks for confirmation (client elicitation) "
-                "before using them. Set empty to disable confirmation."
+                "before using them. An empty value falls back to this "
+                "default; to disable confirmation, set a value that names "
+                "no provider (such as none)."
             ),
             "tags": ("providers",),
         },


### PR DESCRIPTION
Docs-accuracy batch from the open-issue triage. Both fixes verified against runtime behavior, not just reworded.

Closes #343, closes #313

## `PAID_PROVIDERS` empty-value semantics (#343)

The `paid_providers` field's metadata help and `docs/configuration.md` both claimed *"set empty to disable confirmation."* Verified false against the code: `env()` collapses an empty/whitespace value to `None`, so `from_env` falls back to the default `{"openai"}` — an empty value does **not** disable the cost gate. Since #351 that wrong sentence regenerated into `README.md`, both env examples, and the config wizard on every generator run, which is what escalated this issue.

Both places now state the real semantics: an empty value falls back to the default, and disabling requires a value that names no provider (such as `none`). Verified empirically: `PAID_PROVIDERS=""` → `{'openai'}`; `PAID_PROVIDERS="none"` → `{'none'}`, which never matches the `resolved_name not in config.paid_providers` gate in `tools.py`, so no confirmation fires. Generated artifacts (README domain table, wizard spec, `server.json`) regenerated from the corrected metadata; `gen_config_surface.py --check` passes.

## Stale tool count (#313)

`docs/tools.md`'s intro hard-coded "four domain tools" while the file documents roughly sixteen. Now count-free ("the domain tools documented below…") so the sentence cannot rot as tools are added.

## Not included (triaged separately)

#342 was found already fixed on `main` by #348's final revision and closed with evidence; #338 (dated-alias discoverability) is a behavior decision, not a doc fix, and stays open.

## Verification

- `PAID_PROVIDERS` behavior checks above run against the built package
- `uv run pytest -q` — 1059 passed
- `uv run ruff check --fix .` / `ruff format --check .` — clean
- `uv run mypy src/ tests/` — no issues
- `diff-quality … --fail-under=100` vs origin/main — 100%
- `uv run python scripts/gen_config_surface.py --check` — up to date
- Vale on the three changed prose files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xj2NVUc1jUnDLBSXD1Lss1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xj2NVUc1jUnDLBSXD1Lss1)_