### PR TITLE
fix(tools): title every registered tool and enforce it registry-wide

### DIFF
--- a/src/image_generation_mcp/server.py
+++ b/src/image_generation_mcp/server.py
@@ -135,19 +135,24 @@ class _TitledResourcesAsTools(ResourcesAsTools):
     rather than shipping untitled bridge tools.
     """
 
-    def _make_list_resources_tool(self) -> Any:
-        tool = super()._make_list_resources_tool()
-        if tool.annotations is None:  # pragma: no cover — upstream always sets them
-            tool.annotations = ToolAnnotations()
-        tool.annotations.title = "List Resources"
+    @staticmethod
+    def _with_title(tool: Any, title: str) -> Any:
+        """Return *tool* with a per-tool copy of its annotations carrying *title*.
+
+        MUST copy, never mutate in place: upstream passes one module-level
+        ``_DEFAULT_ANNOTATIONS`` singleton to both bridge tools, so an
+        in-place write makes the second tool's title win for both (and
+        pollutes fastmcp's shared default for the process lifetime).
+        """
+        base = tool.annotations or ToolAnnotations()
+        tool.annotations = base.model_copy(update={"title": title})
         return tool
 
+    def _make_list_resources_tool(self) -> Any:
+        return self._with_title(super()._make_list_resources_tool(), "List Resources")
+
     def _make_read_resource_tool(self) -> Any:
-        tool = super()._make_read_resource_tool()
-        if tool.annotations is None:  # pragma: no cover — upstream always sets them
-            tool.annotations = ToolAnnotations()
-        tool.annotations.title = "Read Resource"
-        return tool
+        return self._with_title(super()._make_read_resource_tool(), "Read Resource")
 
 
 def _finalize_transfer_tool_metadata(mcp: FastMCP) -> None:

--- a/src/image_generation_mcp/server.py
+++ b/src/image_generation_mcp/server.py
@@ -124,6 +124,32 @@ _TRANSFER_TOOL_META: dict[str, tuple[ToolAnnotations, str, str | None]] = {
 }
 
 
+class _TitledResourcesAsTools(ResourcesAsTools):
+    """``ResourcesAsTools`` whose two bridge tools carry ``annotations.title``.
+
+    fastmcp's transform constructs ``list_resources`` / ``read_resource``
+    with title-less annotations; the Tool Registration Checklist requires a
+    non-empty title on every registered tool (enforced by
+    ``tests/test_tools.py``). Overrides the parent's private factory methods —
+    if a fastmcp upgrade renames them, the enforcement test fails loudly
+    rather than shipping untitled bridge tools.
+    """
+
+    def _make_list_resources_tool(self) -> Any:
+        tool = super()._make_list_resources_tool()
+        if tool.annotations is None:  # pragma: no cover — upstream always sets them
+            tool.annotations = ToolAnnotations()
+        tool.annotations.title = "List Resources"
+        return tool
+
+    def _make_read_resource_tool(self) -> Any:
+        tool = super()._make_read_resource_tool()
+        if tool.annotations is None:  # pragma: no cover — upstream always sets them
+            tool.annotations = ToolAnnotations()
+        tool.annotations.title = "Read Resource"
+        return tool
+
+
 def _finalize_transfer_tool_metadata(mcp: FastMCP) -> None:
     """Attach title/hints/icon (and the ``write`` tag) to the transfer tools.
 
