### PR TITLE
chore(copier): update template to v4.1.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v3.6.0
+_commit: v4.1.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: MCP server for AI image generation via OpenAI, Google GenAI, or

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,92 @@
+name: Epic
+description: >
+  A multi-feature effort that ships as one user-facing story. Children are
+  linked as native GitHub sub-issues, not markdown checklists. See
+  CONTRIBUTING.md for how epics are structured.
+title: "[Epic]: "
+labels: ["epic"]
+body:
+  - type: textarea
+    id: user-facing-summary
+    attributes:
+      label: What changes for the user
+      description: >
+        One paragraph, written now, before any code exists. This is the
+        highest-value field: it becomes the release-notes highlight for the
+        whole epic, so write it for the user reading the notes, not for the
+        implementer. Release tooling edits and verifies this text against
+        what actually landed rather than reconstructing intent afterwards.
+      placeholder: "After this epic, you can ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: surface-impact
+    attributes:
+      label: Surface impact
+      description: >
+        Which compatibility surfaces this epic touches. Decided once at epic
+        creation and inherited by the children, rather than argued per
+        commit; feeds the breaking-change policy.
+      multiple: true
+      options:
+        - Operator surface (config, env vars, CLI, deployment)
+        - Public library API
+        - MCP tool surface (tools, resources, prompts)
+        - None (internal only)
+    validations:
+      required: true
+  - type: dropdown
+    id: ships-atomically
+    attributes:
+      label: Ships atomically
+      description: >
+        If yes, no release may be cut while this epic is mid-flight. This
+        answer records the intent; the machine-readable signal release
+        tooling queries is a milestone or label set after filing (see the
+        checklist below) — forms cannot assign either.
+      options:
+        - "Yes — no release may be cut mid-epic"
+        - "No — children can ship independently"
+    validations:
+      required: true
+  - type: textarea
+    id: children
+    attributes:
+      label: Planned children
+      description: >
+        The planned child issues, one per line ("#N" for issues that already
+        exist, a one-line description for those that don't yet). This list
+        is planning prose only — the queryable relationship is the native
+        sub-issue link, created after filing (see the checklist below). Do
+        not maintain a markdown task list as the source of truth.
+    validations:
+      required: false
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What this epic deliberately does not cover.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### After filing (issue forms cannot do these)
+
+        Forms cannot create sub-issue links or assign milestones, so finish
+        the epic setup after submitting. The `authoring-issues-prs` skill
+        (`.claude/skills/authoring-issues-prs/SKILL.md`) performs these
+        steps mechanically.
+
+        1. **Link the children as native sub-issues** — issue sidebar
+           ("Create sub-issue" / "Add existing issue") or the sub-issues
+           API. This makes the grouping queryable (`has_parent`,
+           `sub_issues_summary`) instead of prose to pattern-match.
+        2. **If the epic ships atomically, make that queryable:**
+           - **Milestone (preferred):** assign the epic and its children to
+             the milestone of the target release, creating it if needed.
+             Milestones are per-repo and one-per-issue; for a cross-repo
+             epic the milestone lives in the repo where the release is cut.
+           - **Label (fallback):** apply `ships-atomically` when no target
+             release is named yet, or in the repos of a cross-repo epic
+             that do not cut the release.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,9 @@ found nothing.
 ## Local review
 
 - [ ] Ran a local code-review pass on the cumulative diff before `gh pr create`.
+- [ ] Any commit carrying `!` breaks an operator or library surface that
+      existed at the **last stable release** (see the breaking-change policy
+      in `CLAUDE.md`) — MCP tool-surface changes alone do not earn a `!`.
 
 ## Docs impact
 

--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -1,0 +1,43 @@
+{
+  "name": "protect-main",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          { "context": "CI Success" }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/protect-release-branches.json
+++ b/.github/rulesets/protect-release-branches.json
@@ -1,0 +1,43 @@
+{
+  "name": "protect-release-branches",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/release/**"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          { "context": "CI Success" }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/protect-release-tags.json
+++ b/.github/rulesets/protect-release-tags.json
@@ -1,0 +1,22 @@
+{
+  "name": "protect-release-tags",
+  "target": "tag",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ]
+}

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -3,30 +3,39 @@ name: Bootstrap repo
 # Seeds repository state that checked-in config references but GitHub does not
 # create on its own:
 #   1. The `dependencies` label Renovate applies to its PRs, plus the
-#      `bug`/`feature`/`decay`/`question` labels the issue forms reference
-#      (GitHub silently drops labels that don't exist).
+#      `bug`/`feature`/`decay`/`question`/`epic` labels the issue forms
+#      reference (GitHub silently drops labels that don't exist) and the
+#      `ships-atomically` label the epic workflow uses as the fallback
+#      release-cut signal when no milestone names the target release.
 #   2. Repository settings that make Renovate auto-merge SAFE — "Allow
-#      auto-merge" plus branch protection requiring the `CI Success` check.
+#      auto-merge" plus the checked-in rulesets (`.github/rulesets/*.json`)
+#      requiring PRs and the `CI Success` check on `main` and `release/*`.
 #      Without a required check, enabling auto-merge on a PR merges it
 #      immediately; the gate is what holds the merge until CI is green.
+#      Posture, bypass model, and per-branch rules are documented in
+#      docs/deployment/repository-protection.md.
 #
-# Idempotent: label create is `--force`; the settings/branch-protection calls
-# are PATCH/PUT that converge to the same state on every run. The first push to
-# the default branch applies everything; `workflow_dispatch` re-applies on demand.
+# Idempotent: label create is `--force`; the settings call is a PATCH and the
+# ruleset apply upserts by name (PUT onto the existing id, POST otherwise), so
+# every run converges to the checked-in state. The first push to the default
+# branch applies everything; a push touching this workflow or a ruleset file
+# re-applies; `workflow_dispatch` re-applies on demand.
 #
-# Auth: the settings + branch-protection calls need `administration:write`,
-# which the default GITHUB_TOKEN lacks — they use RELEASE_TOKEN.
+# Auth: the settings + ruleset calls need `administration:write`, which the
+# default GITHUB_TOKEN lacks — they use RELEASE_TOKEN.
 
 on:
   push:
     branches: [main]
     paths:
       - .github/workflows/bootstrap.yml
+      - .github/rulesets/**
       - renovate.json
   workflow_dispatch:
 
 permissions:
   issues: write
+  contents: read
 
 jobs:
   labels:
@@ -58,12 +67,22 @@ jobs:
             --color d876e3 \
             --description "Further information is requested" \
             --force
+          gh label create epic \
+            --color 3e4b9e \
+            --description "Multi-feature effort that ships as one user-facing story" \
+            --force
+          gh label create ships-atomically \
+            --color b60205 \
+            --description "No release may be cut while this epic is mid-flight (fallback for a release milestone)" \
+            --force
 
   settings:
-    name: Enable auto-merge + branch protection
+    name: Enable auto-merge + repository rulesets
     runs-on: ubuntu-latest
     steps:
-      - name: Allow auto-merge and require CI Success on main
+      - uses: actions/checkout@v7
+
+      - name: Allow auto-merge
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REPO: ${{ github.repository }}
@@ -71,26 +90,59 @@ jobs:
           # Enable repository-level auto-merge.
           gh api -X PATCH "repos/${REPO}" -F allow_auto_merge=true
 
-          # Require the single drift-proof CI Success context. No required
-          # reviews (a solo account has no second reviewer — requiring one would
-          # deadlock patch/minor auto-merge). enforce_admins=false keeps a
-          # direct-push hotfix path for the owner.
+      - name: Apply repository rulesets
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Upsert every checked-in ruleset by name: PUT onto the existing
+          # ruleset id when one matches, POST otherwise. The rules require PRs
+          # with ZERO approvals (a solo account has no second reviewer —
+          # requiring one would deadlock patch/minor auto-merge) plus the
+          # single drift-proof CI Success context; the repository-admin bypass
+          # entry keeps the release workflow's RELEASE_TOKEN pushes (PSR's
+          # release commit + tag, the merge-back to main) and the owner's
+          # direct-push hotfix path working — the ruleset equivalent of the
+          # old classic protection's enforce_admins=false.
           #
-          # DESTRUCTIVE-IDEMPOTENT: this is a full PUT of the desired protection
-          # state, not a read-merge-write. Bootstrap declaratively OWNS main's
-          # branch protection — any protections added by hand via the GitHub UI
-          # (extra required checks, required reviewers, push restrictions) are
-          # reset to exactly the state below on the next run. Add such settings
-          # here, not in the UI, or they will not stick.
-          gh api -X PUT "repos/${REPO}/branches/main/protection" \
-            --input - <<'JSON'
-          {
-            "required_status_checks": {
-              "strict": true,
-              "contexts": ["CI Success"]
-            },
-            "enforce_admins": false,
-            "required_pull_request_reviews": null,
-            "restrictions": null
-          }
-          JSON
+          # DESTRUCTIVE-IDEMPOTENT: each PUT replaces the whole ruleset with
+          # the checked-in state, not a read-merge-write. Bootstrap
+          # declaratively OWNS these rulesets — edits made by hand in the
+          # GitHub UI are reset on the next run. Change the JSON files
+          # instead, or the edits will not stick. Rulesets with other names
+          # are left alone.
+          #
+          # includes_parents=false keeps org-level rulesets out of the name
+          # match — an org ruleset that happens to share a name must not
+          # receive a repo-level PUT (wrong id, wrong scope).
+          existing=$(gh api \
+            "repos/${REPO}/rulesets?per_page=100&includes_parents=false")
+          for file in .github/rulesets/*.json; do
+            name=$(jq -r '.name' "$file")
+            id=$(jq -r --arg name "$name" \
+              'map(select(.name == $name)) | first | .id // empty' \
+              <<<"$existing")
+            if [ -n "$id" ]; then
+              echo "Updating ruleset '${name}' (id ${id}) from ${file}"
+              gh api -X PUT "repos/${REPO}/rulesets/${id}" \
+                --input "$file" >/dev/null
+            else
+              echo "Creating ruleset '${name}' from ${file}"
+              gh api -X POST "repos/${REPO}/rulesets" \
+                --input "$file" >/dev/null
+            fi
+          done
+
+      - name: Retire classic branch protection on main
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Earlier template versions protected main via the classic
+          # branch-protection API. The rulesets above supersede it, and the
+          # two systems LAYER (most restrictive wins), so a lingering classic
+          # rule would keep enforcing a stale posture no checked-in file
+          # describes. Delete it; the API's 404 ("Branch not protected") is
+          # the steady state on repos bootstrapped after this migration.
+          gh api -X DELETE "repos/${REPO}/branches/main/protection" \
+            || echo "No classic branch protection to remove — already migrated."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release/**"]
   pull_request:
-    branches: [main]
+    # release/** keeps backport PRs CI-gated: the shipped rulesets
+    # (.github/rulesets/) require the CI Success check on release/* exactly
+    # as on main, which deadlocks unless CI actually runs there.
+    branches: [main, "release/**"]
   workflow_dispatch:
 
 jobs:
@@ -411,19 +414,48 @@ jobs:
         run: git fetch origin ${{ github.base_ref }} --depth=50
 
       - name: Structural quality (changed lines only)
+        # One implementation, shared with the pre-push hook. The explicit
+        # STRUCTURAL_GATE_BASE pins the PR's actual base branch (main or a
+        # release/X.Y for backport PRs); the script's no-Python skip and the
+        # diff-quality invocation live in the script.
         env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          # Skip when the diff touches no Python — mirrors the diff-cover guard.
-          HAS_PY=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep -c '\.py$' || true)
-          if [ "$HAS_PY" -eq 0 ]; then
-            echo "No Python source changes — skipping structural diff gate"
-            exit 0
-          fi
-          uv run diff-quality --violations=ruff.check \
-            --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
-            --compare-branch="origin/${BASE_REF}" --fail-under=100
+          STRUCTURAL_GATE_BASE: origin/${{ github.base_ref }}
+        run: bash scripts/structural_gate.sh
 
+
+  pr-title:
+    name: PR Title
+    # A squash merge takes the pull-request title as the commit subject, and
+    # python-semantic-release drops a subject it cannot parse from
+    # CHANGELOG.md silently — not under a fallback heading, absent. This is
+    # the last point at which that subject can still be corrected.
+    #
+    # PR-only by design: the writers to `main` outside a merge are PSR's own
+    # release commit and the automated merge-back, both machine-generated and
+    # already conformant. On push/dispatch the job is skipped, which the
+    # `ci-success` aggregate below treats as a pass.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check pull-request title
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # Read the CURRENT title from the API rather than from
+        # `github.event.pull_request.title`. A re-run replays the original
+        # event payload, so an author who fixes the title would otherwise have
+        # to push a commit to clear a red check that a retitle already fixed.
+        run: |
+          set -euo pipefail
+          TITLE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .title)"
+          python3 scripts/check_pr_title.py "$TITLE"
 
   ci-success:
     name: CI Success
@@ -438,6 +470,7 @@ jobs:
       - audit
       - secrets
       - vale
+      - pr-title
 
       - structure
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,10 +3,11 @@ name: Claude Code Review
 on:
   pull_request:
     # Match ci.yml's trigger. The review is gated on CI (wait-for-ci job), and
-    # the generated ci.yml only runs on PRs targeting main — firing the reviewer
-    # on other-target PRs would just idle the poll to its timeout, then skip.
-    # Broaden both together if a downstream gates CI on more branches.
-    branches: [main]
+    # the generated ci.yml only runs on PRs targeting main or release/* —
+    # firing the reviewer on other-target PRs would just idle the poll to its
+    # timeout, then skip. Broaden both together if a downstream gates CI on
+    # more branches.
+    branches: [main, "release/**"]
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # On release events the triggering tag may move after the workflow is
-          # queued (semantic-release pushes a version-bump commit); build main.
-          ref: ${{ github.event_name == 'release' && 'main' || github.ref }}
+          # On release events, build the released tag: the release may have
+          # been cut from a release/X.Y branch, where `main` describes code
+          # that is not in the release.  The tag is safe to build since the
+          # version-bump commit lands inside the release commit the tag points
+          # at (see scripts/bump_manifests.py) — tags no longer move.
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -64,21 +67,31 @@ jobs:
 
   deploy:
     # Publish versioned docs with mike, serving from the gh-pages branch:
-    #   stable release (prerelease=false) -> version <major.minor> + `latest` alias (default)
-    #   rc prerelease  (prerelease=true)  -> single rolling `unstable` version
+    #   stable release -> version <major.minor>; the `latest` alias (and
+    #                     set-default) move ONLY when the release is at least
+    #                     the current `latest` — a backport patch cut from an
+    #                     old release/X.Y updates its own minor's page and
+    #                     never repoints `latest` at the older series
+    #   push to main   -> single rolling `unstable` version: the docs face of
+    #                     the edge channel, following merged code continuously
+    #   rc prerelease  -> no deploy; rcs are rare branch-scoped stabilisation
+    #                     builds whose docs ship when the stable ships
     #
     # One-time setup before the first deploy (per-project, cannot be templated):
     #   1. Seed gh-pages:
     #        uv run mike deploy --push --update-aliases unstable --title "unstable (<ver>)"
     #   2. Repo Settings -> Pages -> Deploy from a branch -> gh-pages / (root).
     #   Order matters: seed (1) before switching source (2) so the site is never empty.
-    if: github.event_name == 'release'
+    if: github.event_name == 'push' || (github.event_name == 'release' && !github.event.release.prerelease)
     needs: build
-    # Serialize all release deploys (no cancellation) so two releases close
-    # together never push to gh-pages concurrently.
+    # Separate buckets per trigger: rolling-unstable deploys may cancel each
+    # other (only the newest merge matters) but must never cancel a pending
+    # release deploy, which GitHub's one-pending-per-group rule would allow in
+    # a shared bucket.  Cross-bucket gh-pages pushes are reconciled by the
+    # fetch-reset-retry loop in the publish step.
     concurrency:
-      group: ${{ github.workflow }}-deploy
-      cancel-in-progress: false
+      group: ${{ github.workflow }}-deploy-${{ github.event_name }}
+      cancel-in-progress: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -89,7 +102,9 @@ jobs:
         with:
           # Full history required: mike reads and pushes the gh-pages branch.
           fetch-depth: 0
-          ref: main
+          # Release deploys build the released tag (see the build job's ref
+          # comment); push deploys build the pushed main commit.
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -110,14 +125,43 @@ jobs:
       - name: Publish versioned docs
         env:
           TAG: ${{ github.event.release.tag_name }}
-          # GitHub renders the JSON boolean as the string "true"/"false".
-          PRERELEASE: ${{ github.event.release.prerelease }}
+          EVENT: ${{ github.event_name }}
         run: |
-          version="${TAG#v}"
-          if [ "$PRERELEASE" = "true" ]; then
-            uv run mike deploy --push unstable --title "unstable (${version})"
-          else
+          # NOTE: deploy_docs is called from an `if` condition, where bash
+          # suppresses errexit — every failure path must propagate explicitly
+          # (bare `return` and the `&&` chain below), or a failed deploy would
+          # read as success.
+          deploy_docs() {
+            if [ "$EVENT" = "push" ]; then
+              uv run mike deploy --push unstable --title "unstable (${GITHUB_SHA:0:7})"
+              return
+            fi
+            version="${TAG#v}"
             minor="$(echo "$version" | cut -d. -f1-2)"
-            uv run mike deploy --push --update-aliases --title "$version" "$minor" latest
-            uv run mike set-default --push latest
-          fi
+            # Order-aware `latest`: read which minor currently holds the alias
+            # from mike's manifest on gh-pages. Empty (no gh-pages yet, or no
+            # alias) means first release — claim it.
+            current="$(git cat-file -p origin/gh-pages:versions.json 2>/dev/null \
+              | python3 -c 'import json,sys; vs=json.load(sys.stdin); print(next((v["version"] for v in vs if "latest" in (v.get("aliases") or [])), ""))' \
+              || true)"
+            if [ -z "$current" ] || [ "$(printf '%s\n%s\n' "$current" "$minor" | sort -V | tail -1)" = "$minor" ]; then
+              uv run mike deploy --push --update-aliases --title "$version" "$minor" latest \
+                && uv run mike set-default --push latest
+            else
+              uv run mike deploy --push --title "$version" "$minor"
+            fi
+          }
+          # Deploys from the push and release buckets can race on gh-pages;
+          # on a rejected push, re-sync the local gh-pages ref to the remote
+          # and redo the deploy on the fresh tip.
+          for attempt in 1 2 3; do
+            git fetch origin gh-pages || true
+            if git rev-parse -q --verify refs/remotes/origin/gh-pages > /dev/null; then
+              git update-ref refs/heads/gh-pages refs/remotes/origin/gh-pages
+            fi
+            if deploy_docs; then
+              exit 0
+            fi
+          done
+          echo "::error::docs deploy failed after 3 attempts"
+          exit 1

--- a/.github/workflows/release-notes-publish.yml
+++ b/.github/workflows/release-notes-publish.yml
@@ -1,0 +1,175 @@
+# Agent-written release notes, half two of two (template#347).  When a
+# release-notes page lands on the default branch (normally by merging the PR
+# the Release Notes workflow opened), two deterministic follow-ups make the
+# merged page the release's front door:
+#
+#   1. Release-body upgrade — the NOTES-GENERATOR SEAM in release.yml wrote
+#      an interim summary+pointers body at release time (template#350's
+#      contract); this workflow replaces that summary with the page's marked
+#      summary block and deep-links the page, keeping the compare and
+#      CHANGELOG pointers.  Only bodies still carrying the interim marker
+#      line are touched, so a hand-tuned body is never clobbered.
+#   2. Versioned-docs redeploy — mike deployed /X.Y/ at release time, before
+#      the page existed, so the deep link would 404 without a redeploy.  The
+#      minor is redeployed from its newest tag with the default branch's
+#      docs/releases/ overlaid.  Pages live only on the default branch
+#      (release branches never carry them), so the overlay is the single
+#      source and a backport patch's section reaches its series' docs no
+#      matter which branch the patch was cut from.
+#
+# Deterministic by design: the agent's output was reviewed and merged in the
+# PR; nothing here generates content.  Human edits to a page republish the
+# same way — the docs redeploy re-runs; the body upgrade does not (see the
+# interim-marker rule above; use `gh release edit` for a body fix).
+name: Release Notes Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/releases/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Serialise with ourselves only; gh-pages races with docs.yml deploys are
+    # reconciled by the fetch-reset-retry loop below, same as docs.yml.
+    concurrency:
+      group: release-notes-publish
+      cancel-in-progress: false
+    permissions:
+      contents: write   # gh release edit + gh-pages push
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history: tags (locate each minor's releases) and the
+          # gh-pages branch (mike) both live outside the pushed commit.
+          fetch-depth: 0
+
+      - name: Find changed release pages
+        id: pages
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          # Cover multi-commit pushes; on a forced push or missing before-SHA
+          # fall back to the head commit alone.
+          if git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            range="${BEFORE}..HEAD"
+          else
+            range="HEAD^..HEAD"
+          fi
+          git diff --name-only --diff-filter=AM "$range" -- 'docs/releases/*.md' \
+            | grep -vE '/index\.md$' > changed-pages.txt || true
+          if [ -s changed-pages.txt ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            cat changed-pages.txt
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "only the index changed — nothing to publish"
+          fi
+
+      - name: Upgrade release bodies from merged pages
+        if: steps.pages.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r page; do
+            minor=$(basename "$page" .md)
+            echo "$minor" | grep -qE '^[0-9]+\.[0-9]+$' \
+              || { echo "::warning::${page} does not follow docs/releases/X.Y.md — skipping"; continue; }
+            tags=$(git tag --list | grep -E "^v${minor//./\\.}\.[0-9]+$" | sort -V || true)
+            [ -n "$tags" ] \
+              || { echo "::warning::no stable tag in the ${minor} series yet — the body upgrade runs once the release exists"; continue; }
+            for TAG in $tags; do
+              # The page carries one marked summary block per release; a tag
+              # without a block (e.g. an old patch nobody wrote up) is left
+              # alone.
+              summary=$(awk -v tag="$TAG" '
+                index($0, "RELEASE-SUMMARY " tag " START") { f=1; next }
+                index($0, "RELEASE-SUMMARY " tag " END")   { f=0 }
+                f' "$page" | awk 'NF {p=1} p' | tac | awk 'NF {p=1} p' | tac)
+              [ -n "$summary" ] || continue
+              body=$(gh release view "$TAG" --json body --jq .body 2>/dev/null || true)
+              [ -n "$body" ] || { echo "no GitHub release for ${TAG} — skipping"; continue; }
+              # Upgrade once: only bodies still carrying release.yml's interim
+              # closing line. Anything else is either already upgraded or
+              # hand-written — leave it alone.
+              printf '%s' "$body" | grep -qF 'Release notes will move to a versioned notes page' \
+                || { echo "${TAG} body already upgraded or hand-edited — leaving it alone"; continue; }
+              ver="${TAG#v}"
+              prev=$(
+                { git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                    | grep -Fvx "$TAG"; echo "$TAG"; } \
+                  | sort -V | awk -v t="$TAG" '$0 == t { print p; exit } { p = $0 }'
+              )
+              {
+                printf '%s\n' "$summary"
+                echo
+                echo "- Release notes: https://pvliesdonk.github.io/image-generation-mcp/${minor}/releases/${minor}/"
+                if [ -n "$prev" ]; then
+                  echo "- All changes since ${prev}: https://github.com/${REPO}/compare/${prev}...${TAG}"
+                fi
+                echo "- Commit-level detail: [CHANGELOG.md](https://github.com/${REPO}/blob/${TAG}/CHANGELOG.md)"
+              } > release-body.md
+              gh release edit "$TAG" --notes-file release-body.md
+              echo "upgraded ${TAG} from ${page}"
+            done
+          done < changed-pages.txt
+
+      - name: Install uv
+        if: steps.pages.outputs.found == 'true'
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        if: steps.pages.outputs.found == 'true'
+        run: uv python install 3.12
+
+      - name: Install docs dependencies
+        if: steps.pages.outputs.found == 'true'
+        run: uv sync --no-default-groups --group docs --frozen
+
+      - name: Redeploy versioned docs with the merged pages
+        if: steps.pages.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          MAIN_REF=$(git rev-parse HEAD)
+          while IFS= read -r page; do
+            minor=$(basename "$page" .md)
+            echo "$minor" | grep -qE '^[0-9]+\.[0-9]+$' || continue
+            TAG=$(git tag --list | grep -E "^v${minor//./\\.}\.[0-9]+$" | sort -V | tail -1 || true)
+            [ -n "$TAG" ] || continue
+            ver="${TAG#v}"
+            # Build the minor's docs from its newest tag — the content that
+            # release actually shipped — with the default branch's notes
+            # pages overlaid on top.  `--no-sync` reuses the docs venv
+            # installed above instead of re-locking against the tag.
+            git checkout --force "$TAG"
+            git checkout "$MAIN_REF" -- docs/releases
+            deployed=""
+            # Deploys race with docs.yml's push/release buckets on gh-pages;
+            # on a rejected push, re-sync the local gh-pages ref and redo the
+            # deploy on the fresh tip (same loop as docs.yml).
+            for attempt in 1 2 3; do
+              git fetch origin gh-pages || true
+              if git rev-parse -q --verify refs/remotes/origin/gh-pages > /dev/null; then
+                git update-ref refs/heads/gh-pages refs/remotes/origin/gh-pages
+              fi
+              if uv run --no-sync mike deploy --push --title "$ver" "$minor"; then
+                deployed=1
+                break
+              fi
+            done
+            [ "$deployed" = "1" ] \
+              || { echo "::error::docs redeploy for ${minor} failed after 3 attempts"; exit 1; }
+            git checkout --force "$MAIN_REF"
+          done < changed-pages.txt

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,214 @@
+# Agent-written release notes, half one of two (template#347).  After every
+# stable release an agent researches the release range through the GitHub
+# API — commits, their PRs, the PRs' linked issues; never commit subjects —
+# and opens a PR that adds or extends the release's per-minor page under
+# docs/releases/.  The research contract (theme fan-out, evidence rules,
+# page format, Vale loop) lives in .claude/skills/writing-release-notes/;
+# this workflow only supplies context, tools, and the mechanical PR.
+#
+# INVARIANT: nothing here gates or blocks the release path.  By the time
+# this runs, the release has shipped with the interim summary+pointers body
+# release.yml wrote (its NOTES-GENERATOR SEAM step).  A failed or junk run
+# leaves that body standing; re-run via workflow_dispatch when wanted.  The
+# body upgrade and the versioned-docs redeploy happen only after a human
+# merges the notes PR — see release-notes-publish.yml.
+name: Release Notes
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Stable tag to draft notes for (e.g. v1.2.0). Empty = newest stable tag.'
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  draft:
+    # Stables only: rcs are branch-scoped stabilisation builds that deploy no
+    # versioned docs, and the notes page is per minor (template#350) — the rc
+    # cycle's content lands in the minor's page when the stable finalises,
+    # via the since-previous-stable range below.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    # Serialise drafts: two quick successive releases would race on the same
+    # index page and branch namespace.
+    concurrency:
+      group: release-notes-draft
+      cancel-in-progress: false
+    timeout-minutes: 60
+    permissions:
+      contents: read       # the agent only reads; the PR push uses RELEASE_TOKEN
+      issues: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v7
+        with:
+          # Always the default branch, whatever branch the release was cut
+          # from: notes pages live only there (a backport patch appends to
+          # the page on the default branch; release-notes-publish.yml
+          # overlays these pages onto the tag when redeploying docs, which
+          # is what resolves template#347's patch-page ordering problem).
+          # Research is API-driven, but full depth supplies the tags for the
+          # previous-stable computation and the tag-to-tag surface diffs
+          # (import surface, env examples) the upgrade section derives from.
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          # PAT, so the branch push and PR below trigger CI/review on the
+          # notes PR (GITHUB_TOKEN-created PRs run no workflows).
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Resolve release context
+        id: ctx
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${RELEASE_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            TAG=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          fi
+          echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "::error::'${TAG}' is not a stable vX.Y.Z tag — notes pages are per stable minor; rcs have no page"; exit 1; }
+          git rev-parse -q --verify "refs/tags/${TAG}" > /dev/null \
+            || { echo "::error::tag ${TAG} not found"; exit 1; }
+          ver="${TAG#v}"
+          minor="${ver%.*}"
+          # Highest stable tag strictly below this release (same series-aware
+          # idiom as release.yml's body step); empty on a first release.
+          prev=$(
+            { git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                | grep -Fvx "$TAG"; echo "$TAG"; } \
+              | sort -V | awk -v t="$TAG" '$0 == t { print p; exit } { p = $0 }'
+          )
+          page="docs/releases/${minor}.md"
+          mode=new
+          [ -f "$page" ] && mode=patch
+          {
+            echo "tag=$TAG"
+            echo "version=$ver"
+            echo "minor=$minor"
+            echo "prev=$prev"
+            echo "page=$page"
+            echo "mode=$mode"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install docs dependencies
+        # Gives the agent a working `uv run mkdocs build --strict` check.
+        run: uv sync --no-default-groups --group docs --frozen
+
+      - name: Install Vale and sync style packs
+        # The Vale CLI pin lives in ci.yml's vale job (kept in lockstep with
+        # pre-commit by the template CI); extract it rather than adding a
+        # third pin surface here.  The synced packs include ai-tells, the
+        # LLM-prose detector that is this pipeline's prose gate.
+        run: |
+          set -euo pipefail
+          VER=$(awk '/^  vale:/{f=1} f && /^[[:space:]]+version:/{print; exit}' \
+              .github/workflows/ci.yml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+          [ -n "$VER" ] || { echo "::error::vale version pin not found in ci.yml"; exit 1; }
+          mkdir -p "$RUNNER_TEMP/valebin"
+          TARBALL="vale_${VER}_Linux_64-bit.tar.gz"
+          BASE="https://github.com/vale-cli/vale/releases/download/v${VER}"
+          curl -sSfL -o "$RUNNER_TEMP/$TARBALL" "$BASE/$TARBALL" \
+            || { echo "::error::could not download $BASE/$TARBALL"; exit 1; }
+          curl -sSfL -o "$RUNNER_TEMP/checksums.txt" "$BASE/vale_${VER}_checksums.txt" \
+            || { echo "::error::could not download the vale $VER checksums file"; exit 1; }
+          ( cd "$RUNNER_TEMP" && grep " $TARBALL\$" checksums.txt | sha256sum -c - ) \
+            || { echo "::error::vale $VER tarball failed checksum verification"; exit 1; }
+          tar -xzf "$RUNNER_TEMP/$TARBALL" -C "$RUNNER_TEMP/valebin" vale
+          echo "$RUNNER_TEMP/valebin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/valebin/vale" sync
+
+      # The research contract requires parallel per-theme subagents (Task).
+      # Same pin + rationale as claude-code-review.yml: on Claude Code
+      # >= 2.1.198 claude-code-action drops background subagents before they
+      # finish (claude-code-action#1499), so the fan-out would silently lose
+      # its research. Remove once #1499 is fixed upstream.
+      - name: Install pinned Claude Code (2.1.197, pre-background-subagents)
+        run: |
+          set -euo pipefail
+          curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.197
+          BIN="$HOME/.local/bin/claude"
+          test -x "$BIN"
+          "$BIN" --version
+          echo "CLAUDE_BIN=$BIN" >> "$GITHUB_ENV"
+
+      - name: Draft the notes page
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          path_to_claude_code_executable: ${{ env.CLAUDE_BIN }}
+          prompt: |
+            Load the writing-release-notes skill (.claude/skills/writing-release-notes/SKILL.md) and follow it end to end for this stable release:
+
+            - repository: ${{ github.repository }}
+            - tag: ${{ steps.ctx.outputs.tag }} (version ${{ steps.ctx.outputs.version }}, minor series ${{ steps.ctx.outputs.minor }})
+            - previous stable: ${{ steps.ctx.outputs.prev }} (empty means first release)
+            - page: ${{ steps.ctx.outputs.page }}
+            - mode: ${{ steps.ctx.outputs.mode }} (new = write the whole page and add it to docs/releases/index.md; patch = append one dated section inside the patch sentinels)
+
+            The vale binary (packs synced) and `uv run mkdocs build --strict` are available for the skill's quality gates. Write your proposed pull-request body to .release-notes-pr-body.md at the repository root. Do not commit, push, or open a PR yourself — the workflow's next step does that mechanically from your working tree.
+          track_progress: true
+          display_report: true
+          include_fix_links: false
+          # Read-only GitHub research (MCP read tools + gh api), Task for the
+          # per-theme fan-out, Skill to load the contract, vale + mkdocs for
+          # the quality loop, and read-only git for tag-to-tag surface diffs.
+          # Edit/Write stay available from the action's defaults; the job's
+          # `contents: read` keeps the agent from pushing anything.
+          claude_args: |
+            --allowedTools "Skill,Task,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs *),Bash(git tag *),Bash(git show *),Bash(git diff *),Bash(git log *)"
+
+      - name: Open the notes PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG: ${{ steps.ctx.outputs.tag }}
+          DEFAULT: ${{ github.event.repository.default_branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Only the notes surface is ever committed: the release pages and
+          # any vocabulary the Vale loop legitimately added.  An agent run
+          # that changed nothing (honest failure) opens no PR — the release
+          # stands with its interim body.
+          ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
+          if ! git status --porcelain -- docs/releases "$ACCEPT" | grep -q .; then
+            echo "no notes changes produced — skipping PR; the release keeps its interim body"
+            exit 0
+          fi
+          BODY=.release-notes-pr-body.md
+          if [ ! -f "$BODY" ]; then
+            {
+              echo "Agent-drafted release notes for ${TAG} (the drafting run left no PR body; review the page against its inline evidence links)."
+              echo
+              echo "Refs: https://github.com/${REPO}/releases/tag/${TAG}"
+            } > "$BODY"
+          fi
+          BRANCH="release-notes/${TAG}"
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add docs/releases "$ACCEPT"
+          git commit -m "docs(releases): release notes for ${TAG}"
+          # Force: a re-dispatch for the same tag replaces the previous draft.
+          git push --force origin "HEAD:${BRANCH}"
+          gh pr create --base "$DEFAULT" --head "$BRANCH" \
+            --title "docs(releases): release notes for ${TAG}" \
+            --body-file "$BODY" \
+            || echo "PR for ${BRANCH} already exists — the force-push updated it"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,20 @@
+# Prerelease-ness is a property of the BRANCH, not of a dispatch flag (see
+# [tool.semantic_release.branches] in pyproject.toml): dispatching from `main`
+# cuts a stable release; dispatching from a short-lived `release/X.Y`
+# stabilisation branch cuts an rc by default, or the final stable X.Y.Z when
+# the `finalize` box is checked.  Every publish gate below derives from PSR's
+# own outputs (`is_prerelease`) and from tag ordering — never from a dispatch
+# input — so a mismatched dispatch cannot open a stable-only gate for an rc.
+# After any release cut from a `release/*` branch, the `merge-back` job merges
+# the branch back into `main`; without that, the tag is unreachable from
+# `main` and PSR deadlocks there ("already released" forever).
 name: Release
 
 on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Force version bump type (empty = auto from commits). patch/minor/major override commit analysis. Ignored when pre-release box is checked and an rc series is already active — the revision is advanced automatically.'
+        description: 'Force version bump type (empty = auto from commits). patch/minor/major override commit analysis. Only valid on main — a release/X.Y branch has its target fixed at cut time.'
         type: choice
         default: ''
         options:
@@ -12,10 +22,10 @@ on:
           - patch
           - minor
           - major
-      prerelease:
-        description: 'Create a pre-release (rc channel — skips PyPI, catalog, registry, linux packages). Uncheck to cut a real release.'
+      finalize:
+        description: 'On a release/X.Y branch: cut the final stable X.Y.Z instead of the next rc. No effect on main, which always releases stable.'
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -23,8 +33,13 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Per-branch buckets: a patch release off release/X.Y must not serialise
+    # behind a minor off main.  Cross-branch resources stay safe without a
+    # global bucket: PyPI/GitHub-release/registry writes are per-version, the
+    # marketplace push rebase-retries, docs deploys serialise in docs.yml, and
+    # the rolling Docker tags are ordering-gated below.
     concurrency:
-      group: release
+      group: release-${{ github.ref_name }}
       cancel-in-progress: false
 
     permissions:
@@ -39,49 +54,81 @@ jobs:
           ref: ${{ github.ref_name }}
           token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Detect active pre-release series
-        id: detect-rc
+      # The branch fixes the version target, so only two dispatch surfaces
+      # remain and each is guarded: `force` is a main-only override (on a
+      # release branch it would compound past the target fixed at cut time —
+      # the failure mode behind template#154), and any branch matching neither
+      # PSR branch group is rejected by PSR itself before anything publishes.
+      - name: Reject force bump on a release branch
+        if: startsWith(github.ref, 'refs/heads/release/') && inputs.force != ''
         run: |
-          latest_rc=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$' | head -1 || true)
-          latest_stable=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-          in_rc_series=false
-          if [ -n "$latest_rc" ]; then
-            rc_base="${latest_rc%-rc.*}"
-            # Active only when the rc's stable base is not yet tagged AND the
-            # series targets a version newer than the latest stable release. An
-            # rc whose base is <= the latest stable is an abandoned/superseded
-            # series (e.g. a v2.0.0-rc left behind when the project jumped to
-            # v3.x); it must not trigger the force=prerelease revision bump,
-            # which from a stable base produces <current>-rc.1 instead of a
-            # bumped version.
-            newest=$(printf '%s\n%s\n' "$rc_base" "${latest_stable:-v0.0.0}" | sort -V | tail -1)
-            if ! git tag --list | grep -qx "$rc_base" \
-               && [ "$newest" = "$rc_base" ] && [ "$rc_base" != "${latest_stable:-v0.0.0}" ]; then
-              in_rc_series=true
-              echo "rc_series_target=$rc_base" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-          echo "in_rc_series=$in_rc_series" >> "$GITHUB_OUTPUT"
-
-      - name: Compute effective PSR force
-        id: compute-force
-        run: |
-          force="${{ inputs.force }}"
-          prerelease="${{ inputs.prerelease }}"
-          in_rc_series="${{ steps.detect-rc.outputs.in_rc_series }}"
-          if [[ "$prerelease" == "true" && "$force" == "" && "$in_rc_series" == "true" ]]; then
-            echo "effective_force=prerelease" >> "$GITHUB_OUTPUT"
-          else
-            echo "effective_force=$force" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Reject force bump on active pre-release series
-        if: steps.detect-rc.outputs.in_rc_series == 'true' && inputs.prerelease == false && (inputs.force == 'patch' || inputs.force == 'minor' || inputs.force == 'major')
-        run: |
-          echo "::error::An active pre-release series is in progress targeting ${{ steps.detect-rc.outputs.rc_series_target }}."
-          echo "::error::force=patch/minor/major with prerelease=false applies an additional bump on top of the series target and will skip ${{ steps.detect-rc.outputs.rc_series_target }}."
-          echo "::error::To finalize the series as a stable release, dispatch with force='' and prerelease=false."
+          echo "::error::force=${{ inputs.force }} is not valid on ${{ github.ref_name }}: a release branch's version target is fixed at cut time."
+          echo "::error::Dispatch with force='' — commits on the branch advance the rc revision; check 'finalize' to cut the final stable."
           exit 1
+
+      # Advisory only (never blocks — the cut may be intentional, or belong on
+      # a release/X.Y branch cut from an earlier commit).  Surfaces both
+      # queryable quiescence signals the epic conventions record:
+      #   * the preferred milestone — a release-named milestone (X.Y) with
+      #     open issues means that version is not yet safe to cut; and
+      #   * the ships-atomically label — for each open epic it also counts
+      #     open native sub-issues, which may live in another repo, so a
+      #     cross-repo epic whose children are elsewhere stays visible.
+      # Every gh call is guarded so a failure or an unsupported endpoint
+      # degrades to no warning rather than failing the step under pipefail.
+      - name: Warn about open ships-atomically epics and release milestones
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # (1) Open ships-atomically epics, each with a count of still-open
+          #     children (native sub-issues — cross-repo aware).
+          epics=$(gh issue list --repo "$REPO" --label ships-atomically \
+            --state open --json number,title \
+            --jq '.[] | "\(.number)\t\(.title)"' 2>/dev/null || true)
+          if [ -n "$epics" ]; then
+            printf '%s\n' "$epics" | while IFS="$(printf '\t')" read -r num title; do
+              [ -n "$num" ] || continue
+              kids=$(gh api "repos/$REPO/issues/$num/sub_issues" \
+                --jq '[.[] | select(.state == "open")] | length' 2>/dev/null || echo '?')
+              echo "::warning::Open ships-atomically epic #$num ($title) — $kids open child issue(s). Releasing $REPO@main ships HEAD mid-story; consider a release/X.Y branch cut from before the epic started."
+            done || true
+          fi
+          # (2) The preferred signal: a release-named milestone (X.Y) that
+          #     still has open issues — that version is not yet quiescent.
+          milestones=$(gh api "repos/$REPO/milestones?state=open&per_page=100" \
+            --jq '.[] | select(.open_issues > 0) | select(.title | test("^[0-9]+[.][0-9]+$")) | "\(.title): \(.open_issues) open issue(s)"' 2>/dev/null || true)
+          if [ -n "$milestones" ]; then
+            printf '%s\n' "$milestones" | while IFS= read -r ms; do
+              [ -n "$ms" ] || continue
+              echo "::warning::Release milestone $ms — not yet safe to cut that version from a quiescent trunk."
+            done || true
+          fi
+
+      # PSR's CLI can force prerelease ON (--as-prerelease) but not OFF, so
+      # the final stable from a release branch needs a one-run config override:
+      # the same [tool.semantic_release] config with the release group's
+      # `prerelease` flipped to false.  Generated from pyproject.toml at run
+      # time (never committed — PSR stages only version files and assets), so
+      # it cannot drift from the real config.
+      - name: Prepare stable-finalize config override
+        id: psr-config
+        if: inputs.finalize && startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          python3 - <<'EOF'
+          import json
+          import tomllib
+
+          with open("pyproject.toml", "rb") as fh:
+              cfg = tomllib.load(fh)["tool"]["semantic_release"]
+          # Fails loudly (KeyError) if the branch groups were removed/renamed;
+          # silently inventing a group here would mask a broken config.
+          cfg["branches"]["release"]["prerelease"] = False
+          with open(".psr-finalize.json", "w") as fh:
+              json.dump({"semantic_release": cfg}, fh)
+          EOF
+          echo "config_file=.psr-finalize.json" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -98,9 +145,116 @@ jobs:
           github_token: ${{ secrets.RELEASE_TOKEN }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
-          force: ${{ steps.compute-force.outputs.effective_force }}
-          prerelease: ${{ inputs.prerelease }}
-          prerelease_token: rc
+          force: ${{ inputs.force }}
+          # Empty unless finalizing a release branch; "" means pyproject.toml.
+          config_file: ${{ steps.psr-config.outputs.config_file }}
+
+      # A release from an old series must not repoint rolling channels at
+      # older content: Docker `latest`/`vX`/`vX.Y`, the GitHub "latest
+      # release" pointer, the marketplace entry, and the MCP registry all
+      # follow ONLY when this release is the highest in the relevant series.
+      # Tags are complete here: full-depth checkout plus the tag PSR just cut.
+      - name: Determine channel ordering
+        id: ordering
+        if: steps.release.outputs.released == 'true'
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.release.outputs.is_prerelease }}
+        run: |
+          is_latest=false
+          is_latest_major=false
+          is_latest_minor=false
+          if [ "$IS_PRERELEASE" != "true" ]; then
+            ver="${TAG#v}"
+            major="${ver%%.*}"
+            minor="${ver%.*}"
+            stable=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
+            if [ "$(printf '%s\n' "$stable" | sort -V | tail -1)" = "$TAG" ]; then
+              is_latest=true
+            fi
+            if [ "$(printf '%s\n' "$stable" | grep -E "^v${major}\." | sort -V | tail -1)" = "$TAG" ]; then
+              is_latest_major=true
+            fi
+            if [ "$(printf '%s\n' "$stable" | grep -E "^v${minor//./\\.}\." | sort -V | tail -1)" = "$TAG" ]; then
+              is_latest_minor=true
+            fi
+          fi
+          {
+            echo "is_latest=$is_latest"
+            echo "is_latest_major=$is_latest_major"
+            echo "is_latest_minor=$is_latest_minor"
+          } >> "$GITHUB_OUTPUT"
+
+      # Release-body contract (template#350, settled jointly with
+      # template#347): the body is a user-facing summary plus pointers — the
+      # docs site is canonical, and commit-level detail stays behind the
+      # compare link and CHANGELOG.md.  Composing the body here (overwriting
+      # PSR's default commit-list notes) makes it independent of the
+      # tag-to-tag commit range, so a stable that finalises an rc series gets
+      # the same body as any other release instead of an empty-range one.
+      # The compare link spans the cycle since the previous STABLE tag — one
+      # definition of "what belongs in this release" for stables and rcs
+      # alike.  Tags are complete here (see the ordering step above).
+      # NOTES-GENERATOR SEAM (template#347): consumed. The body written here
+      # is the at-release interim state; after the Release Notes workflow's
+      # agent-drafted docs/releases page merges, release-notes-publish.yml
+      # replaces the interim summary with the page's marked summary block and
+      # a deep link into the versioned docs/releases page, keeping the
+      # compare and CHANGELOG pointers. The closing line below doubles as the
+      # upgrade-once marker that workflow keys on — reword them together.
+      - name: Set release body (summary + docs pointers)
+        if: steps.release.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.release.outputs.is_prerelease }}
+          REPO: ${{ github.repository }}
+        run: |
+          ver="${TAG#v}"
+          minor="${ver%%-*}"
+          minor="${minor%.*}"
+          # Highest stable tag strictly below this release (series-aware via
+          # sort -V; empty on a project's very first release).
+          prev=$(
+            { git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                | grep -Fvx "$TAG"; echo "$TAG"; } \
+              | sort -V | awk -v t="$TAG" '$0 == t { print p; exit } { p = $0 }'
+          )
+          {
+            if [ "$IS_PRERELEASE" = "true" ]; then
+              echo "Release candidate ${ver}: a branch-scoped stabilisation build for the upcoming v${minor} stable. Install it only to help test that release."
+              echo
+              # The stable's versioned docs publish when the stable ships;
+              # rcs deploy no docs, so point at the site root instead of a
+              # not-yet-existing /X.Y/ page.
+              echo "- Documentation: https://pvliesdonk.github.io/image-generation-mcp/ (the v${minor} pages publish when the stable ships)"
+            else
+              echo "image-generation-mcp ${ver}."
+              echo
+              echo "- Documentation: https://pvliesdonk.github.io/image-generation-mcp/${minor}/"
+            fi
+            if [ -n "$prev" ]; then
+              echo "- All changes since ${prev}: https://github.com/${REPO}/compare/${prev}...${TAG}"
+            fi
+            echo "- Commit-level detail: [CHANGELOG.md](https://github.com/${REPO}/blob/${TAG}/CHANGELOG.md)"
+            # Only a stable's body gets the notes-page promise: the Release
+            # Notes Publish workflow matches stable tags only, so an rc body
+            # would carry a pointer nothing ever fulfils.
+            if [ "$IS_PRERELEASE" != "true" ]; then
+              echo
+              echo "Release notes will move to a versioned notes page on the documentation site; until then, the links above carry the full change record."
+            fi
+          } > release-body.md
+          gh release edit "$TAG" --notes-file release-body.md
+
+      # GitHub auto-marks the newest non-prerelease as the repo's "latest
+      # release", which would repoint /releases/latest (and the versionless
+      # .deb/.rpm URLs) at a backport patch cut after a newer stable. Demote it.
+      - name: Keep the GitHub latest-release pointer ordered
+        if: steps.release.outputs.released == 'true' && steps.release.outputs.is_prerelease == 'false' && steps.ordering.outputs.is_latest == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ steps.release.outputs.tag }} --latest=false
 
       - name: Build package
         if: steps.release.outputs.released == 'true'
@@ -140,10 +294,19 @@ jobs:
       released: ${{ steps.release.outputs.released }}
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
+      # "true"/"false" from PSR itself — the single source the publish gates
+      # below derive from, so gate state can never desync from what PSR cut.
+      is_prerelease: ${{ steps.release.outputs.is_prerelease }}
+      is_latest: ${{ steps.ordering.outputs.is_latest }}
+      is_latest_major: ${{ steps.ordering.outputs.is_latest_major }}
+      is_latest_minor: ${{ steps.ordering.outputs.is_latest_minor }}
 
   publish-pypi:
     needs: release
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    # Every stable, including a backport patch from an old release/X.Y: PyPI
+    # versions are immutable and unordered, and installers pinned below a
+    # newer major are exactly who a backport serves.
+    if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -215,12 +378,18 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Rolling tags are ordering-gated (see the release job): a backport
+          # patch cut after a newer stable updates only the series tags it is
+          # actually the newest member of, and never `latest`.  An rc pushes
+          # its immutable version tag alone — the rolling `unstable` tag is
+          # retired now that rcs are rare, branch-scoped stabilisation builds
+          # ("run the latest code" is the `edge` tag, pushed per merge to main
+          # by the Unstable channel workflow).
           tags: |
             type=raw,value=v${{ steps.version.outputs.version }}
-            type=raw,value=latest,enable=${{ !inputs.prerelease }}
-            type=raw,value=v${{ steps.version.outputs.minor }},enable=${{ !inputs.prerelease }}
-            type=raw,value=v${{ steps.version.outputs.major }},enable=${{ !inputs.prerelease }}
-            type=raw,value=unstable,enable=${{ inputs.prerelease }}
+            type=raw,value=latest,enable=${{ needs.release.outputs.is_latest == 'true' }}
+            type=raw,value=v${{ steps.version.outputs.minor }},enable=${{ needs.release.outputs.is_latest_minor == 'true' }}
+            type=raw,value=v${{ steps.version.outputs.major }},enable=${{ needs.release.outputs.is_latest_major == 'true' }}
           labels: |
             org.opencontainers.image.title=image-generation-mcp
             org.opencontainers.image.description=MCP server for AI image generation via OpenAI, Google GenAI, or Stable Diffusion WebUI
@@ -265,7 +434,7 @@ jobs:
 
   publish-linux-packages:
     needs: release
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
 
     permissions:
@@ -371,7 +540,9 @@ jobs:
   # than failing the release.
   publish-claude-plugin:
     needs: release
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    # `is_latest` keeps the single marketplace entry ordered: a backport patch
+    # from an old series must not repoint the catalog at older content.
+    if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease == 'false' && needs.release.outputs.is_latest == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check plugin artifact exists at tag
@@ -470,7 +641,10 @@ jobs:
 
   publish-registry:
     needs: [release, publish-pypi, publish-docker]
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    # `is_latest` for the same reason as the marketplace: the registry entry
+    # is a discovery surface for the newest release; a backport's audience
+    # already holds pins and installs from PyPI or GitHub releases.
+    if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease == 'false' && needs.release.outputs.is_latest == 'true'
     runs-on: ubuntu-latest
 
     permissions:
@@ -481,7 +655,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: main
+          # The released ref, not a branch: the release commit — with the
+          # bumped server.json this job publishes — lives on whatever branch
+          # the release was cut from, and mid-cycle `main` may carry a
+          # different version entirely.
+          ref: ${{ needs.release.outputs.tag }}
           fetch-depth: 1
 
       - name: Install mcp-publisher
@@ -503,3 +681,54 @@ jobs:
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
+
+  # After ANY release cut from a release/* branch, the branch merges back into
+  # the default branch.  This is not housekeeping but a hard requirement:
+  # with the new tag unreachable from main, PSR on main recomputes the same
+  # version from main's own history, finds the tag taken repo-globally, and
+  # reports "already released" forever — no later commit unblocks it.  The
+  # merge is the only reverse flow (it carries PSR's release commits; feature
+  # cherry-picks never come back), and it also keeps main's version metadata
+  # current so edge builds self-report a real version.  scripts/merge_back.sh
+  # resolves version-coupled files (pyproject.toml, changelog, PSR assets) to
+  # main's side — main is authoritative for current metadata; the tag
+  # preserves the branch's own state — and fails loudly on any other
+  # conflict, leaving a clean tree for a manual merge:
+  #   git checkout main && git merge --no-ff release/X.Y  (resolve, push)
+  merge-back:
+    needs: release
+    if: needs.release.outputs.released == 'true' && startsWith(github.ref, 'refs/heads/release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          # Same PAT that pushes the release commit; a plain GITHUB_TOKEN push
+          # would also suppress the CI/docs/edge workflows this merge should
+          # trigger on main.
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Merge release branch back into default branch
+        env:
+          BRANCH: ${{ github.ref_name }}
+          TAG: ${{ needs.release.outputs.tag }}
+          DEFAULT: ${{ github.event.repository.default_branch }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          # Concurrent pushes to main race with ours; redo the whole merge on
+          # a fresh tip rather than rebasing a merge commit.
+          for attempt in 1 2 3; do
+            git fetch origin "$BRANCH" "$DEFAULT"
+            git reset --hard "origin/$DEFAULT"
+            bash scripts/merge_back.sh "origin/$BRANCH" "$TAG"
+            if git push origin "HEAD:$DEFAULT"; then
+              exit 0
+            fi
+          done
+          echo "::error::could not push the merge-back of $BRANCH after 3 attempts; merge $BRANCH into $DEFAULT manually — until it lands, PSR cannot release from $DEFAULT"
+          exit 1

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,0 +1,110 @@
+# Rolling unstable channel (#351): every merge to `main` rebuilds the
+# container image under the fixed `edge` tag and packs an mcpb bundle as a
+# workflow artifact. No git tag, no GitHub release, no version bump, no
+# manifest churn — this channel answers "let me run the latest merged code"
+# without release machinery. Version-numbered pre-releases (rc) remain
+# release.yml's job, cut from short-lived release/X.Y stabilisation branches
+# and published only under their immutable vX.Y.Z-rc.N image tags (the
+# rc-fed rolling `unstable` tag is retired; `edge` is the one rolling
+# unstable tag, and one tag must have exactly one producer).
+name: Unstable channel
+
+on:
+  push:
+    branches: [main]
+  # Manual dispatch seeds or refreshes the channel without waiting for a
+  # merge (first-time setup, registry hiccup recovery).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Only the newest commit matters for a rolling tag: superseded runs are
+# cancelled so an older build cannot finish after a newer one and leave
+# `edge` pointing at stale code.
+concurrency:
+  group: unstable-channel
+  cancel-in-progress: true
+
+jobs:
+  docker-edge:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # A single fixed tag. metadata-action stamps
+          # org.opencontainers.image.revision with the commit sha, so the
+          # exact commit behind `edge` is always readable from the image
+          # despite the channel carrying no version.
+          tags: |
+            type=raw,value=edge
+          labels: |
+            org.opencontainers.image.title=image-generation-mcp
+            org.opencontainers.image.description=MCP server for AI image generation via OpenAI, Google GenAI, or Stable Diffusion WebUI
+            org.opencontainers.image.vendor=pvliesdonk
+            io.modelcontextprotocol.server.name=io.github.pvliesdonk/image-generation-mcp
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  mcpb-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # Render/validate/pack/smoke live in the shared composite action
+      # (.github/actions/build-mcpb) — the same steps release.yml and the
+      # pre-release-check workflow run, so this path cannot drift from what
+      # a real release executes.
+      - name: Build and smoke-test mcpb bundle
+        uses: ./.github/actions/build-mcpb
+        with:
+          # Constant, versionless by design: 0.0.0-dev is valid semver (so
+          # `mcpb validate` accepts it), sorts below every real release (so
+          # an unstable bundle can never masquerade as an upgrade), and is
+          # already the pre-release-check workflow's proven default.
+          version: 0.0.0-dev
+
+      - name: Upload mcpb bundle artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcpb-bundle-edge
+          path: dist/image-generation-mcp-*.mcpb
+          if-no-files-found: error

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,16 +28,16 @@ repos:
         args: [src/]
 
       # Structural-health gate: strict ruff structural rules on CHANGED LINES
-      # ONLY (diff vs origin/main), mirroring the CI `structure` job. NOTE the
-      # base is hardcoded `origin/main` here while CI compares against the PR's
-      # actual base (`github.base_ref`); the two coincide for a PR targeting
-      # `main` and diverge only for a non-main base branch.
-      # bash -c so the shell — not pre-commit's arg splitter — owns the
-      # --options quoting. Pre-push (not commit-time): a commit has no base to
-      # compare and may be partial; pre-push sees the full branch range CI checks.
+      # ONLY, sharing scripts/structural_gate.sh with the CI `structure` job so
+      # the command cannot drift between the two. The script derives its
+      # compare branch (nearest of origin/main and origin/release/*, or the
+      # STRUCTURAL_GATE_BASE override), so a backport branch targeting
+      # release/X.Y is measured against that base rather than origin/main.
+      # Pre-push (not commit-time): a commit has no base to compare and may be
+      # partial; pre-push sees the full branch range CI checks.
       - id: structural-diff-gate
-        name: structural quality (diff vs origin/main)
-        entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" --compare-branch=origin/main --fail-under=100'
+        name: structural quality (diff vs derived base)
+        entry: bash scripts/structural_gate.sh
         language: system
         pass_filenames: false
         # Skip the hook when the push has no Python (with pass_filenames: false,

--- a/.vale.ini
+++ b/.vale.ini
@@ -51,3 +51,7 @@ BasedOnStyles = Vale, Google, proselint, write-good, ai-tells
 # legitimately appear with different casing. Vale.Spelling still accepts
 # all entries case-insensitively; we just don't enforce one canonical form.
 Vale.Terms = NO
+
+# Retain the template-owned explanation of Bootstrap's upsert behavior.
+[docs/deployment/repository-protection.md]
+ai-tells.VerbTricolon = NO

--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -34,13 +34,18 @@ stdio
 
 # --- Operational / config jargon ---
 allowlist
+backports
 config
 deployer
 env
+hotfix
+ruleset
+rulesets
 truthy
 uncommented
 uncommenting
 unprefixed
+upserts
 validators
 
 # --- Diagnostics / observability ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,14 +31,57 @@ src/image_generation_mcp/
 - Python 3.11+
 - `uv` for package management, `ruff` for linting/formatting (line length 88)
 - `hatchling` build backend
-- Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+- Conventional commits, one type from `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` — optionally scoped (`feat(search): ...`) and with `!` for a breaking change. `feat` cuts a minor release, `fix` and `perf` cut a patch, the rest cut none.
 - Google-style docstrings on all public functions
 - `logging.getLogger(__name__)` throughout, no `print()`
 - Type hints everywhere
 - Tests: `pytest` with fixtures in `tests/fixtures/`
 
+**Pull-request titles are enforced, not merely encouraged.** A squash merge
+takes the PR title as the commit subject, so CI's `PR Title` job checks it
+against the type list above and fails the `CI Success` aggregate when it does
+not match. This is not style policing: python-semantic-release parses that
+subject, and a type it does not recognise is dropped from `CHANGELOG.md`
+without a warning — no fallback heading, no entry at all. A commit that never
+reaches the changelog never reaches the release notes that link into it.
+
+Retitling is enough to clear a failure — the job reads the current title from
+the API, so re-running it after a retitle needs no push.
+
+**Reverts are the one accepted title with a caveat.** `Revert "..."`, the
+shape `git revert` and GitHub's revert button generate, passes: it is the
+ecosystem's convention, and Conventional Commits deliberately leaves reverts
+unspecified. But no python-semantic-release parser reads it — `angular` and
+`conventional` both fail on it — so such a commit does **not** reach
+`CHANGELOG.md`. The job says so with a warning annotation rather than letting
+you find out at release time. `revert: ORIGINAL SUBJECT` is the form that does
+reach the changelog. Either way the revert is narrated on the
+`docs/releases/` page, whose research runs off merged pull requests and linked
+issues rather than commit subjects.
+
+The accepted set lives in `pyproject.toml` under
+`[tool.semantic_release.commit_parser_options] allowed_tags`.
+`scripts/check_pr_title.py` and the list above are checked against it by
+`tests/test_commit_conventions.py`, so no one of the three can drift alone.
+
 The automated Claude review runs **only after CI passes** — if CI is red, no
 review is posted. Fix CI and push; the review runs on the next green run.
+
+## Breaking Changes and the `!` Marker
+
+Releases are cut by python-semantic-release from commit messages alone, so the `!` marker (or `BREAKING CHANGE:` footer) *is* the major-version decision — apply it deliberately, not by habit. A change is **breaking** only if it breaks one of two surfaces:
+
+- **Operator surface** — an environment variable, config file, CLI flag, deployment layout, or on-disk state format a human must change to upgrade.
+- **Public library interface** — anything importable from `image_generation_mcp` that a downstream Python consumer uses. A mechanical guard for this tier is tracked at pvliesdonk/fastmcp-server-template#352.
+
+A change to the **MCP tool surface** (tool names, parameters, return schemas, adding or removing tools) is **not** breaking on its own. The LLM client is stateless and re-discovers the surface over the protocol on connect, so a server restart resolves it with no user action.
+
+Two refinements:
+
+1. **Re-discovery covers a tool's *shape*, not its *semantics*.** A tool that keeps its signature but changes what it does can still break operator automation, prompts, or skills. If only the MCP surface changed and the previous behaviour is still reachable (additive / dual-mode), the change is not breaking; if the old behaviour is gone, treat it as breaking even though the schema re-discovers cleanly.
+2. **Assess against the last stable release, not the previous commit.** A change to something introduced in the same unreleased range breaks nothing a user has, and does not earn a `!`. When a feature and its rework land in one release cycle, only the net effect on the released surface counts. Sanity-check any commit carrying `!` before it merges: if `git tag --contains` on the commit that introduced the surface comes back empty, the surface never shipped and the `!` is spurious.
+
+The two-part test: (1) does an operator or a library consumer of the last stable release have to change something? → breaking. (2) If only the MCP surface changed, is the previous behaviour still reachable? → not breaking; if it is gone, breaking.
 
 ## Hard PR Acceptance Gates
 
@@ -51,13 +94,11 @@ Every PR must pass **all** of the following before merge. Do not open or push a 
 
 5. **Structural quality (diff) passes** — new/changed code must introduce no new structural violations (complexity, too-many-*, security). Enforced on the diff only, so pre-existing code is never blocked. Run before pushing:
    ```bash
-   uv run diff-quality --violations=ruff.check \
-     --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
-     --compare-branch=origin/main --fail-under=100
+   bash scripts/structural_gate.sh
    ```
-   `# noqa: C901` (etc.) with a one-line justification is the escape hatch for genuinely irreducible new code.
+   The script derives its compare branch (nearest of `origin/main` and `origin/release/*`; override with `STRUCTURAL_GATE_BASE`) and runs `diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" --fail-under=100` against it. `# noqa: C901` (etc.) with a one-line justification is the escape hatch for genuinely irreducible new code.
 6. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
-7. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
+7. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version: the latest *stable* release. Stable releases bump them atomically via PSR; pre-releases deliberately leave them untouched, because the versions they name are only published for stable releases. Manual touches require updating all three.
 
 
 ## Pre-commit Hooks
@@ -67,7 +108,7 @@ This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), 
 - **Install once per clone:** `uv run pre-commit install`.
 - **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
 
-- **Structural gate runs at push time:** the `structural-diff-gate` hook (pre-push stage) runs the command above automatically. `uv run pre-commit install` wires it via `default_install_hook_types`. A clean local push implies a clean CI `structure` job — same command, same range, as long as your PR targets `main` (the hook hardcodes `origin/main`; CI compares against the PR's actual base branch).
+- **Structural gate runs at push time:** the `structural-diff-gate` hook (pre-push stage) runs `scripts/structural_gate.sh` automatically. `uv run pre-commit install` wires it via `default_install_hook_types`. A clean local push implies a clean CI `structure` job — CI runs the same script, pinning the compare branch to the PR's actual base, while the hook derives it (nearest of `origin/main` and `origin/release/*`), so backport branches targeting a release branch are measured against the right base locally too.
 
 - **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
 
@@ -126,7 +167,7 @@ Every issue, PR, and code change must consider documentation impact. Before clos
 - **`docs/design/`** — internal design specs and architecture decisions (the authoritative dev reference). Any new feature, changed behavior, or architectural decision must be reflected here. Not part of the published site.
 - **`README.md`** — user-facing documentation. New env vars, tools, resources, prompts, CLI flags, or configuration options must be documented here.
 - **`docs/` site pages** — the published documentation site. New or changed MCP tools/resources/prompts, new env vars, new installation methods or deployment options.
-- **`CHANGELOG.md`** — managed by semantic-release from conventional commits.
+- **`CHANGELOG.md`** — machine-generated audit trail: python-semantic-release inserts each release's version section at the `<!-- version list -->` insertion flag during the release workflow. Never hand-edit version sections or the flag line. If this project was generated before the flag existed, add the flag line to `CHANGELOG.md` once by hand — `tests/test_release_contract.py` fails with the exact line until it is present.
 - **Inline docstrings** — new or changed public API methods need accurate Google-style docstrings.
 
 **Rule: code without matching docs is incomplete.**
@@ -238,16 +279,77 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 
 ### Release manifest extension points
 
-`scripts/bump_manifests.py` bumps `server.json` and refreshes `uv.lock`'s self-version entry inside the release commit, so the tag never points at a manifest whose version lags it. These sentinel blocks in that script are preserved across `copier update`. Add bumps for this project's own version-coupled manifests (a Claude Code `plugin.json`, an `.mcp.json`, another lockstep JSON/TOML) inside them:
+`scripts/bump_manifests.py` bumps `server.json` and refreshes `uv.lock`'s self-version entry inside the release commit, so a stable tag never points at a manifest whose version lags it. On pre-release versions the script leaves `server.json` at the last published stable — pre-releases skip PyPI and the MCP registry, so bumping those pins would make `main` name a version that does not exist anywhere (`tests/test_release_contract.py` asserts both behaviors). `uv.lock` is refreshed on every release, pre-release included, because it tracks `pyproject.toml` rather than a published artifact. These sentinel blocks in that script are preserved across `copier update`. Add bumps for this project's own version-coupled manifests (a Claude Code `plugin.json`, an `.mcp.json`, another lockstep JSON/TOML) inside them:
 
 - `# DOMAIN-MANIFESTS-HELPERS-START` / `-END` — module-level helpers (use `_load` / `_dump` for JSON so the byte format matches what `scripts/gen_config_surface.py` asserts)
 - `# DOMAIN-MANIFESTS-START` / `-END` — the calls, inside `main()`, where `version` is in scope
 
 Every path bumped there must also appear in `pyproject.toml`'s `[tool.semantic_release] assets`, or PSR leaves it out of the release commit. The two are checked against each other by `tests/test_release_contract.py`, so a manifest named in one and not the other fails the gate rather than shipping a release commit with a stale file in it.
 
+## Public import surface guard
+
+`tests/test_import_surface.py` (template-owned, re-rendered on template updates) asserts the set of public names importable from the `image_generation_mcp` package root against the project-owned snapshot `tests/public_import_surface.txt` (seeded once, never re-rendered by template updates — yours). The surface is enumerated in a fresh interpreter — every non-underscore name in `dir(package)` or `__all__` that resolves via `getattr` — so lazy `__getattr__` re-exports count, incidental submodule imports from earlier tests do not, and a root holding only a docstring and `__version__` has an empty surface. When the test fails:
+
+- **A name disappeared** — that is a breaking change to the public library interface. Either restore the name, or regenerate the snapshot (`uv run python tests/test_import_surface.py --update`) **and** mark the commit/PR breaking (`feat!:` / `fix!:`, or a `BREAKING CHANGE:` footer) per the versioning policy's public-library-interface tier (pvliesdonk/fastmcp-server-template#342).
+- **A name appeared** — not breaking; regenerate the snapshot and commit it alongside the change, so the snapshot diff stays the reviewable record of every surface change.
+
+The guard covers the package root only — submodule paths, env vars, and CLI flags are out of its scope.
+
 ## Pre-release artifact smoke test
 
 The `Pre-release check` workflow (Actions tab, `workflow_dispatch`) builds and validates the mcpb bundle from any branch at a caller-supplied version (default `0.0.0-dev`), uploads it as a workflow artifact for manual install testing, and can optionally attach it to a deletable `v<version>-rc` pre-release. It runs the exact same steps a real release runs — both call the shared `.github/actions/build-mcpb` composite — so a green pre-release check means the release path's bundle build is green too. Project-specific artifact assertions (extra bundles, plugin manifests) belong in `packaging/pre-release-checks.sh` — an executable script the workflow runs when present, with `VERSION` and `BUNDLE` exported; the file is project-owned, and template updates never touch it.
+
+## Release model
+
+`main` is trunk. Everything merges there, and **merging is not releasing**: a merge feeds the rolling `edge` channel (next section) and nothing else. A release is a separate, deliberate event — dispatching the Release workflow — and the sections below say when and from where.
+
+**The default release path is trunk.** When a release is wanted and trunk is quiescent (no atomic epic mid-flight — the cut criterion below), dispatch Release on `main`. It cuts a stable from HEAD: no branch, no ceremony. Most releases should look like this.
+
+**The cut criterion.** An epic that ships atomically makes trunk unreleasable while it is open: releasing `main` ships HEAD, mid-story. Judge quiescence from the queryable signal the epic conventions record (see CONTRIBUTING.md's Epics section): preferably the **release milestone** — safe to cut means no open issues in the target release's milestone — with the **`ships-atomically` label** as the fallback when no milestone names a release yet. An open atomic epic with unclosed children means either release from a commit before the epic started (a `release/X.Y` branch cut from that commit) or wait. The Release workflow's advisory step surfaces both signals on every `main` dispatch — a release-named milestone (`X.Y`) that still has open issues, and open `ships-atomically` epics (each with a count of its native sub-issues, so a cross-repo epic whose children live elsewhere stays visible); it warns and never blocks, because the cut may still be intentional.
+
+**The `release/X.Y` branch is the exception tool**, for exactly two cases:
+
+1. **Dirty trunk at cut time** — trunk carries unfinished work that must be excluded from the release. Cut the branch from the last quiescent commit behind HEAD, stabilise there (rcs), and finalize the stable.
+2. **Patching a shipped release** — an already-released version needs a fix while `main` has moved on past it. The branch does not need to exist in advance: create it retroactively from the tag (`git branch release/X.Y vX.Y.Z`), land the fix, release.
+
+Fixes flow trunk → branch only: land on `main` first, cherry-pick to the branch. The automated release merge-back (see the release machinery section below) is the single reverse flow — it carries PSR's release commits, never features.
+
+**Branching cannot defer a structural refactor.** A refactor that changes existing behaviour makes every later cherry-pick across it conflict-prone, so a stabilisation branch buys no room for one. Land structural refactors early in a cycle, far from the next cut — not late, when a branch is about to be needed.
+
+**Cadence: value-triggered, not time-boxed.** No fixed release train — a calendar cadence is wrong for a low-traffic project and adds nothing to a busy one. Release when unreleased user-visible work (features, fixes, and especially security patches) has accumulated, and never hold a release hostage to unfinished work: excluding that work is exactly what the branch tool is for. The failure mode to avoid is drift — weeks of unreleased commits held behind one open epic.
+
+**The three channels and their promises:**
+
+| Channel | Identity | Promise |
+|---|---|---|
+| `edge` | none — the commit is the identity | the newest merged code, rebuilt on every merge to `main`; rolling and disposable |
+| rc | `vX.Y.Z-rc.N`, target fixed at cut time | a stabilisation step toward exactly that version, cut only from `release/X.Y` (a fresh stabilisation branch starts at `X.Y.0-rc.1`) |
+| stable | `vX.Y.Z` | a quiescent-trunk release (the default) or the promotion of a stabilisation branch (`finalize`) |
+
+An rc is not "the latest build with a version number" — that job belongs to `edge`, which costs one build-and-push and leaves no tag, release, or version bump behind. Cut rcs only when genuinely stabilising a specific release.
+
+## Unstable channel (rolling `edge` image)
+
+The `Unstable channel` workflow (`.github/workflows/unstable.yml`) runs on every push to `main` (plus manual dispatch for seeding) and rebuilds two artifacts from that commit: the container image, pushed to `ghcr.io/pvliesdonk/image-generation-mcp:edge` — a fixed rolling tag whose contents each merge replaces — and an mcpb bundle built through the same shared `.github/actions/build-mcpb` composite the release path uses, uploaded as the `mcpb-bundle-edge` workflow artifact at the constant version `0.0.0-dev`. The channel is deliberately versionless: no git tag, no GitHub release, no version bump, no manifest change. "Run the latest merged code" costs one build-and-push and leaves nothing behind; the image's `org.opencontainers.image.revision` label carries the exact commit. The docs site's rolling `unstable` version deploys from the same trigger (`docs.yml`), so it tracks merged code the way `edge` does. Cutting a version-numbered pre-release (rc) remains `release.yml`'s job, from a `release/X.Y` branch (see the release machinery section below); rc images ship only under their immutable `vX.Y.Z-rc.N` tags — `edge` is the sole rolling unstable tag.
+
+## Release machinery (branches, rcs, merge-back)
+
+Prerelease-ness is a property of the **branch**, not of a dispatch flag: `[tool.semantic_release.branches]` maps `main` to stable releases and `release/.*` to rc pre-releases (token `rc`), and every publish gate in `release.yml` derives from PSR's own outputs (`is_prerelease`, tag ordering) — there is no pre-release checkbox to desync. Dispatching Release on `main` cuts a stable; on a short-lived `release/X.Y` stabilisation branch it cuts the next rc, or the final stable `X.Y.Z` when the `finalize` input is checked (implemented as a one-run generated config override, because PSR's CLI can force prerelease on but not off). The `force` input is main-only — a release branch's target is fixed at cut time. Branches matching neither group cannot release; PSR refuses them.
+
+Rolling channels are ordering-aware: Docker `latest`/`vX`/`vX.Y`, the GitHub latest-release pointer, the docs `latest` alias, the marketplace entry, and the registry entry only follow a release that is the newest in the relevant series, so a backport patch cut from an old `release/X.Y` never repoints them backwards.
+
+**After any release cut from a `release/*` branch, the branch must merge back into `main`.** The `merge-back` job does this automatically via `scripts/merge_back.sh` (version-coupled files resolve to `main`'s side; real conflicts fail loudly for a manual `git merge --no-ff release/X.Y`). This is a hard requirement, not hygiene: with the release tag unreachable from `main`, PSR recomputes the same version from `main`'s own history, finds the tag taken repo-globally, and reports "already released" forever. When to cut a branch at all — and the default of releasing from a quiescent trunk without one — is the [release model](#release-model) above, not machinery.
+
+<!-- TEMPLATE-TRACKING-START -->
+## Release notes pages
+
+`docs/releases/` is the canonical human-facing release narrative: one page per minor series, patch releases appending a dated section to their series page. The GitHub release body is a summary plus a deep link to the page, and `CHANGELOG.md` stays machine-written — never move narrative prose into it. After every stable release, the **Release Notes** workflow has an agent research the release range through the GitHub API (linked issues and PRs, never commit subjects) and open a PR adding or extending the page; the `writing-release-notes` skill (`.claude/skills/writing-release-notes/SKILL.md`) is the contract it follows. Notes pages always land on `main` via that PR — never by direct push, and never on a `release/*` branch.
+
+Two rules for working with these PRs:
+
+- **The evidence contract governs the page.** Every causal claim must trace to a linked issue or PR; no evidence, no narrative. Review a notes PR as an evidence check — follow the links and verify they support the claims — not as a prose polish; Vale (including the `ai-tells` pack) already gated the prose.
+- **Merging is what publishes.** On merge, the **Release Notes Publish** workflow upgrades the release body from the page's marked summary block and redeploys the minor's versioned docs so the deep link resolves. Notes PRs are tooling-authored and need no separate issue (same class as Renovate bumps).
+<!-- TEMPLATE-TRACKING-END -->
 
 ## Tool Registration Checklist
 
@@ -266,6 +368,10 @@ Every MCP tool you register must carry the full set of metadata below — not ju
 
 For services that talk to a remote upstream (e.g. paperless, an HTTP API), wire the upstream version inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/image_generation_mcp/server.py`. Pass `upstream_version=` (a zero-arg callable returning a dict / str / None) and optionally `upstream_label="<service>"` (default `"upstream"`). The simplest pattern is a module-level upstream client (typically constructed from env vars at import time) whose version method is referenced from the callable — `CurrentContext()` is a FastMCP DI marker that only resolves inside parameter defaults, so it cannot be called directly from a zero-arg provider. The block is preserved across `copier update`.
 
+## Repository protection (rulesets)
+
+`.github/rulesets/*.json` are the source of truth for this repository's branch and tag rulesets — required PRs + the `CI Success` check on `main` and `release/*`, deletion/force-push protection for `v*` tags — and `bootstrap.yml` applies them (upsert by name) on pushes touching those files and on manual dispatch. Never adjust protection in the GitHub UI: the next bootstrap run resets it to the checked-in state. Change the JSON files instead. The release pipeline's `RELEASE_TOKEN` (a repository admin's PAT) bypasses these rules **by design** via the admin-role bypass entry — PSR's release commit + tag push and the merge-back to `main` are direct pushes. Posture and bypass model: `docs/deployment/repository-protection.md`.
+
 <!-- TEMPLATE-TRACKING-START -->
 ## Shared Infrastructure
 
@@ -279,6 +385,8 @@ Fixes and improvements to shared code land in those repos and propagate here via
 ## Contributing fixes upstream
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the three-tier routing (library to `fastmcp-pvl-core`, template to `fastmcp-server-template`, domain to this repo), the issue/PR discipline, and the uncertainty rule. CONTRIBUTING.md is the single source; this section is a pointer.
+
+The `authoring-issues-prs` skill (`.claude/skills/authoring-issues-prs/SKILL.md`) fires when filing issues or PRs: it walks the routing, picks the issue form, and performs the follow-up steps forms cannot (native sub-issue links for epics, the release milestone or `ships-atomically` label). The skill is template-owned and re-rendered on `copier update`; project-specific authoring conventions belong inside its `DOMAIN-AUTHORING` sentinel block.
 
 If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
 <!-- TEMPLATE-TRACKING-END -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,19 @@ Use the issue templates in `.github/ISSUE_TEMPLATE/`:
 
 - **Bug report** — something isn't working as expected.
 - **Feature request** — a new capability or enhancement.
+- **Epic** — a multi-feature effort that ships as one user-facing story.
+  See [Epics](#epics) below.
 - **Decay / structural debt** — refactor-later observations.
 - **Question / support** — questions and support requests.
+
+Before filing, search the target repo's existing issues — open **and**
+closed — for the same observation. If it is already on file, comment there
+rather than opening a duplicate.
+
+The `authoring-issues-prs` skill (`.claude/skills/authoring-issues-prs/`)
+walks this guide's routing and filing procedure and performs the follow-up
+steps issue forms cannot (sub-issue links, milestones). It points back at
+this file; this file stays the single source of the rules.
 
 ### Observation, not work order
 
@@ -55,6 +66,35 @@ a separate issue for it.
 | An "Additional context" section that introduces new problems | Open a separate issue |
 | Implementation steps (a numbered list of code changes) | Remove entirely |
 
+### Epics
+
+An epic is not just a bigger issue. It is the unit that answers two
+questions nothing else answers: **what story does this tell a user**, and
+**does it ship as a whole**. File one with the Epic form and:
+
+- **Write "What changes for the user" at epic creation**, before any code
+  exists. It becomes the release-notes highlight for the whole epic, so the
+  release editor verifies it against what landed instead of reconstructing
+  intent from merged PRs.
+- **Link children as native GitHub sub-issues, not markdown task lists.**
+  Sub-issues make the grouping queryable (parent, children, and progress
+  are API fields); a checklist is prose. Issue forms cannot create the link
+  at filing time — use the issue sidebar ("Create sub-issue" / "Add
+  existing issue") or the sub-issues API after filing. The
+  `authoring-issues-prs` skill performs this mechanically.
+- **If the epic ships atomically** (no release may be cut mid-epic), make
+  that queryable too. Preferred: assign the epic and its children to the
+  **milestone** named for the target release — "safe to cut" then reduces
+  to "no open issues in that milestone". Milestones are per-repo and
+  one-per-issue; for a cross-repo epic the milestone lives in the repo
+  where the release is cut. Fallback: apply the **`ships-atomically`
+  label** when no target release is named yet, or in the repos of a
+  cross-repo epic that do not cut the release. The form's yes/no field
+  records intent; only the milestone or label is what release tooling can
+  query.
+
+Existing epics tracked as hand-written checklists need no migration.
+
 ## Pull requests
 
 Every PR must have at least one associated issue. If the work has no issue
@@ -64,6 +104,13 @@ PR may close multiple issues (`Closes #A, closes #B`); the rule is "no orphan
 PRs", not "one PR per issue". Trivial exceptions: pure typo fixes and
 automated dependency bumps (Renovate) may skip the issue.
 
+Mark a commit breaking (`feat!:` / `BREAKING CHANGE:`) only under the
+breaking-change policy in `CLAUDE.md`: the change must break the operator
+surface (env var, config file, CLI flag, deployment layout, on-disk state)
+or the public library interface, assessed against the **last stable
+release**, not the previous commit. MCP tool-surface changes are not
+breaking on their own.
+
 State what the PR deliberately does **not** do, with each deferral's tracking
 issue. A change that says what it left out is easier to trust than one that
 appears to have found nothing.
@@ -71,6 +118,17 @@ appears to have found nothing.
 Run a local code-review pass on the cumulative diff before `gh pr create`.
 Code without matching docs is incomplete; check `README.md`, the `docs/`
 site, `docs/design/`, and inline docstrings.
+
+## Releases
+
+Merging is not releasing. When a release is cut, and from where, is
+governed by the release model in `CLAUDE.md`: releases normally come
+straight from a quiescent trunk, and a short-lived `release/X.Y` branch
+is the exception tool for excluding unfinished work or patching a
+shipped release. The ships-atomically signal recorded on epics
+(milestone preferred, label fallback; see [Epics](#epics)) is the input
+that judgement consumes: an open atomic epic with unclosed children
+means the release comes from before it started, or waits.
 
 ## Where to send fixes
 

--- a/FORKING.md
+++ b/FORKING.md
@@ -28,7 +28,8 @@ This removes the link copier uses to reattach. The weekly cron that ran
 ```bash
 rm -f .github/workflows/copier-update.yml \
       .github/workflows/claude.yml \
-      .github/workflows/claude-code-review.yml
+      .github/workflows/claude-code-review.yml \
+      .github/workflows/release-notes.yml
 rm -f scripts/copier_update_aggregator.py
 rm -rf scripts/copier_update_prompts
 ```
@@ -37,13 +38,20 @@ What this removes and why:
 
 - `copier-update.yml` — template-update automation; meaningless once detached.
 - `claude.yml`, `claude-code-review.yml` — fleet review-bot wiring.
+- `release-notes.yml` — the Claude-agent release-notes drafter (same
+  `CLAUDE_CODE_OAUTH_TOKEN` dependency as the review wiring). Keep it
+  instead if your fork keeps that secret and wants agent-drafted notes.
 - `scripts/copier_update_aggregator.py`, `scripts/copier_update_prompts/` —
   the orchestration that only `copier-update.yml` invoked; dead weight once
   that workflow is gone.
 
 **Keep** your own CI and release workflows: `ci.yml`, `codeql.yml`,
-`coverage-status.yml`, `docs.yml`, and `release.yml`. (`release.yml` still needs
-the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
+`coverage-status.yml`, `docs.yml`, `release.yml`, and
+`release-notes-publish.yml`. (`release.yml` still needs the `RELEASE_TOKEN`
+secret; only its `copier-update` justification is gone.
+`release-notes-publish.yml` is deterministic — no Claude dependency — and
+still publishes any `docs/releases/` page you write by hand: it upgrades the
+matching release body and redeploys the minor's versioned docs on merge.)
 
 ## Step 3 — Scrub template-tracking guidance from `CLAUDE.md`
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ uv sync --all-extras --all-groups
 docker pull ghcr.io/pvliesdonk/image-generation-mcp:latest
 ```
 
+To run the newest merged code instead of the newest release, use the rolling `edge` tag. It is rebuilt on every merge to `main` and carries no version identity. See [Image tags](docs/deployment/docker.md#image-tags) for the full tag list.
+
+```bash
+docker pull ghcr.io/pvliesdonk/image-generation-mcp:edge
+```
+
 A `compose.yml` ships at the repo root as a starting point. Copy `.env.example` to `.env`, edit, and `docker compose up -d`.
 
 To attach a remote Python debugger (development only; the protocol is unauthenticated), see [Remote debugging](docs/deployment/docker.md#remote-debugging).
@@ -92,6 +98,18 @@ mcpb install image-generation-mcp-<version>.mcpb
 Claude Desktop prompts for required env vars via a GUI wizard, with no manual JSON editing needed.
 
 For manual Claude Desktop configuration and setup options, see [Claude Desktop deployment](docs/deployment/claude-desktop.md).
+
+## Release channels
+
+Artifacts ship on three channels. Each row lists exactly what that channel publishes.
+
+| Channel | Version identity | Artifacts |
+|---|---|---|
+| `edge` (rolling) | None; the commit is the identity | Docker image `:edge` rebuilt on every merge to `main`; `.mcpb` bundle as the `mcpb-bundle-edge` workflow artifact; rolling `unstable` docs version. It leaves no git tag, GitHub release, or PyPI entry behind. |
+| Pre-release | `vX.Y.Z-rc.N`, cut from a `release/X.Y` branch | GitHub release with wheels, `sdist`, `.mcpb` bundle, and SBOM attached; Docker image under its immutable `vX.Y.Z-rc.N` tag only. Skips PyPI, `.deb`/`.rpm` packages, the plugin marketplace, the MCP registry, and the docs deploy. |
+| Stable | `vX.Y.Z` | Everything: PyPI, Docker (version tag plus ordering-aware `latest` / `vX` / `vX.Y`), `.deb`/`.rpm`, GitHub release assets (wheels, `sdist`, `.mcpb` bundle, SBOM), plugin marketplace and MCP registry entries (when the release is the newest stable), versioned docs with an ordering-aware `latest` alias. |
+
+The PyPI split is deliberate: `edge` and pre-release builds never reach PyPI, where every ordinary installer would see them. A pre-release's wheels are still attached to its GitHub release and installable by URL for anyone who opts in. Rolling pointers are ordering-aware, so a patch release cut from an old `release/X.Y` branch never moves `latest`-style tags back to older content. See [Release process](docs/deployment/release-process.md) for the full model.
 
 ## Quick start
 
@@ -141,9 +159,9 @@ CI workflows reference three repository secrets. Configure them via **Settings â
 
 | Secret | Used by | How to generate |
 |---|---|---|
-| `RELEASE_TOKEN` | `release.yml`, `copier-update.yml`, `renovate.yml`, `bootstrap.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write`, `pull_requests: write`, and `administration: write` (bootstrap sets branch protection + auto-merge). Scoped to this repo. |
+| `RELEASE_TOKEN` | `release.yml`, `release-notes.yml`, `copier-update.yml`, `renovate.yml`, `bootstrap.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write`, `pull_requests: write`, and `administration: write` (bootstrap applies the repository rulesets + auto-merge). Must belong to a repository admin: the shipped rulesets grant bypass to the admin role, and the release workflow's direct pushes rely on it. Scoped to this repo. |
 | `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io>: sign in with GitHub and add the repo. The upload token is on its settings page. |
-| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml`, `release-notes.yml` | Run `claude setup-token` locally and paste the result. |
 
 ```bash
 gh secret set RELEASE_TOKEN
@@ -153,9 +171,11 @@ gh secret set CLAUDE_CODE_OAUTH_TOKEN
 
 > Dependency updates are handled by **Renovate** (`renovate.yml`), which reuses
 > `RELEASE_TOKEN`. It maintains `uv.lock` and auto-merges patch/minor bumps once
-> the `CI Success` check is green; `bootstrap.yml` enables auto-merge and branch
-> protection on first push. GitHub Actions are updated in the copier template
-> and arrive via `copier update`, not per-repo.
+> the `CI Success` check is green; `bootstrap.yml` enables auto-merge and applies
+> the repository rulesets (`.github/rulesets/`) on first push. See
+> [Repository Protection](docs/deployment/repository-protection.md) for the
+> per-branch posture and bypass model. GitHub Actions are updated in the copier
+> template and arrive via `copier update`, not per-repo.
 
 `GITHUB_TOKEN` is auto-provided; no action needed.
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -8,6 +8,22 @@ docker compose up -d
 
 The server listens on port 8000 with HTTP transport by default.
 
+## Image tags
+
+| Tag | Contents | Updated by |
+|-----|----------|------------|
+| `latest` | Newest stable release | Each stable release that is newest across all series |
+| `vX.Y.Z` | That exact release (pre-releases included, as `vX.Y.Z-rc.N`) | Never (immutable) |
+| `vX.Y`, `vX` | Newest stable release in that series | Each stable release that is newest in its series |
+| `edge` | Newest commit on `main` | Every merge to `main` |
+
+Rolling tags are ordering-aware: a patch release cut from an old `release/X.Y` branch after a newer stable has shipped updates its own series tags but never `latest`. A pre-release pushes only its immutable `vX.Y.Z-rc.N` tag. To run the latest merged code, use `edge`, which follows `main` continuously and carries no version identity. To find the commit behind an `edge` image, read its `org.opencontainers.image.revision` label:
+
+```bash
+docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+  ghcr.io/pvliesdonk/image-generation-mcp:edge
+```
+
 ## Environment variables
 
 | Variable | Default | Description |

--- a/docs/deployment/release-process.md
+++ b/docs/deployment/release-process.md
@@ -1,0 +1,95 @@
+# Release Process
+
+`main` is trunk: every change merges there, and merging is not releasing.
+A merge feeds the rolling `edge` channel and nothing else. A release is a
+separate, deliberate event, cut by dispatching the **Release** workflow,
+and this page describes what each kind of release publishes and where
+releases come from.
+
+## Channels
+
+| Channel | Version identity | What it promises |
+|---|---|---|
+| `edge` | None; the commit is the identity | The newest merged code. Every merge to `main` rebuilds the rolling Docker tag plus an `.mcpb` bundle workflow artifact, and the rolling `unstable` docs version deploys from the same trigger. It leaves no git tag, GitHub release, or PyPI entry behind. |
+| Pre-release | `vX.Y.Z-rc.N`, fixed at cut time | A stabilisation step toward exactly that version, cut from a `release/X.Y` branch. Publishes a GitHub release with wheels, `sdist`, `.mcpb` bundle, and SBOM attached, plus a Docker image under its immutable version tag. Skips PyPI, `.deb`/`.rpm` packages, the marketplace and registry entries, and the docs deploy. |
+| Stable | `vX.Y.Z` | The full artifact set: PyPI, Docker, Linux packages, GitHub release assets (wheels, `sdist`, `.mcpb` bundle, SBOM), marketplace and registry entries, versioned docs. |
+
+Pre-release and `edge` builds never reach PyPI: PyPI is where every
+ordinary installer looks, and unstable builds do not belong in front of
+it. A pre-release's wheels are still attached to its
+[GitHub release](https://github.com/pvliesdonk/image-generation-mcp/releases)
+and installable by URL for anyone who opts in.
+
+Rolling pointers are ordering-aware. The Docker `latest`, `vX`, and `vX.Y`
+tags, the GitHub latest-release pointer, the docs `latest` alias, and the
+marketplace and registry entries follow a release only when it is the
+newest in the relevant series, so a patch release cut from an old
+`release/X.Y` branch never moves them back to older content. See
+[Image tags](docker.md#image-tags) for the Docker tag list.
+
+## Releasing from trunk
+
+The default release path is trunk. When trunk is quiescent (no epic that
+must ship whole is mid-flight), dispatching Release on `main` cuts a
+stable from the head commit: no branch, no ceremony. The workflow prints
+an advisory warning when a release-named milestone still has open issues,
+or when an open `ships-atomically` epic shows work in flight. It counts the
+epic's native sub-issues, which may live in another repository, so a
+cross-repo epic stays visible. Either way the warning never blocks, since
+the cut may still be intentional.
+
+## Stabilisation branches
+
+A short-lived `release/X.Y` branch is the exception tool, for two cases:
+
+1. **Trunk carries unfinished work** that the release must exclude. The
+   branch is cut from the last quiescent commit behind the head, release candidates are
+   cut there while fixes land, and the `finalize` dispatch input cuts the
+   final stable `X.Y.Z`.
+2. **A shipped release needs a patch** while `main` has moved on. The
+   branch can be created retroactively from the release tag, so no branch
+   needs to exist in advance of the need.
+
+Fixes flow from trunk to the branch: they land on `main` first and are
+cherry-picked over. After any release cut from a `release/X.Y` branch, an
+automated merge-back job merges the branch into `main`; that merge is the
+single reverse flow, and it carries only the release machinery's version
+commits, never features.
+
+Release branches carry shipped releases, so they get the same protection
+as `main`: pull requests plus green CI, applied by the shipped rulesets.
+See [Repository Protection](repository-protection.md).
+
+## Where to read about a release
+
+Each release is described in three places with distinct jobs:
+
+- **The GitHub release body** carries a short user-facing summary and a
+  link to the release's notes page on this site. The body is a pointer,
+  not the record.
+- **The release notes pages on this docs site** are the canonical
+  human-facing narrative of what changed and why it matters.
+- **`CHANGELOG.md`** in the repository is the machine-written,
+  commit-level audit trail, generated from conventional commits by the
+  release tooling.
+
+### How the notes pages are produced
+
+The pages under [Release Notes](../releases/index.md) cover one minor
+series each; a patch release adds a dated section to its series page.
+After every stable release, the **Release Notes** workflow drafts the
+page: an agent researches the release range through the GitHub API (the
+linked issues and pull requests, not commit subjects) and opens a pull
+request against `main`. Every causal claim in a page must cite a linked
+issue or pull request. The drafting agent runs the same prose lint as the
+rest of this site while it writes, and the notes pull request's own CI
+enforces it: the `vale` job must pass before the pull request can merge,
+the same gate every change to this site clears.
+
+A maintainer merge is the publication step. Nothing lands on the site
+without review, and until the merge the release keeps the short interim
+body the release workflow wrote; a failed or unconvincing draft never
+blocks or alters a release. On merge, the **Release Notes Publish**
+workflow updates the GitHub release body from the page's summary and
+redeploys that minor's versioned docs so the body's deep link resolves.
+Later hand edits to a merged page redeploy the docs the same way.

--- a/docs/deployment/repository-protection.md
+++ b/docs/deployment/repository-protection.md
@@ -1,0 +1,110 @@
+# Repository Protection
+
+The template ships GitHub repository rulesets that gate the branches a
+release can ship from. The rules live as JSON files in `.github/rulesets/`
+and the `bootstrap.yml` workflow applies them, so the effective protection
+state is checked in, reviewed, and re-applied rather than clicked together
+in the UI and forgotten.
+
+## What ships
+
+Three rulesets, one file each:
+
+| Ruleset | Targets | Rules |
+|---|---|---|
+| `protect-main` | the default branch | pull request required (zero approvals), `CI Success` status check (strict), no deletion, no force push |
+| `protect-release-branches` | `release/*` branches | same gates as the default branch |
+| `protect-release-tags` | `v*` tags | no deletion, no force move (creation stays open) |
+
+The reasoning per branch class:
+
+- **`main`** requires a pull request and the aggregate `CI Success` check.
+  Zero required approvals is deliberate: a solo-maintainer account has no
+  second reviewer, and requiring one would deadlock the Renovate
+  patch/minor auto-merge. The pull request requirement still routes every
+  change through CI and the review tooling; the check requirement is what
+  holds an auto-merge until CI is green.
+- **`release/*`** stabilisation branches carry a shipped release for their
+  lifetime, so backports get the same gate class as `main`: pull request
+  plus `CI Success`, with the CI structural gate measuring the diff against
+  the release branch itself rather than `main`. The generated `ci.yml` runs
+  on pull requests targeting `release/*` for exactly this reason. Status
+  checks are not enforced on branch creation, so cutting `release/X.Y` is a
+  plain push.
+- **`v*` tags** are the identity of every shipped release: package
+  registries, Docker tags, and install instructions all point at them.
+  The ruleset blocks deleting or force-moving them. Creating tags stays
+  unrestricted because the release workflow creates one per release.
+
+## Who bypasses, and how
+
+Ruleset bypass lists name roles, teams, apps, or deploy keys, not user
+accounts. The shipped entry grants bypass to the **repository admin role**
+(`actor_id` 5, the one actor a template can name without knowing your
+account), with `bypass_mode: always`.
+
+The release flow depends on this. `RELEASE_TOKEN` is a personal access
+token, and a personal access token (classic or fine-grained) acts as its
+owner and holds the repository role of that owner. With the token owned by
+a repository admin, all of the release pipeline's direct pushes bypass the
+rules:
+
+- the release commit and `vX.Y.Z` tag that python-semantic-release pushes
+  to the released branch (`main` or `release/X.Y`),
+- the merge-back merge commit pushed to `main` after a release cut from a
+  `release/*` branch,
+- the owner's own hotfix pushes, preserving the escape hatch the previous
+  classic protection provided via its disabled admin enforcement.
+
+Two clean-up operations the release model implies depend on this bypass
+too. `protect-release-branches` blocks deleting a `release/X.Y` branch, and
+`protect-release-tags` blocks deleting a `v*` tag, yet a stabilisation
+branch is short-lived, and the `Pre-release check` workflow describes its
+`v<version>-rc` pre-release as safe to delete. Both deletions are available
+only to the admin role, through the same bypass. A `RELEASE_TOKEN` that is
+not owned by a repository admin cannot perform them, and those spent
+branches and pre-release tags then accumulate until an admin removes them.
+
+Everyone below admin, including outside collaborators, write-role
+contributors, and any workflow using the default `GITHUB_TOKEN`, goes
+through a pull request with green CI.
+
+If your release credential is a GitHub App installation token rather than
+a personal access token, the role-based entry does not cover it: add a
+bypass actor with `actor_type: Integration` and the app id to each
+ruleset file.
+
+## The files own the state
+
+`bootstrap.yml` upserts each ruleset by name: it updates the existing
+ruleset when one matches and creates it otherwise, replacing the whole
+ruleset with the checked-in state every time. Edits made by hand in the
+GitHub UI are reset on the next run, so change the JSON files instead. A
+push that touches `.github/rulesets/` or the bootstrap workflow re-applies
+automatically; `workflow_dispatch` re-applies on demand. Rulesets with
+other names are never touched, so you can add your own alongside.
+
+The apply step needs `administration: write`, a permission the default
+`GITHUB_TOKEN` cannot be granted, so it runs with `RELEASE_TOKEN`,
+matching the permission set the README already asks for.
+
+## Applying by hand
+
+Without the bootstrap workflow (or when importing into another repository):
+
+```bash
+gh api -X POST "repos/OWNER/REPO/rulesets" \
+  --input .github/rulesets/protect-main.json
+```
+
+or import each file in the UI under **Settings → Rules → Rulesets →
+New ruleset → Import a ruleset**. The JSON files use the same schema the
+UI exports.
+
+## Plan limits
+
+GitHub enforces rulesets on public repositories on every plan; private
+repositories need a paid plan. On a Free-plan private repository the
+ruleset API rejects the apply and the `settings` job fails; the labels
+job still runs, and the rulesets take effect once the repository is public
+or the plan allows enforcement.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,13 @@
+# Release Notes
+
+Each minor release series gets one page here telling its story: what
+changed, why it matters, and how to adopt it. Patch releases add a dated
+section to their series page, so a series stays one linkable document.
+The commit-level record lives in the repository's `CHANGELOG.md`; each
+GitHub release links back to its page here.
+
+<!-- RELEASE-PAGES-START: newest series first; one list entry per page.
+     The first real entry replaces the placeholder line below. -->
+No release pages yet. The first entry appears with the first stable
+release cut after this project adopted release-notes pages.
+<!-- RELEASE-PAGES-END -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,10 @@ plugins:
           - deployment/docker.md: Docker Compose, Traefik, volumes
           - deployment/systemd.md: Systemd service, .deb/.rpm packages, security hardening
           - deployment/oidc.md: OIDC authentication setup
+        # Glob deliberately: each minor's release-notes page is auto-indexed
+        # without a sections-list update (same rationale as guides/*).
+        Release Notes:
+          - releases/*.md
         # PROJECT-LLMSTXT-SECTIONS-END
   - mkdocstrings:
       handlers:
@@ -162,4 +166,10 @@ nav:
       - Systemd: deployment/systemd.md
       - OIDC Authentication: deployment/oidc.md
       - Claude Desktop: deployment/claude-desktop.md
+      - Release Process: deployment/release-process.md
+      - Repository Protection: deployment/repository-protection.md
+  # Landing page only, deliberately: per-minor pages stay out of nav so a new
+  # release never needs a nav edit (mkdocs treats not-in-nav pages as INFO,
+  # so `--strict` stays green); the landing page and search link them.
+  - Release Notes: releases/index.md
   # PROJECT-NAV-END

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,9 +279,66 @@ assets = [
 
 ]
 
+# Branch groups: prerelease-ness is a property of the BRANCH, not of a
+# dispatch flag.  `main` always releases stable; a short-lived `release/X.Y`
+# stabilisation branch releases rcs by default, with the release workflow's
+# `finalize` input cutting the final stable X.Y.Z from the branch (it
+# generates a one-run config override, since PSR's CLI can force prerelease
+# ON but not OFF).  A branch matching neither pattern cannot release at all —
+# PSR refuses, which is the desired guard.  After ANY release cut from a
+# `release/*` branch, the branch must merge back into `main` (the release
+# workflow's merge-back job): with the tag unreachable from `main`, PSR
+# computes the same version from `main`'s own history, finds the tag taken
+# repo-globally, and reports "already released" forever.
+[tool.semantic_release.branches.main]
+match = "(main|master)"
+prerelease = false
+
+[tool.semantic_release.branches.release]
+match = "release/.*"
+prerelease = true
+prerelease_token = "rc"
+
+# PSR's changelog runs in `update` mode (the v10 default, pinned here so the
+# contract is visible): each release inserts its version section at the
+# insertion flag in CHANGELOG.md and preserves everything else in the file
+# verbatim.  Both halves are explicit because the flag is load-bearing — a
+# changelog without the flag line is silently never written (template#350).
+# CHANGELOG.md is seeded with the flag; a project whose CHANGELOG.md predates
+# it must add the flag line once, by hand (tests/test_release_contract.py
+# fails with the exact line until it is present).
 [tool.semantic_release.changelog]
+mode = "update"
+insertion_flag = "<!-- version list -->"
+
+# `changelog_file` lives under `default_templates` (its supported location
+# since PSR v9.11); the bare `changelog.changelog_file` key is deprecated.
+[tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.commit_parser_options]
+# The accepted commit types, stated explicitly rather than left to the
+# parser's default, because this list is one half of a contract: CI's
+# `PR Title` job runs scripts/check_pr_title.py against the same set, and
+# tests/test_commit_conventions.py fails when the two halves disagree.
+#
+# Getting a type wrong is not a cosmetic problem. A subject whose type is not
+# listed here does not parse, and PSR then omits the commit from CHANGELOG.md
+# entirely — no fallback heading, no warning. `revert` is added on top of the
+# parser's own default set for exactly that reason: reverts belong in the
+# audit trail, and the default drops them.
+allowed_tags = [
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "revert",
+    "style",
+    "test",
+]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended", ":dependencyDashboard"],
   "labels": ["dependencies"],
   "enabledManagers": ["pep621"],
+  "semanticCommits": "enabled",
   "rangeStrategy": "update-lockfile",
   "lockFileMaintenance": {
     "enabled": true,

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -10,6 +10,16 @@ commit — which is the commit it then tags.
 The script runs inside PSR's Docker action container (python:3.14-slim), which
 has Python but no ``jq`` — hence Python rather than a shell+jq wrapper.
 
+Pre-releases are handled differently (#345): the release workflow's
+``publish-pypi`` and ``publish-registry`` jobs (and the marketplace publish)
+all skip pre-releases, so a pre-release version never exists on PyPI or the
+MCP registry.  Manifests whose version fields name a *published* artifact —
+``server.json`` and the Claude Code plugin pair — are therefore left at the
+last published stable on pre-release runs, and the next stable release
+re-bumps them.  Only ``uv.lock`` is refreshed unconditionally: it tracks
+``pyproject.toml``, not PyPI, and letting it lag would break ``uv lock
+--check`` on the release commit.
+
 This file is TEMPLATE-OWNED: it re-renders on every ``copier update``, so a
 fix to the shared bumpers (``server.json``, ``uv.lock``) arrives whole rather
 than half — the ``assets`` half landing in the re-rendered ``pyproject.toml``
@@ -45,6 +55,82 @@ def _dump(path: Path, data: Any) -> None:
         # jq's default behavior and how a human editor would save the file.
         json.dump(data, fh, indent=2, ensure_ascii=False)
         fh.write("\n")
+
+
+def _is_prerelease(version: str) -> bool:
+    """Return True unless ``version`` is a plain stable ``X.Y.Z``.
+
+    PSR (``tag_format = "v{version}"``, ``prerelease_token: rc``) emits
+    stable versions as ``X.Y.Z`` and pre-releases in SemVer form as
+    ``X.Y.Z-rc.N``.  The check is deliberately conservative: anything that
+    is not a plain three-component release (a pre-release, a build tag, an
+    unexpected format) keeps the PyPI-referencing pins at the last published
+    stable instead of pinning a version that may never exist on PyPI.
+    Stdlib-only on purpose — PSR's container Python has no guaranteed
+    ``packaging`` install.
+    """
+    return re.fullmatch(r"\d+\.\d+\.\d+", version) is None
+
+
+def _bump_server_json(version: str) -> int:
+    """Bump ``server.json``: top-level version, PyPI package version, OCI tag.
+
+    Called for stable releases only — both version fields name artifacts that
+    are published exclusively for stable releases, so pre-release runs leave
+    the file at the last published stable (see ``main()``).  Replace only the
+    ``:v<old>`` suffix of the OCI identifier so forks/renames keep their own
+    ``ghcr.io/<owner>/<image>`` base.  Returns a process exit code.
+    """
+    server_path = Path("server.json")
+    if not server_path.exists():
+        print(
+            f"server.json not found in {Path.cwd()} — run from repo root",
+            file=sys.stderr,
+        )
+        return 1
+    server = _load(server_path)
+    if not isinstance(server, dict):
+        print(
+            f"{server_path} must contain a JSON object (top-level), "
+            f"got {type(server).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+    server["version"] = version
+    packages = server.get("packages", [])
+    if not isinstance(packages, list):
+        print(
+            f"{server_path}: 'packages' must be a JSON array, got "
+            f"{type(packages).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+    for i, pkg in enumerate(packages):
+        if not isinstance(pkg, dict):
+            print(
+                f"WARNING: packages[{i}] is not a JSON object "
+                f"(got {type(pkg).__name__}) — skipped",
+                file=sys.stderr,
+            )
+            continue
+        if pkg.get("registryType") == "pypi":
+            pkg["version"] = version
+        elif pkg.get("registryType") == "oci":
+            # ``or ""`` covers both the absent-key and the JSON-null cases;
+            # ``dict.get(key, default)`` only returns default when the key
+            # is absent, not when the value is None.
+            identifier = pkg.get("identifier") or ""
+            new_id, n = re.subn(r":v[^:]+$", f":v{version}", identifier)
+            if n == 0:
+                print(
+                    f"WARNING: OCI identifier {identifier!r} has no ':v<tag>' "
+                    "suffix to bump — left unchanged",
+                    file=sys.stderr,
+                )
+            pkg["identifier"] = new_id
+    _dump(server_path, server)
+    print(f"bump_manifests: server.json → {version}")
+    return 0
 
 
 def _bump_lockfile(version: str) -> None:
@@ -104,63 +190,27 @@ def main() -> int:
         )
         return 1
 
-    # server.json: top-level version, PyPI package version, OCI tag suffix.
-    # Replace only the ``:v<old>`` suffix of the OCI identifier so forks/renames
-    # keep their own ``ghcr.io/<owner>/<image>`` base.
-    server_path = Path("server.json")
-    if not server_path.exists():
+    prerelease = _is_prerelease(version)
+    if prerelease:
+        # Pre-releases skip publish-pypi / publish-registry / the marketplace
+        # publish, so rewriting the manifests that name a published artifact
+        # would pin a version that never exists there (#345).  Leave them at
+        # the last published stable; the next stable release re-bumps them.
         print(
-            f"server.json not found in {Path.cwd()} — run from repo root",
-            file=sys.stderr,
+            f"bump_manifests: {version} is a pre-release — "
+            "server.json left at the last published stable"
         )
-        return 1
-    server = _load(server_path)
-    if not isinstance(server, dict):
-        print(
-            f"{server_path} must contain a JSON object (top-level), "
-            f"got {type(server).__name__}",
-            file=sys.stderr,
-        )
-        return 1
-    server["version"] = version
-    packages = server.get("packages", [])
-    if not isinstance(packages, list):
-        print(
-            f"{server_path}: 'packages' must be a JSON array, got "
-            f"{type(packages).__name__}",
-            file=sys.stderr,
-        )
-        return 1
-    for i, pkg in enumerate(packages):
-        if not isinstance(pkg, dict):
-            print(
-                f"WARNING: packages[{i}] is not a JSON object "
-                f"(got {type(pkg).__name__}) — skipped",
-                file=sys.stderr,
-            )
-            continue
-        if pkg.get("registryType") == "pypi":
-            pkg["version"] = version
-        elif pkg.get("registryType") == "oci":
-            # ``or ""`` covers both the absent-key and the JSON-null cases;
-            # ``dict.get(key, default)`` only returns default when the key
-            # is absent, not when the value is None.
-            identifier = pkg.get("identifier") or ""
-            new_id, n = re.subn(r":v[^:]+$", f":v{version}", identifier)
-            if n == 0:
-                print(
-                    f"WARNING: OCI identifier {identifier!r} has no ':v<tag>' "
-                    "suffix to bump — left unchanged",
-                    file=sys.stderr,
-                )
-            pkg["identifier"] = new_id
-    _dump(server_path, server)
-
-    print(f"bump_manifests: server.json → {version}")
+    else:
+        rc = _bump_server_json(version)
+        if rc != 0:
+            return rc
     _bump_lockfile(version)
     # DOMAIN-MANIFESTS-START — bump this project's extra versioned manifests
-    # here; `version` is the new version string, and the repo root is the cwd.
-    # Every path touched here must also be listed in `pyproject.toml`
+    # here; `version` is the new version string, `prerelease` says whether it
+    # is a pre-release, and the repo root is the cwd.  A manifest that names a
+    # published artifact (a PyPI pin, a registry entry) should follow the same
+    # rule as the template's own bumps: skip the rewrite when `prerelease` is
+    # true.  Every path touched here must also be listed in `pyproject.toml`
     # `[tool.semantic_release] assets`, or PSR leaves it out of the release
     # commit.  Kept across copier update; everything outside these markers is
     # template-owned and re-rendered, which is what keeps the bumpers above in

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Check a pull-request title against the conventional-commit type set.
+
+A squash merge takes the pull-request title as the resulting commit subject,
+so the title is the last point at which a subject can be corrected before it
+reaches ``main``.  That matters more than style: python-semantic-release
+builds its subject regex from the types listed in ``pyproject.toml``'s
+``[tool.semantic_release.commit_parser_options] allowed_tags``, and a subject
+whose type is not among them fails to parse and is dropped from the generated
+``CHANGELOG.md`` entirely -- not filed under a fallback heading, absent.  The
+release audit trail is only as complete as the subjects feeding it.
+
+The type list below and ``allowed_tags`` are two halves of one contract.
+``tests/test_commit_conventions.py`` fails when they disagree, so neither half
+can drift alone.
+
+Usage::
+
+    python3 scripts/check_pr_title.py "feat(search): add hybrid ranking"
+    python3 scripts/check_pr_title.py --list
+
+Exits 0 when the title conforms, 1 otherwise, after printing a GitHub
+workflow error annotation naming the accepted types.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+#: Commit types this project accepts, kept in agreement with
+#: ``[tool.semantic_release.commit_parser_options] allowed_tags``.
+ALLOWED_TYPES: tuple[str, ...] = (
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "revert",
+    "style",
+    "test",
+)
+
+# Mirrors python-semantic-release's angular parser: an optional
+# parenthesised scope, an optional `!` breaking marker, a colon, whitespace,
+# then a non-empty subject.  Case-sensitive, as the parser is.
+_TITLE_RE = re.compile(
+    r"^(?P<type>[A-Za-z]+)"
+    r"(?:\((?P<scope>[^()\n]+)\))?"
+    r"(?P<breaking>!)?"
+    r":[ \t]+"
+    r"(?P<subject>\S.*)$"
+)
+
+# `git revert` and GitHub's revert button both produce `Revert "<original>"`.
+# That is the wider ecosystem's shape, not a GitHub quirk, and Conventional
+# Commits deliberately leaves revert handling open -- so it is accepted rather
+# than second-guessed.  The greedy `.+` also accepts the stacked form a revert
+# of a revert produces: `Revert "Revert "feat: x""`.
+#
+# It does carry a cost, and the caller is told about it rather than left to
+# find out: python-semantic-release has no revert handling in any parser (both
+# `angular` and `conventional` return ParseError for this shape), so a commit
+# with this subject does not reach CHANGELOG.md.  The release-notes page is
+# where such a change gets narrated -- its research runs off merged pull
+# requests and linked issues, not commit subjects.
+_GIT_REVERT_RE = re.compile(r'^Revert\s+".+"\s*$')
+
+_TYPES_LINE = ", ".join(ALLOWED_TYPES)
+
+_HOW_TO_FIX = (
+    "Retitle the pull request, then re-run this job -- it reads the current "
+    "title from the API, so no push is needed."
+)
+
+
+def _example() -> str:
+    return (
+        "Accepted shape: type(optional-scope)!: subject\n"
+        "  feat(search): add hybrid ranking\n"
+        "  fix: stop the writer thread on shutdown\n"
+        "  feat(config)!: drop the deprecated env alias\n"
+        f"Accepted types: {_TYPES_LINE}"
+    )
+
+
+#: Emitted for an accepted title that the release parser still cannot read.
+REVERT_CAVEAT = (
+    'Accepted: this is the Revert "..." form git and GitHub generate. '
+    "python-semantic-release cannot parse it, though, so the commit will not "
+    "appear in CHANGELOG.md. Title it 'revert: ORIGINAL SUBJECT' instead if "
+    "you want it there; either way the release-notes page narrates it, since "
+    "that research runs off merged pull requests rather than commit subjects."
+)
+
+
+def is_git_revert(title: str) -> bool:
+    """Report whether a title is the ``Revert "..."`` form git generates.
+
+    Args:
+        title: The pull-request title, as GitHub reports it.
+
+    Returns:
+        ``True`` for the git/GitHub revert shape, including the stacked form
+        a revert of a revert produces (``Revert`` applied twice).
+    """
+    return _GIT_REVERT_RE.match(title.strip()) is not None
+
+
+def check_title(title: str) -> str | None:
+    """Validate a pull-request title.
+
+    Args:
+        title: The pull-request title, as GitHub reports it.
+
+    Returns:
+        ``None`` when the title conforms, otherwise a multi-line explanation
+        of what is wrong and how to fix it.
+    """
+    stripped = title.strip()
+    if not stripped:
+        return f"The pull-request title is empty.\n{_example()}\n{_HOW_TO_FIX}"
+
+    if is_git_revert(stripped):
+        return None
+
+    match = _TITLE_RE.match(stripped)
+    if not match:
+        return (
+            "The pull-request title is not a conventional-commit subject.\n"
+            f"{_example()}\n{_HOW_TO_FIX}"
+        )
+
+    commit_type = match.group("type")
+    if commit_type not in ALLOWED_TYPES:
+        lowered = commit_type.lower()
+        hint = ""
+        if lowered in ALLOWED_TYPES:
+            hint = f"\nTypes are case-sensitive; use {lowered!r}, not {commit_type!r}."
+        return (
+            f"{commit_type!r} is not an accepted commit type. A subject with "
+            "an unrecognised type is dropped from CHANGELOG.md without a "
+            "warning.\n"
+            f"Accepted types: {_TYPES_LINE}{hint}\n{_HOW_TO_FIX}"
+        )
+
+    return None
+
+
+def main(argv: list[str]) -> int:
+    """Run the check.
+
+    Args:
+        argv: Command-line arguments without the program name. Either
+            ``["--list"]`` or a single pull-request title.
+
+    Returns:
+        Process exit status: 0 when the title conforms, 1 otherwise.
+    """
+    if argv == ["--list"]:
+        print("\n".join(ALLOWED_TYPES))
+        return 0
+    if len(argv) != 1:
+        print("usage: check_pr_title.py [--list | TITLE]", file=sys.stderr)
+        return 2
+
+    problem = check_title(argv[0])
+    if problem is None:
+        print(f"Pull-request title OK: {argv[0]}")
+        if is_git_revert(argv[0]):
+            print(REVERT_CAVEAT)
+            print(f"::warning title=Revert title::{REVERT_CAVEAT}")
+        return 0
+
+    print(problem, file=sys.stderr)
+    summary = problem.splitlines()[0]
+    print(f"::error title=Pull-request title::{summary}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/merge_back.sh
+++ b/scripts/merge_back.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Merge a release branch back into the currently checked-out branch (normally
+# the default branch) after a release was cut from it.
+#
+# Why this exists: after any release cut from a release/X.Y branch, the new
+# tag is unreachable from main until the branch merges back.  PSR's
+# already-released check is repo-global while its version computation is
+# ancestry-scoped, so an unmerged branch release deadlocks main — PSR
+# recomputes the same version from main's own history, finds the tag taken,
+# and reports "already released" forever.  The release workflow's merge-back
+# job runs this script; it is also safe to run by hand from a main checkout.
+#
+# Conflict policy: version-coupled files (pyproject.toml, the changelog, and
+# every [tool.semantic_release] asset) resolve to the CURRENT branch's side —
+# main is authoritative for current version metadata, and the release tag
+# preserves the branch's own state.  Any other conflict means real divergence
+# a human must look at: the merge is aborted, the tree left clean, and the
+# script exits non-zero.
+#
+# Usage: merge_back.sh <release-ref> <tag>
+#   release-ref  the branch to merge back, e.g. origin/release/4.0
+#   tag          the tag just released from it (commit-message context only)
+#
+# Requires python3 >= 3.11 (tomllib) to read the asset list from
+# pyproject.toml, so the file list can never drift from what PSR stages.
+set -euo pipefail
+
+release_ref="${1:?usage: merge_back.sh <release-ref> <tag>}"
+tag="${2:?usage: merge_back.sh <release-ref> <tag>}"
+
+if git merge-base --is-ancestor "$release_ref" HEAD; then
+    echo "merge_back: ${release_ref} is already reachable from HEAD; nothing to do"
+    exit 0
+fi
+
+coupled="$(python3 - <<'PY'
+import tomllib
+
+with open("pyproject.toml", "rb") as fh:
+    cfg = tomllib.load(fh)["tool"]["semantic_release"]
+files = {"pyproject.toml"}
+changelog_cfg = cfg.get("changelog", {})
+files.add(
+    changelog_cfg.get("default_templates", {}).get("changelog_file")
+    or changelog_cfg.get("changelog_file")  # pre-v9.11 deprecated location
+    or "CHANGELOG.md"
+)
+files.update(str(asset) for asset in cfg.get("assets", []))
+print("\n".join(sorted(files)))
+PY
+)"
+
+if ! git merge --no-ff --no-commit "$release_ref"; then
+    while IFS= read -r f; do
+        if git ls-files --unmerged -- "$f" | grep -q .; then
+            if git checkout --ours -- "$f" 2>/dev/null; then
+                git add -- "$f"
+            fi
+        fi
+    done <<<"$coupled"
+    remaining="$(git diff --name-only --diff-filter=U)"
+    if [ -n "$remaining" ]; then
+        echo "merge_back: conflicts outside the version-coupled files need a human:" >&2
+        printf '%s\n' "$remaining" >&2
+        git merge --abort
+        exit 1
+    fi
+fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+git commit -m "chore(release): merge ${release_ref#origin/} back into ${current_branch} after ${tag}"

--- a/scripts/structural_gate.sh
+++ b/scripts/structural_gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Structural diff gate — the ONE implementation shared by the pre-push hook
+# (.pre-commit-config.yaml) and ci.yml's `structure` job, so the command and
+# its ruff selection cannot drift between the two.
+#
+# Compare-branch resolution, in order:
+#   1. STRUCTURAL_GATE_BASE — explicit override; CI sets it to the PR's
+#      actual base (origin/<base_ref>).
+#   2. Derived: the nearest base among origin/main and origin/release/*,
+#      picked by most-recent merge-base with HEAD.  A feature branch off main
+#      resolves to origin/main; a backport branch off release/X.Y resolves to
+#      origin/release/X.Y, so backport PRs are measured against the branch
+#      they actually target instead of an ever-growing diff vs main.
+#   3. origin/main, when nothing else resolves (fresh clone, no remotes).
+set -euo pipefail
+
+base="${STRUCTURAL_GATE_BASE:-}"
+if [ -z "$base" ]; then
+    best_ts=0
+    for ref in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/main 'refs/remotes/origin/release/*'); do
+        mb="$(git merge-base HEAD "$ref" 2>/dev/null)" || continue
+        ts="$(git log -1 --format=%ct "$mb")"
+        # Strict > prefers the earlier-listed origin/main on a timestamp tie.
+        if [ "$ts" -gt "$best_ts" ]; then
+            best_ts="$ts"
+            base="$ref"
+        fi
+    done
+fi
+base="${base:-origin/main}"
+
+# Test seam: print the resolved base and exit, so the derivation is testable
+# without diff-quality or a venv (see tests/test_structural_gate.py).
+if [ -n "${STRUCTURAL_GATE_PRINT_BASE:-}" ]; then
+    printf '%s\n' "$base"
+    exit 0
+fi
+
+# No Python in the diff → nothing for the gate to measure (mirrors the
+# diff-cover guard; the pre-push hook also skips via `types: [python]`).
+has_py="$(git diff --name-only "${base}...HEAD" | grep -c '\.py$' || true)"
+if [ "$has_py" -eq 0 ]; then
+    echo "No Python source changes — skipping structural diff gate"
+    exit 0
+fi
+
+echo "structural gate: comparing against ${base}"
+uv run diff-quality --violations=ruff.check \
+    --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
+    --compare-branch="${base}" --fail-under=100

--- a/tests/public_import_surface.txt
+++ b/tests/public_import_surface.txt
@@ -1,0 +1,13 @@
+# Public import surface of the `image_generation_mcp` package root — one name
+# per line, sorted.  `#` lines and blank lines are ignored.
+#
+# Project-owned (seeded once by the template, never re-rendered), consumed by
+# the template-owned tests/test_import_surface.py.  Regenerate with:
+#
+#     uv run python tests/test_import_surface.py --update
+#
+# Removing a name from this file is a breaking change to the public library
+# interface: the commit that does it must be marked breaking (`feat!:` /
+# `fix!:`, or a `BREAKING CHANGE:` footer) per the versioning policy
+# (pvliesdonk/fastmcp-server-template#342).
+PackageNotFoundError

--- a/tests/test_commit_conventions.py
+++ b/tests/test_commit_conventions.py
@@ -1,0 +1,146 @@
+"""Guards for the commit-type contract between PSR, CI, and the docs.
+
+Three places name the accepted commit types: `pyproject.toml`'s
+`[tool.semantic_release.commit_parser_options] allowed_tags` (what
+python-semantic-release will parse), `scripts/check_pr_title.py` (what CI
+rejects before a squash merge turns a title into a subject), and `CLAUDE.md`
+(what a contributor reads). Let any one drift and the failure is silent: PSR
+does not warn about a subject it cannot parse, it simply omits the commit from
+`CHANGELOG.md` — no fallback heading, no entry.
+
+That is not hypothetical. Seven commits reached one downstream project's
+`main` with `diag(review):` / `experiment(review):` / prose subjects and are
+absent from its generated changelog (see the template's #368). These tests are
+what keeps the three halves honest.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECKER = REPO_ROOT / "scripts" / "check_pr_title.py"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+
+
+def _parser_options() -> dict[str, list[str]]:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    options = data["tool"]["semantic_release"]["commit_parser_options"]
+    return {key: [str(item) for item in value] for key, value in options.items()}
+
+
+def _run_checker(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _checker_types() -> list[str]:
+    result = _run_checker("--list")
+    assert result.returncode == 0, result.stderr
+    return result.stdout.split()
+
+
+def test_checker_and_psr_accept_the_same_types() -> None:
+    """The gate must not reject what PSR accepts, or accept what it drops."""
+    assert set(_checker_types()) == set(_parser_options()["allowed_tags"])
+
+
+def test_release_bump_types_are_parseable() -> None:
+    """A type that bumps a version but does not parse would never bump one."""
+    options = _parser_options()
+    bumping = set(options["minor_tags"]) | set(options["patch_tags"])
+    assert bumping <= set(options["allowed_tags"])
+
+
+def test_claude_md_documents_every_accepted_type() -> None:
+    """Contributors read CLAUDE.md; an undocumented type is a trap."""
+    prose = CLAUDE_MD.read_text(encoding="utf-8")
+    missing = [f"`{tag}`" for tag in _checker_types() if f"`{tag}`" not in prose]
+    assert not missing, f"CLAUDE.md does not document: {missing}"
+
+
+def test_ci_runs_the_checker_and_gates_on_it() -> None:
+    """The check is worthless unless the required aggregate depends on it."""
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "scripts/check_pr_title.py" in workflow
+    assert "\n      - pr-title\n" in workflow, (
+        "the pr-title job must be a `needs` entry of the ci-success aggregate"
+    )
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "feat: add a thing",
+        "fix(search): stop the writer thread on shutdown",
+        "feat(config)!: drop the deprecated env alias",
+        "chore(deps): update dependency ruff to v0.9.0",
+        "revert: feat(search): add hybrid ranking",
+        'Revert "feat: add a thing"',
+        'Revert "Revert "feat: add a thing""',
+        "perf: reuse the compiled pattern",
+        "docs: document the new env var",
+    ],
+)
+def test_accepted_titles(title: str) -> None:
+    result = _run_checker(title)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "diag(review): pin the reviewer action",
+        "experiment(review): show full output",
+        "Modify CI workflow to handle Renovate PRs",
+        'Reverted "feat: add a thing"',
+        "Feat: capitalised type",
+        "fix:no space after the colon",
+        "feat: ",
+        "",
+    ],
+)
+def test_rejected_titles(title: str) -> None:
+    result = _run_checker(title)
+    assert result.returncode == 1
+    assert "::error" in result.stdout
+
+
+def test_rejection_names_the_accepted_types() -> None:
+    """An actionable failure tells the author what to type instead."""
+    result = _run_checker("diag(review): pin the reviewer action")
+    assert result.returncode == 1
+    assert ", ".join(_checker_types()) in result.stderr
+
+
+def test_git_revert_titles_pass_but_warn_about_the_changelog() -> None:
+    """The git/GitHub revert form is accepted; its cost is stated, not hidden.
+
+    Neither of python-semantic-release 10.5.3's parsers reads that shape --
+    both return ParseError -- so the commit never reaches CHANGELOG.md. The
+    check accepts the title (it is what git itself generates) and annotates
+    the run rather than leaving the author to discover the gap at release
+    time.
+    """
+    result = _run_checker('Revert "feat: add a thing"')
+    assert result.returncode == 0, result.stderr
+    assert "::warning" in result.stdout
+    assert "CHANGELOG.md" in result.stdout
+
+
+def test_conventional_revert_titles_pass_without_a_warning() -> None:
+    """`revert:` is in allowed_tags, so that form does reach the changelog."""
+    result = _run_checker("revert: feat: add a thing")
+    assert result.returncode == 0, result.stderr
+    assert "::warning" not in result.stdout

--- a/tests/test_import_surface.py
+++ b/tests/test_import_surface.py
@@ -1,0 +1,183 @@
+"""Guard for the public import surface of the `image_generation_mcp` package root.
+
+A change that removes or renames a name importable from the package root is a
+breaking change to the public library interface, and must be marked as such
+(`feat!:` / `fix!:`, or a `BREAKING CHANGE:` footer) so the release pipeline
+cuts a major.  Historically this class of break shipped unmarked: the author
+sees an internal refactor, downstream consumers see `ImportError`.  These tests
+make the surface mechanical — the project-owned snapshot
+`tests/public_import_surface.txt` is the expected set of names, and any drift
+between it and the real, imported package fails at PR time with instructions.
+
+The surface definition: every non-underscore name in ``dir(package)`` or
+``__all__`` that resolves via ``getattr``, enumerated in a fresh interpreter.
+``dir()`` + ``getattr`` (rather than a static ``__all__`` read) is deliberate —
+a root that re-exports through a lazy PEP 562 ``__getattr__`` map still counts,
+and a minimal root exporting nothing yields an empty surface.  The fresh
+interpreter keeps the result independent of whatever submodules earlier tests
+happened to import.
+
+Ownership: this file is template-owned (re-rendered on `copier update`); the
+snapshot is project-owned (seeded once, then yours).  Regenerate it with::
+
+    uv run python tests/test_import_surface.py --update
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SNAPSHOT = REPO_ROOT / "tests" / "public_import_surface.txt"
+UPDATE_COMMAND = "uv run python tests/test_import_surface.py --update"
+
+_HEADER = """\
+# Public import surface of the `image_generation_mcp` package root — one name
+# per line, sorted.  `#` lines and blank lines are ignored.
+#
+# Project-owned (seeded once by the template, never re-rendered), consumed by
+# the template-owned tests/test_import_surface.py.  Regenerate with:
+#
+#     uv run python tests/test_import_surface.py --update
+#
+# Removing a name from this file is a breaking change to the public library
+# interface: the commit that does it must be marked breaking (`feat!:` /
+# `fix!:`, or a `BREAKING CHANGE:` footer) per the versioning policy
+# (pvliesdonk/fastmcp-server-template#342).
+"""
+
+# Runs in a fresh interpreter so the enumeration cannot be polluted by
+# submodules that earlier tests imported (importing `pkg.sub` binds `sub` as an
+# attribute of `pkg` for the rest of the process).
+_ENUMERATE = """\
+import importlib
+import json
+
+module = importlib.import_module("image_generation_mcp")
+names = set(dir(module)) | set(getattr(module, "__all__", ()))
+missing = object()
+public = sorted(
+    name
+    for name in names
+    if not name.startswith("_") and getattr(module, name, missing) is not missing
+)
+print(json.dumps(public))
+"""
+
+
+def current_surface() -> list[str]:
+    """Enumerate the package root's public names in a fresh interpreter.
+
+    Returns:
+        Sorted list of public attribute names importable from the package root.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-P", "-c", _ENUMERATE],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    result: list[str] = json.loads(proc.stdout)
+    return result
+
+
+def snapshot_names() -> list[str]:
+    """Parse the snapshot file: one name per line, `#` comments and blanks ignored.
+
+    Returns:
+        The declared names, in file order.
+    """
+    lines = SNAPSHOT.read_text(encoding="utf-8").splitlines()
+    stripped = (line.strip() for line in lines)
+    return [line for line in stripped if line and not line.startswith("#")]
+
+
+def test_snapshot_file_exists() -> None:
+    """The snapshot is the contract; without it there is nothing to hold."""
+    assert SNAPSHOT.is_file(), (
+        f"{SNAPSHOT.relative_to(REPO_ROOT)} is missing — it records the public "
+        f"import surface of `image_generation_mcp`. Generate it with:\n"
+        f"    {UPDATE_COMMAND}\n"
+        "and commit the result."
+    )
+
+
+def test_snapshot_is_sorted_and_unique() -> None:
+    """A canonical (sorted, deduplicated) snapshot keeps its diffs reviewable."""
+    names = snapshot_names()
+    assert names == sorted(set(names)), (
+        f"{SNAPSHOT.relative_to(REPO_ROOT)} is not sorted/deduplicated — "
+        f"regenerate it with:\n    {UPDATE_COMMAND}"
+    )
+
+
+def test_public_import_surface_matches_snapshot() -> None:
+    """The imported surface and the snapshot must agree exactly, both ways.
+
+    Removals are the dangerous direction (an unmarked library break); additions
+    fail too, so the snapshot diff stays the reviewable record of every surface
+    change rather than silently lagging reality.
+    """
+    actual = set(current_surface())
+    expected = set(snapshot_names())
+    removed = sorted(expected - actual)
+    added = sorted(actual - expected)
+    problems: list[str] = []
+    if removed:
+        problems.append(
+            "public names REMOVED from the import surface of "
+            f"`image_generation_mcp`: {', '.join(removed)}\n"
+            "  Removing or renaming a public name is a BREAKING change to the "
+            "public library interface.\n"
+            "  Either restore the names, or — if the removal is intentional —\n"
+            f"    1. regenerate the snapshot:  {UPDATE_COMMAND}\n"
+            "    2. mark the commit/PR breaking (`feat!:` / `fix!:`, or a "
+            "`BREAKING CHANGE:` footer)\n"
+            "       per the versioning policy's public-library-interface tier "
+            "(pvliesdonk/fastmcp-server-template#342)."
+        )
+    if added:
+        problems.append(
+            "public names ADDED to the import surface of "
+            f"`image_generation_mcp`: {', '.join(added)}\n"
+            "  Additions are not breaking — record them so the snapshot stays "
+            "the reviewed surface:\n"
+            f"    {UPDATE_COMMAND}\n"
+            "  then commit the updated snapshot with this change."
+        )
+    assert not problems, "\n".join(problems)
+
+
+def _update_snapshot() -> int:
+    """Rewrite the snapshot from the currently importable surface.
+
+    Returns:
+        Number of names written.
+    """
+    names = current_surface()
+    SNAPSHOT.write_text(
+        _HEADER + "".join(f"{name}\n" for name in names), encoding="utf-8"
+    )
+    return len(names)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Public import-surface snapshot tool for `image_generation_mcp`."
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="regenerate tests/public_import_surface.txt from the imported package",
+    )
+    if not parser.parse_args().update:
+        parser.error("nothing to do — pass --update to regenerate the snapshot")
+    count = _update_snapshot()
+    sys.stdout.write(
+        f"wrote {SNAPSHOT.relative_to(REPO_ROOT)} ({count} public names)\n"
+    )

--- a/tests/test_merge_back.py
+++ b/tests/test_merge_back.py
@@ -1,0 +1,157 @@
+"""Behavioral tests for scripts/merge_back.sh against sandbox git repos.
+
+After any release cut from a release/X.Y branch, the release workflow's
+merge-back job merges the branch back into main — mandatory, because PSR's
+already-released check is repo-global while its version computation is
+ancestry-scoped: an unmerged branch release leaves PSR on main recomputing the
+same version, finding the tag taken, and reporting "already released" forever.
+
+The script's contract, asserted here:
+
+* already-merged branches are a no-op (idempotent job re-runs);
+* a clean merge (the rc-finalise case: main untouched since the cut) lands the
+  branch's release commits, version metadata included;
+* conflicts on version-coupled files (the backport case: main released again
+  after the cut) resolve to MAIN's side — main is authoritative for current
+  metadata, the tag preserves the branch's state;
+* any other conflict aborts the merge, leaves a clean tree, and exits
+  non-zero for a human to take over.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MERGE_BACK = REPO_ROOT / "scripts" / "merge_back.sh"
+
+PYPROJECT_STUB = """\
+[project]
+name = "sandbox"
+version = "{version}"
+
+[tool.semantic_release]
+assets = ["server.json"]
+
+[tool.semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
+"""
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return proc.stdout.strip()
+
+
+def _commit_all(repo: Path, message: str) -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", message)
+
+
+def _write_version(repo: Path, version: str) -> None:
+    (repo / "pyproject.toml").write_text(PYPROJECT_STUB.format(version=version))
+    # json.dumps, not an f-string literal: doubled braces in this
+    # template-rendered file would read as Jinja delimiters.
+    (repo / "server.json").write_text(json.dumps({"version": version}) + "\n")
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """A repo on main at version 4.0.0 with a release/4.0 branch cut from it."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    _write_version(repo, "4.0.0")
+    (repo / "CHANGELOG.md").write_text("# Changelog\n")
+    (repo / "app.py").write_text("x = 1\n")
+    _commit_all(repo, "chore: baseline")
+    _git(repo, "branch", "release/4.0")
+    return repo
+
+
+def _merge_back(repo: Path, branch: str, tag: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(MERGE_BACK), branch, tag],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_already_merged_branch_is_a_noop(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    before = _git(repo, "rev-parse", "HEAD")
+
+    result = _merge_back(repo, "release/4.0", "v4.0.0")
+
+    assert result.returncode == 0, result.stderr
+    assert "nothing to do" in result.stdout
+    assert _git(repo, "rev-parse", "HEAD") == before
+
+
+def test_clean_merge_lands_release_commits(tmp_path: Path) -> None:
+    """The rc-finalise case: main untouched since the cut, so the branch's
+    version bump flows onto main via an ordinary clean merge."""
+    repo = _make_repo(tmp_path)
+    _git(repo, "checkout", "release/4.0")
+    _write_version(repo, "4.1.0")
+    _commit_all(repo, "4.1.0")
+    _git(repo, "checkout", "main")
+
+    result = _merge_back(repo, "release/4.0", "v4.1.0")
+
+    assert result.returncode == 0, result.stderr
+    assert '"4.1.0"' in (repo / "server.json").read_text()
+    subject = _git(repo, "log", "-1", "--format=%s")
+    assert subject == "chore(release): merge release/4.0 back into main after v4.1.0"
+    # A real merge commit: two parents, so the tag becomes reachable from main.
+    assert len(_git(repo, "log", "-1", "--format=%P").split()) == 2
+
+
+def test_version_conflicts_resolve_to_mains_side(tmp_path: Path) -> None:
+    """The backport case: main has released a newer version since the cut, so
+    the version-coupled files conflict and main's side must win."""
+    repo = _make_repo(tmp_path)
+    _git(repo, "checkout", "release/4.0")
+    _write_version(repo, "4.0.1")
+    _commit_all(repo, "4.0.1")
+    _git(repo, "checkout", "main")
+    _write_version(repo, "5.0.0")
+    _commit_all(repo, "5.0.0")
+
+    result = _merge_back(repo, "release/4.0", "v4.0.1")
+
+    assert result.returncode == 0, result.stderr
+    assert 'version = "5.0.0"' in (repo / "pyproject.toml").read_text()
+    assert '"5.0.0"' in (repo / "server.json").read_text()
+    assert len(_git(repo, "log", "-1", "--format=%P").split()) == 2
+    # Ancestry restored: the branch tip is now reachable from main.
+    _git(repo, "merge-base", "--is-ancestor", "release/4.0", "HEAD")
+
+
+def test_code_conflicts_abort_cleanly(tmp_path: Path) -> None:
+    """A conflict outside the version-coupled set is real divergence: the
+    script must abort the merge, leave the tree clean, and exit non-zero."""
+    repo = _make_repo(tmp_path)
+    _git(repo, "checkout", "release/4.0")
+    (repo / "app.py").write_text("x = 2  # branch\n")
+    _commit_all(repo, "fix: branch-side change")
+    _git(repo, "checkout", "main")
+    (repo / "app.py").write_text("x = 3  # main\n")
+    _commit_all(repo, "fix: main-side change")
+    before = _git(repo, "rev-parse", "HEAD")
+
+    result = _merge_back(repo, "release/4.0", "v4.0.1")
+
+    assert result.returncode != 0
+    assert "need a human" in result.stderr
+    assert "app.py" in result.stderr
+    # Merge aborted: no MERGE_HEAD, clean tree, main tip unchanged.
+    assert not (repo / ".git" / "MERGE_HEAD").exists()
+    assert _git(repo, "status", "--porcelain") == ""
+    assert _git(repo, "rev-parse", "HEAD") == before

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -15,10 +15,39 @@ commits shipped a lockfile whose self entry lagged `pyproject.toml`, which made
 mutation (#325, #326).  The script is template-owned now, with
 `DOMAIN-MANIFESTS` seams for a project's own manifests; these tests are what
 keeps the two halves honest for anything added through those seams.
+
+A second invariant joined in template#345: the bumper must never pin a version
+the release will not publish.  Pre-releases skip PyPI, the MCP registry, and
+the marketplace publish, so on a pre-release run the manifests that name a
+published artifact (`server.json` and the Claude Code plugin pair) must stay
+at the last published stable, while `uv.lock` — which tracks `pyproject.toml`,
+not PyPI — must still move.  The behavioral tests below run the real script
+against a sandbox repo root and assert both directions: a stable version moves
+everything, a pre-release version moves only the lockfile.
+
+A third invariant joined in template#350: PSR's changelog writing has two
+halves that fail silently when either is missing.  `update` mode (the v10
+default) inserts version sections only at the insertion flag, so the config
+must name the flag and `CHANGELOG.md` must carry it — a flag-less changelog is
+never written, with no error.  And `changelog_file` must sit in its supported
+location (`changelog.default_templates`), not the deprecated bare
+`changelog.changelog_file` key.  The changelog tests below pin both halves.
+
+A fourth invariant joined in template#375: the two behavioral tests above
+prove the *bumper* never writes a pre-release pin, but nothing read the
+committed manifests themselves.  The stable-pin test below does, so a bad
+pin that arrives by hand edit or a half-applied update — outside the bumper
+— still fails.
 """
 
 from __future__ import annotations
 
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -127,3 +156,197 @@ def test_domain_manifest_calls_sentinel_lives_inside_main() -> None:
     end = text.index("# DOMAIN-MANIFESTS-END")
     assert main_def < start < end
     assert text.index("_bump_lockfile(version)") < start
+
+
+def test_changelog_config_lives_in_the_supported_location() -> None:
+    """`changelog_file` sits under `default_templates`; `mode` is pinned.
+
+    The bare `changelog.changelog_file` key is the pre-v9.11 deprecated
+    location (template#350) — PSR may stop honouring it in a future major,
+    and while it is honoured it silently rewires `output_format`.  `mode` is
+    asserted so the update-at-flag contract the seeded CHANGELOG.md relies on
+    stays explicit rather than riding on PSR's default.
+    """
+    changelog_cfg = _semantic_release_config()["changelog"]
+    assert "changelog_file" not in changelog_cfg, (
+        "changelog.changelog_file is the deprecated pre-v9.11 location — move "
+        "it to [tool.semantic_release.changelog.default_templates]"
+    )
+    assert changelog_cfg["default_templates"]["changelog_file"] == "CHANGELOG.md"
+    assert changelog_cfg["mode"] == "update"
+
+
+def test_changelog_carries_the_insertion_flag() -> None:
+    """`CHANGELOG.md` contains the exact insertion flag the config names.
+
+    In `update` mode PSR inserts each release's version section at this flag
+    and preserves the rest of the file; without the flag it writes nothing —
+    silently, on every release (template#350).  If this project's
+    CHANGELOG.md predates the flag, add the line once by hand, anywhere a
+    machine-written version list should begin (typically after the intro
+    prose).
+    """
+    flag = _semantic_release_config()["changelog"]["insertion_flag"]
+    changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert flag in changelog, (
+        f"CHANGELOG.md lacks the PSR insertion flag — add this exact line "
+        f"once, where version sections should be inserted: {flag}"
+    )
+
+
+_PRERELEASE_SUFFIX = re.compile(r"-(?:alpha|beta|rc|dev|pre|a|b)\b", re.IGNORECASE)
+
+
+def _published_manifest_versions() -> dict[str, str]:
+    """Version each committed published-manifest currently pins.
+
+    These are the files the "Manifest version lockstep" rule keeps at the
+    latest *stable* release: ``server.json``'s own version and its pypi
+    package versions. The oci image identifier is
+    excluded — it legitimately ends in the tag form ``:vX.Y.Z``.
+    """
+    versions: dict[str, str] = {}
+    server = json.loads((REPO_ROOT / "server.json").read_text(encoding="utf-8"))
+    versions["server.json version"] = str(server["version"])
+    for pkg in server.get("packages", []):
+        if pkg.get("registryType") == "pypi":
+            versions[f"server.json pypi {pkg.get('identifier', '')}"] = str(
+                pkg["version"]
+            )
+    return versions
+
+
+def test_committed_manifest_pins_are_stable_versions() -> None:
+    """No committed published-manifest pins a pre-release version.
+
+    The bumper leaves these files at the last published stable on a
+    pre-release run (proven by the sandbox tests below), but a value can
+    reach the committed file another way — a hand edit, a bad merge, a
+    half-applied copier update.  A pre-release pin such as ``X.Y.Z-rc.N``
+    names a version PyPI, the MCP registry, and the marketplace never
+    publish, so ``uvx --from pkg==X.Y.Z-rc.N`` cannot resolve it (the failure
+    tracked at markdown-vault-mcp#1053).  This reads the committed files
+    themselves, which the sandbox tests never touch.
+    """
+    bad = {
+        where: ver
+        for where, ver in _published_manifest_versions().items()
+        if _PRERELEASE_SUFFIX.search(ver)
+    }
+    assert not bad, (
+        "committed manifests must pin the latest stable release, but these "
+        "carry a pre-release version: "
+        + ", ".join(f"{where} = {ver}" for where, ver in sorted(bad.items()))
+    )
+
+
+def _stable_release_tags() -> list[str] | None:
+    """Stable ``vX.Y.Z`` tags in this repo, or ``None`` when git is absent.
+
+    A freshly generated project is not yet a git repository and has no tags,
+    so the caller skips there rather than failing.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "tag", "--list"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return [t for t in completed.stdout.split() if re.fullmatch(r"v\d+\.\d+\.\d+", t)]
+
+
+def test_committed_server_version_matches_a_released_tag() -> None:
+    """When the repo has stable tags, ``server.json`` names one of them.
+
+    Best-effort and self-skipping: it asserts nothing before a project's
+    first stable, but once stables exist a committed version with no matching
+    ``vX.Y.Z`` tag means the pin drifted from what was actually released.
+    """
+    tags = _stable_release_tags()
+    if not tags:
+        pytest.skip("no stable release tags in this repository yet")
+    version = str(
+        json.loads((REPO_ROOT / "server.json").read_text(encoding="utf-8"))["version"]
+    )
+    if version in {"0.0.0", "0.1.0"}:
+        pytest.skip("initial placeholder version, before the first release")
+    assert f"v{version}" in tags, (
+        f"server.json pins {version}, but no matching stable tag v{version} "
+        "exists — the manifest must name a released stable version"
+    )
+
+
+def _run_bumper(workdir: Path, version: str) -> subprocess.CompletedProcess[str]:
+    """Run the real bumper against ``workdir`` with ``NEW_VERSION`` set."""
+    return subprocess.run(
+        [sys.executable, str(BUMPER)],
+        cwd=workdir,
+        env={**os.environ, "NEW_VERSION": version},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def release_sandbox(tmp_path: Path) -> Path:
+    """A minimal repo root the bumper can rewrite without touching this repo.
+
+    `server.json` is copied verbatim so the test exercises the
+    real manifest shapes; `pyproject.toml` and `uv.lock` are minimal stand-ins
+    carrying only what `_bump_lockfile` reads.
+    """
+    shutil.copy(REPO_ROOT / "server.json", tmp_path / "server.json")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "sandbox-pkg"\nversion = "1.2.3"\n', encoding="utf-8"
+    )
+    (tmp_path / "uv.lock").write_text(
+        '[[package]]\nname = "sandbox-pkg"\nversion = "1.2.3"\n', encoding="utf-8"
+    )
+    return tmp_path
+
+
+def test_stable_release_bumps_every_published_version_field(
+    release_sandbox: Path,
+) -> None:
+    """A stable version moves every manifest the release publishes."""
+    result = _run_bumper(release_sandbox, "9.9.9")
+    assert result.returncode == 0, result.stderr
+
+    server = json.loads((release_sandbox / "server.json").read_text(encoding="utf-8"))
+    assert server["version"] == "9.9.9"
+    pypi = [p for p in server["packages"] if p.get("registryType") == "pypi"]
+    assert pypi and all(p["version"] == "9.9.9" for p in pypi)
+    oci = [p for p in server["packages"] if p.get("registryType") == "oci"]
+    assert all(p["identifier"].endswith(":v9.9.9") for p in oci)
+
+    lock = (release_sandbox / "uv.lock").read_text(encoding="utf-8")
+    assert 'version = "9.9.9"' in lock
+
+
+@pytest.mark.parametrize("version", ["9.9.9-rc.1", "9.9.9-rc.12"])
+def test_prerelease_leaves_published_version_fields_untouched(
+    release_sandbox: Path, version: str
+) -> None:
+    """A pre-release run must not pin versions PyPI/the registry never get.
+
+    `publish-pypi`, `publish-registry`, and the marketplace publish are all
+    gated on PSR's `is_prerelease` output, so a pre-release version never
+    exists on those channels — pinning it would leave the branch naming an
+    uninstallable version between stables (template#345).  `uv.lock` still
+    moves: it tracks `pyproject.toml`, and lagging there breaks
+    `uv lock --check` on `main`.
+    """
+    before_server = (release_sandbox / "server.json").read_bytes()
+
+    result = _run_bumper(release_sandbox, version)
+    assert result.returncode == 0, result.stderr
+    assert "pre-release" in result.stdout
+
+    assert (release_sandbox / "server.json").read_bytes() == before_server
+    lock = (release_sandbox / "uv.lock").read_text(encoding="utf-8")
+    assert f'version = "{version}"' in lock

--- a/tests/test_structural_gate.py
+++ b/tests/test_structural_gate.py
@@ -8,6 +8,7 @@ wired correctly. Only rendered when ``enable_structural_gate`` is true.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -200,21 +201,21 @@ def test_precommit_config_wires_pre_push_hook() -> None:
     block = _structural_hook_block(text)
     assert "stages: [pre-push]" in block
     assert "language: system" in block
-    # Mirrors the CI HAS_PY skip: no Python in the push → hook does not run.
+    # Mirrors the script's no-Python skip: no Python in the push → hook does
+    # not run.
     assert "types: [python]" in block
-    # The `entry: bash -c` wrapper is load-bearing: it makes the shell (not
-    # pre-commit's arg splitter) own the --options quoting verified by the
-    # end-to-end test. Assert it so a refactor to a direct `uv run` entry —
-    # which would break that quoting — can't pass silently.
-    assert "entry: bash -c " in block
-    assert f"--extend-select={STRUCTURAL}" in block
+    # The hook delegates to the shared script (one implementation for hook and
+    # CI); the diff-quality command itself is asserted on the script below.
+    assert "entry: bash scripts/structural_gate.sh" in block
 
 
 def test_ci_has_structure_job() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     assert "structure:" in text
-    assert "diff-quality" in text
-    assert f"--extend-select={STRUCTURAL}" in text
+    # CI runs the same shared script as the pre-push hook, pinning the compare
+    # branch to the PR's real base via the script's env override.
+    assert "scripts/structural_gate.sh" in text
+    assert "STRUCTURAL_GATE_BASE" in text
     # PR-only, like the diff-cover patch-coverage steps.
     assert "github.event_name == 'pull_request'" in text
 
@@ -231,12 +232,85 @@ def test_claudemd_documents_the_gate_command() -> None:
 
 
 def test_structural_select_string_is_identical_across_surfaces() -> None:
-    """The select string lives in three rendered files; drift between them is a
-    silent gate weakening. Assert all three carry the canonical string verbatim.
+    """The select string lives in the shared script (which the pre-commit hook
+    and the CI job both execute) and in CLAUDE.md's documented command; drift
+    between them is a silent gate weakening. Assert both carry the canonical
+    string verbatim.
     """
     needle = f"--extend-select={STRUCTURAL}"
-    precommit = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
-    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    script = (REPO_ROOT / "scripts" / "structural_gate.sh").read_text()
     claudemd = (REPO_ROOT / "CLAUDE.md").read_text()
-    for name, text in [("pre-commit", precommit), ("ci", ci), ("CLAUDE.md", claudemd)]:
+    for name, text in [("structural_gate.sh", script), ("CLAUDE.md", claudemd)]:
         assert needle in text, f"{name} missing canonical structural select"
+
+
+def _print_base(repo: Path, env: dict[str, str] | None = None) -> str:
+    """Run the script's base-derivation seam and return the resolved base."""
+    proc = subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts" / "structural_gate.sh")],
+        cwd=repo,
+        env={**os.environ, "STRUCTURAL_GATE_PRINT_BASE": "1", **(env or {})},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+def _commit(repo: Path, name: str, stamp: str) -> None:
+    (repo / name).write_text(name + "\n")
+    _git(["add", "."], repo)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", name],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_DATE": stamp,
+            "GIT_COMMITTER_DATE": stamp,
+        },
+    )
+
+
+def test_gate_script_derives_compare_branch(tmp_path: Path) -> None:
+    """Base derivation: a branch off main compares against origin/main; a
+    backport branch off release/X.Y compares against origin/release/X.Y (the
+    branch its PR targets); an explicit STRUCTURAL_GATE_BASE always wins.
+
+    The remote-tracking refs are created directly with update-ref — the
+    derivation reads refs/remotes/origin/*, not a live remote.
+    """
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(["init", "-b", "main"], repo)
+    _commit(repo, "c1.py", "2026-01-01T10:00:00")
+    _commit(repo, "c2.py", "2026-01-02T10:00:00")
+    _git(["update-ref", "refs/remotes/origin/main", "HEAD"], repo)
+
+    # Feature branch off main: only origin/main exists -> origin/main.
+    _git(["checkout", "-b", "feature"], repo)
+    _commit(repo, "f1.py", "2026-01-05T10:00:00")
+    assert _print_base(repo) == "origin/main"
+
+    # Cut release/4.0 from main's tip, advance it (newer merge-base than
+    # main's for anything branched off it), publish as a remote ref.
+    _git(["checkout", "-b", "release/4.0", "main"], repo)
+    _commit(repo, "r1.py", "2026-01-03T10:00:00")
+    _git(["update-ref", "refs/remotes/origin/release/4.0", "HEAD"], repo)
+
+    # Backport branch off the release branch -> origin/release/4.0.
+    _git(["checkout", "-b", "backport", "release/4.0"], repo)
+    _commit(repo, "b1.py", "2026-01-04T10:00:00")
+    assert _print_base(repo) == "origin/release/4.0"
+
+    # The feature branch still resolves to origin/main: both merge-bases land
+    # on the same cut commit, and the tie deliberately prefers origin/main...
+    _git(["checkout", "feature"], repo)
+    assert _print_base(repo) == "origin/main"
+    # ...and the explicit override beats any derivation.
+    assert (
+        _print_base(repo, {"STRUCTURAL_GATE_BASE": "origin/somewhere"})
+        == "origin/somewhere"
+    )


### PR DESCRIPTION
## Summary

- update Copier template from v3.6.0 to v4.1.0
- adopt template rulesets, import-surface snapshot, release-branch workflow, and release documentation
- preserve template-owned Bootstrap behavior; migrate the existing legacy ruleset after Bootstrap succeeds

Refs #364

## Verification

- focused import/commit tests: 27 passed
- `uv run pytest --cov=src/image_generation_mcp --cov-report=term-missing`: 1126 passed, 94%
- config-surface, Ruff, mypy, strict MkDocs, pre-commit, and structural diff gates
- local task review and scoped ruleset-migration re-review

## Pre-Merge / Post-Merge Gate

Before merge, confirm `RELEASE_TOKEN` has repository-administration scope. After merge, confirm Bootstrap created `protect-main`, `protect-release-branches`, and `protect-release-tags`; only then delete the legacy active `Default` ruleset (`id: 14067652`). Do not delete it if Bootstrap fails.