@@ -290,7 +316,7 @@ def make_server(
 
     # IG-specific: expose resources as tools for clients without resource support.
     # Apply AFTER all registrations so the transform sees every resource.
-    mcp.add_transform(ResourcesAsTools(mcp))
+    mcp.add_transform(_TitledResourcesAsTools(mcp))
 
     if config.read_only:
         mcp.disable(tags={"write"})

--- a/src/image_generation_mcp/tools.py
+++ b/src/image_generation_mcp/tools.py
@@ -374,6 +374,7 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"write"},
         task=True,
         annotations={
+            "title": "Generate Image",
             "readOnlyHint": False,
             "destructiveHint": False,
             "openWorldHint": True,
@@ -579,6 +580,7 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"write"},
         task=True,
         annotations={
+            "title": "Transform Image",
             "readOnlyHint": False,
             "destructiveHint": False,
             "openWorldHint": True,
@@ -893,6 +895,7 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         annotations={
+            "title": "Check Generation Status",
             "readOnlyHint": True,
             "destructiveHint": False,
             "openWorldHint": False,
@@ -966,6 +969,7 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         annotations={
+            "title": "Show Image",
             "readOnlyHint": True,
             "destructiveHint": False,
             "openWorldHint": False,
@@ -1129,6 +1133,7 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         annotations={
+            "title": "Browse Gallery",
             "readOnlyHint": True,
             "destructiveHint": False,
             "openWorldHint": False,
@@ -1233,6 +1238,7 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         annotations={
+            "title": "Gallery Page",
             "readOnlyHint": True,
             "destructiveHint": False,
             "openWorldHint": False,
@@ -1333,6 +1339,7 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         annotations={
+            "title": "Gallery Full Image",
             "readOnlyHint": True,
             "destructiveHint": False,
             "openWorldHint": False,
@@ -1391,6 +1398,7 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"write"},
         icons=[Icon(src=_LUCIDE.format("trash-2"), mimeType="image/svg+xml")],
         annotations={
+            "title": "Delete Image",
             "readOnlyHint": False,
             "destructiveHint": True,
             "openWorldHint": False,
@@ -1420,6 +1428,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=[Icon(src=_LUCIDE.format("layers"), mimeType="image/svg+xml")],
         annotations={
+            "title": "List Providers",
             "readOnlyHint": True,
             "destructiveHint": False,
             "openWorldHint": True,
@@ -1465,6 +1474,7 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         annotations={
+            "title": "Edit Image",
             "readOnlyHint": True,
             "destructiveHint": False,
             "openWorldHint": False,
@@ -1520,6 +1530,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         tags={"write"},
         annotations={
+            "title": "Save Edited Image",
             "readOnlyHint": False,
             "destructiveHint": False,
             "openWorldHint": False,
@@ -1622,6 +1633,7 @@ def register_tools(mcp: FastMCP) -> None:
         ),
         tags={"write"},
         annotations={
+            "title": "Save Style",
             "readOnlyHint": False,
             "destructiveHint": False,
             "openWorldHint": False,
@@ -1690,6 +1702,7 @@ def register_tools(mcp: FastMCP) -> None:
         ),
         tags={"write"},
         annotations={
+            "title": "Delete Style",
             "readOnlyHint": False,
             "destructiveHint": True,
             "openWorldHint": False,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1270,6 +1270,28 @@ class TestFullRegistryTitles:
         )
         assert not untitled, f"tools without annotations.title: {untitled}"
 
+    async def test_bridge_tools_carry_distinct_correct_titles(self) -> None:
+        """Regression: the two bridge tools must not share a title.
+
+        Upstream constructs both from one module-level ``_DEFAULT_ANNOTATIONS``
+        singleton; an in-place title write in ``_TitledResourcesAsTools`` made
+        the second tool's title win for both (and mutated fastmcp's shared
+        default). The registry-wide non-empty check above cannot catch a
+        title-swap, so pin the exact per-tool titles and singleton hygiene.
+        """
+        import fastmcp.server.transforms.resources_as_tools as _rat
+
+        from image_generation_mcp.server import _TitledResourcesAsTools
+
+        transform = _TitledResourcesAsTools(FastMCP("t"))
+        list_tool = transform._make_list_resources_tool()
+        read_tool = transform._make_read_resource_tool()
+        assert list_tool.annotations.title == "List Resources"
+        assert read_tool.annotations.title == "Read Resource"
+        assert list_tool.annotations is not read_tool.annotations
+        # fastmcp's shared default must stay untouched
+        assert _rat._DEFAULT_ANNOTATIONS.title is None
+
 
 # ---------------------------------------------------------------------------
 # edit_image tool

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1225,6 +1225,48 @@ class TestToolAnnotations:
             )
 
 
+class TestFullRegistryTitles:
+    """CLAUDE.md Tool Registration Checklist enforcement (issue #315).
+
+    Every registered tool must carry a non-empty ``annotations.title``.
+    Enumerates the FULL registry via the parent-class accessor — including
+    app-only tools, write-tagged tools hidden in read-only mode, the
+    ``ResourcesAsTools`` bridge tools, and the transfer tools — so a future
+    tool cannot ship its machine name as the client-facing label.
+    """
+
+    async def test_every_registered_tool_has_a_nonempty_title(
+        self, tmp_path: Path
+    ) -> None:
+        from fastmcp_pvl_core import ServerConfig
+
+        from image_generation_mcp.config import ProjectConfig
+        from image_generation_mcp.server import make_server
+
+        server = make_server(
+            transport="http",
+            config=ProjectConfig(
+                server=ServerConfig(
+                    base_url="https://mcp.example.com", kv_store_url="memory://"
+                ),
+                scratch_dir=tmp_path,
+                read_only=True,
+            ),
+        )
+        # Parent-class accessor bypasses FastMCP's model-visibility filter,
+        # the same trick tests._helpers.get_tool_including_app_only uses.
+        tools = await super(FastMCP, server).list_tools()
+        # Sanity: this is the full registry (domain + core + bridge +
+        # transfer tools), not the filtered client-facing listing.
+        assert len(tools) >= 18, [t.name for t in tools]
+        untitled = sorted(
+            t.name
+            for t in tools
+            if t.annotations is None or not (t.annotations.title or "").strip()
+        )
+        assert not untitled, f"tools without annotations.title: {untitled}"
+
+
 # ---------------------------------------------------------------------------
 # edit_image tool
 # ---------------------------------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1256,9 +1256,13 @@ class TestFullRegistryTitles:
         # Parent-class accessor bypasses FastMCP's model-visibility filter,
         # the same trick tests._helpers.get_tool_including_app_only uses.
         tools = await super(FastMCP, server).list_tools()
-        # Sanity: this is the full registry (domain + core + bridge +
-        # transfer tools), not the filtered client-facing listing.
-        assert len(tools) >= 18, [t.name for t in tools]
+        # Sanity: this is the full registry, not the filtered client-facing
+        # listing — 15 tools.py registrations (incl. the app-only gallery
+        # and save handlers), core's get_server_info, the 2 bridge tools,
+        # and the 2 transfer tools = 20 on an HTTP server with base_url.
+        # Exact-count floor so a tool silently vanishing from registration
+        # fails here too, not just an untitled addition.
+        assert len(tools) >= 20, sorted(t.name for t in tools)
         untitled = sorted(
             t.name
             for t in tools


### PR DESCRIPTION
Closes #315

The Tool Registration Checklist (CLAUDE.md) requires a non-empty `annotations.title` on every registered tool — title-aware clients (notably VS Code) otherwise render the raw machine name. Before this PR only `fetch_image`, `ingest_base64_image`, the two transfer tools, and core's `get_server_info` carried one; the other 15 tools in the full registry were untitled.

## Changes

- **Titles for the 13 untitled domain tools** in `tools.py` (`generate_image` → "Generate Image", etc.), including the app-only `gallery_page` / `gallery_full_image` / `_save_edited_image`.
- **`_TitledResourcesAsTools`** in `server.py`: a small subclass of fastmcp's `ResourcesAsTools` transform that sets titles on the auto-generated `list_resources` / `read_resource` bridge tools (upstream constructs them with title-less `_DEFAULT_ANNOTATIONS`; it exposes no title hook). Overrides the parent's private factory methods — if a fastmcp upgrade renames them, the new enforcement test fails loudly rather than shipping untitled bridge tools.
- **`TestFullRegistryTitles`** in `tests/test_tools.py`: the checklist's CI gate. Enumerates the FULL registry via the parent-class accessor (the same visibility-filter bypass as `tests/_helpers.get_tool_including_app_only`) on an HTTP server with `base_url`, so app-only tools, write-tagged tools hidden in read-only mode, the bridge tools, and the transfer tools are all covered — 20 tools asserted, a future untitled tool fails CI.

## Scope

Titles only, per #315's scope boundary — behavioural hints and per-tool icons are unchanged.

## Verification

- `uv run pytest -q` — 1060 passed (new enforcement test included)
- `uv run ruff check --fix .` / `ruff format --check .` — clean
- `uv run mypy src/ tests/` — no issues
- `diff-quality … --fail-under=100` vs origin/main — 100% (S101 asserts replaced with graceful narrowing)
- `uv run python scripts/gen_config_surface.py --check` — up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xj2NVUc1jUnDLBSXD1Lss1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xj2NVUc1jUnDLBSXD1Lss1)_