### PR TITLE
fix(copier): restore tracked contributor skills

### DIFF
--- a/.claude/skills/authoring-issues-prs/SKILL.md
+++ b/.claude/skills/authoring-issues-prs/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: authoring-issues-prs
+description: >-
+  Use when filing a bug, opening or creating a GitHub issue, drafting an
+  epic or ticket, writing up a finding or review observation worth
+  tracking, or opening a pull request for this repository. Routes the
+  change to the right repo first (library / template / domain), picks the
+  right issue form, links epic children as native sub-issues, and applies
+  CONTRIBUTING.md before anything is posted.
+---
+
+<!-- ===== TEMPLATE-OWNED — re-rendered on copier update. Project-specific
+     additions go inside the DOMAIN-AUTHORING sentinel at the end. ===== -->
+
+# Authoring issues and pull requests
+
+`CONTRIBUTING.md` at the repository root is the single source for the rules:
+issue voice, uncertainty markers, one-issue-one-problem, PR discipline, and
+the three-tier routing. This skill adds only what a document cannot — the
+trigger, the order of operations, and the API mechanics for the steps issue
+forms cannot perform. It deliberately does not restate the rules; a second
+copy would drift from the file silently.
+
+## Procedure
+
+### 1. Read CONTRIBUTING.md — now, not from memory
+
+Read `CONTRIBUTING.md` (repository root) before drafting a single sentence,
+even if you believe you remember it. You are about to apply these sections,
+and their exact wording matters:
+
+- "Observation, not work order" and "The uncertainty rule" — issue voice
+  and the `[verified: how]` / `[unverified]` markers.
+- "One issue, one observed problem" and the "Remove before posting" table —
+  run your draft through the table before submitting.
+- "Pull requests" — no orphan PRs, the deliberately-does-not section.
+- "Where to send fixes" — the routing walked in step 2.
+
+If anything in this skill appears to conflict with `CONTRIBUTING.md`, the
+file wins.
+
+### 2. Route before writing
+
+Decide the repo first, then write for that repo. The test: **which file
+would a fix change?**
+
+1. Anything you'd change in `fastmcp_pvl_core` → **library**: file on
+   `pvliesdonk/fastmcp-pvl-core`.
+2. A template-owned file — workflows, `Dockerfile`, the `server.py`
+   skeleton, anything `copier update` re-renders — → **template**: file on
+   `pvliesdonk/fastmcp-server-template`.
+3. Anything inside a `DOMAIN-*` / `CONFIG-*` / `PROJECT-*` sentinel block,
+   or `tools.py` / `resources.py` / `prompts.py` / `domain.py` / `tests/`
+   → **domain**: file on this repository.
+
+`CONTRIBUTING.md`'s "Where to send fixes" defines these tiers with the
+post-merge propagation for each. When the tier is genuinely unclear, say so
+in the issue with an `[unverified]` marker instead of guessing silently.
+
+### 3. Search for duplicates
+
+Search the target repo's issues — open **and** closed — before filing:
+
+```bash
+gh issue list --repo OWNER/REPO --state all --search "<key terms>"
+```
+
+Match on the observation, not the wording. If the problem is already on
+file, comment on the existing issue rather than opening a twin; if a closed
+issue shows it regressed, say that in the new issue and link it.
+
+### 4. Pick the form
+
+Forms live in `.github/ISSUE_TEMPLATE/` of the target repo:
+
+| You have | Form |
+|----------|------|
+| Something not working as expected | `bug-report.yml` |
+| A capability that's missing | `feature-request.yml` |
+| A multi-feature effort telling one user-facing story | `epic.yml` |
+| Structural decay worth refactoring later | `decay.yml` |
+| A question or support request | `question.yml` |
+
+When filing via API/CLI rather than the web form, mirror the chosen form's
+section headings and apply its labels (`bug`, `feature`, `epic`, `decay`,
+`question`) so the issue is indistinguishable from a form-filed one.
+
+### 5. For epics: finish what the form cannot do
+
+Issue forms cannot create sub-issue links or assign milestones. After the
+epic is filed, perform these steps — this is the mechanical half of the
+epic form's "After filing" checklist:
+
+```bash
+repo=OWNER/REPO        # the repo decided in step 2
+epic=EPIC_NUMBER
+
+# 1. Link each child as a NATIVE sub-issue (the endpoint takes the child's
+#    database id, not its issue number):
+child_id=$(gh api "repos/$repo/issues/CHILD_NUMBER" --jq '.id')
+gh api -X POST "repos/$repo/issues/$epic/sub_issues" -F "sub_issue_id=$child_id"
+
+# 2a. Ships atomically — milestone (preferred): assign the epic AND its
+#     children to the target release's milestone, creating it if needed.
+#     Milestones are per-repo and one-per-issue; for a cross-repo epic the
+#     milestone lives in the repo where the release is cut.
+gh api "repos/$repo/milestones" -F "title=X.Y"     # once, if it doesn't exist
+gh issue edit "$epic" --repo "$repo" --milestone "X.Y"
+
+# 2b. Ships atomically — label (fallback): when no target release is named
+#     yet, or in the repos of a cross-repo epic that do not cut the release.
+gh issue edit "$epic" --repo "$repo" --add-label ships-atomically
+```
+
+Working through the GitHub MCP server instead: `sub_issue_write` (method
+`add`) performs the same link, and `issue_read` returns `has_parent` /
+`has_children` / `sub_issues_summary` to verify it took.
+
+Never track children as a markdown task list in the epic body — the native
+link is what release tooling queries.
+
+### 6. Pull requests
+
+Route first (step 2): the issue and the PR that closes it belong in the
+same repo. Then follow `CONTRIBUTING.md`'s "Pull requests" section and the
+repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) — every section,
+including "What this PR deliberately does NOT do" and the docs-impact
+checklist.
+
+### 7. Attribution footer
+
+When you (an agent) author an issue or PR body, end it with exactly:
+
+```markdown
+---
+_Generated by [Claude Code](https://claude.ai/code)_
+```
+
+<!-- DOMAIN-AUTHORING-START -->
+<!-- Project-specific authoring conventions (extra labels, forms, routing
+     notes) go here. This block survives copier update. -->
+<!-- DOMAIN-AUTHORING-END -->

--- a/.claude/skills/writing-release-notes/SKILL.md
+++ b/.claude/skills/writing-release-notes/SKILL.md
@@ -1,0 +1,403 @@
+---
+name: writing-release-notes
+description: >-
+  Use when drafting or revising a release-notes page under docs/releases/ —
+  the Release Prepare workflow's notes job invokes it for every release PR
+  (rc and stable alike), and a human may invoke the Release Notes dispatch
+  for a re-draft or backfill. Walks the API-driven research fan-out (commits
+  to PRs to linked issues, never commit subjects), the evidence contract,
+  the per-minor page format, and the Vale loop, and ends with pages written
+  into the working tree for the calling workflow to land — never a direct
+  push.
+---
+
+<!-- ===== TEMPLATE-OWNED — re-rendered on template updates. ===== -->
+
+# Writing release notes
+
+The pages under `docs/releases/` are the canonical human-facing narrative of
+each release; the GitHub release body is a summary plus a link to them, and
+`CHANGELOG.md` is the machine-written commit-level audit trail. This skill is
+the contract for producing a page: what to research, what counts as evidence,
+what the page looks like, and which gates it must pass. Every requirement
+below was established empirically by trial runs recorded on
+pvliesdonk/fastmcp-server-template#347; where this skill says "must", a trial
+produced the failure the rule prevents.
+
+## Inputs
+
+You are given, or must derive first:
+
+- `TAG` / `VERSION` — the stable release (e.g. `v3.2.0` / `3.2.0`). At
+  prepare time (an open release PR, tag not yet created) these name the
+  release being prepared; an rc target still drafts its stable minor's page.
+- `MINOR` — the series (e.g. `3.2`); the page is `docs/releases/MINOR.md`.
+- `PREV` — the highest stable tag strictly below the target version
+  (series-aware, `sort -V`); empty on a first release.
+- `RANGE_END` — where the research range ends, always a commit SHA. After
+  a release this is the tagged commit; at prepare time it is the release
+  PR's source commit, because the tag does not exist yet. The evidence rules below are identical either
+  way — only the range endpoints move. A prepare-time draft is refreshed
+  (branch force-pushed) alongside any re-dispatch of the release PR.
+- Mode — **new page** (the minor's page does not exist: write the whole
+  page), **patch append** (the page exists but does not yet cover the
+  target patch release, `Z > 0`: add one section inside the patch
+  sentinels; leave the rest of the page alone unless it is factually
+  wrong), or **redraft** (the page already covers the target — an `X.Y.0`
+  page drafted at prepare time, or any target whose `RELEASE-SUMMARY`
+  marker an earlier candidate already wrote: update the covering section
+  and its summary block in place, and never append a duplicate section
+  for a release the page already covers).
+- Watermark — an existing page carries an invisible
+  `<!-- notes-range-end: SHA -->` comment recording where its last
+  accepted draft's research ended. This is the incremental-research
+  anchor for the modes below.
+- Full-redraft flag — the operator may set it on either dispatch
+  (Release Prepare threads it through to the notes job); it suspends
+  the watermark's cache role for that one run (see the override below).
+
+## Incremental research (patch and redraft modes)
+
+The accepted page is the cache; do not re-research a range the page
+already covers. When the page carries the watermark:
+
+- If the watermark SHA equals `RANGE_END`, the page's researched content
+  is already current: do no re-research and leave the prose alone, but
+  still apply the date backfill from the page-format section — it derives
+  from tag existence, not from the research range. Say what you did in
+  your final report either way; the calling workflow treats an unchanged
+  existing page as success, and a backfill-only change lands like any
+  other draft.
+- Otherwise research only `WATERMARK..RANGE_END` (the same fan-out and
+  evidence rules, over the delta), fold the findings into the existing
+  narrative — extend a theme, add one, or leave prose untouched when the
+  delta is stamps and mechanics — and verify claims the delta might have
+  invalidated rather than re-deriving the whole page.
+- Always move the watermark to `RANGE_END` when you touch the page, and
+  write it (once, at the top of the page after the front matter or title)
+  when you create a page.
+
+A page without a watermark predates this contract: research the full
+`PREV..RANGE_END` range once, and add the watermark with the result.
+
+**Full-redraft override.** When the run's inputs say full redraft, the
+watermark loses its cache role for that run only, and the calling
+workflow has already **emptied the page** (after snapshotting it):
+write the complete page from scratch, exactly as in new-page mode.
+Research the full range the page covers — from the highest stable tag
+strictly below the minor's first release (`X.Y.0`, series-aware via
+the tags API; the whole history on a first series) through
+`RANGE_END` — and re-derive every part of the page under the current
+contract: the summary block for each release the page covered (the
+minor's tags, read via the API, tell you which), the theme sections,
+the upgrade section, the patch sentinels and their sections, and the
+watermark at `RANGE_END`. The previous page remains readable through
+the API at the branch ref for reference, but write from the
+re-research, never by restoring it — a full redraft that reproduces
+the old prose with word-level touch-ups is the override not honoured.
+The index entry lives in a separate file and stays. This is the
+operator's remedy when this skill's own rules changed after a page was
+accepted: the incremental path above deliberately preserves accepted
+prose, so contract improvements never reach an already-covered range
+without this override. The flag is off by default on every entry
+point — a refresh is incremental unless the operator sets it, either
+on the Release Prepare dispatch (threaded through to the notes job) or
+on the Release Notes dispatch directly.
+
+## Non-negotiables
+
+1. **No evidence, no narrative.** Every causal claim ("X was slow because
+   Y", "this was driven by user demand") must trace to a linked issue or PR
+   you actually read, and the page links it. A claim you cannot source gets
+   dropped, not hedged. Concrete numbers appear only verbatim from a source.
+   Attribute quoted judgements (for example "[per the maintainer]" with the
+   link) rather than presenting them as your own analysis.
+2. **Output is reviewed before it publishes, never pushed live.** The
+   dominant failure mode is plausible-but-wrong rationale, and a
+   confabulated "why" on a published docs site is worse than no narrative.
+   The page reaches a human either inside the release PR's diff (the
+   primary flow — the release review includes the notes evidence check) or
+   as a standalone notes PR (backfill); write for that review either way.
+3. **Never touch `CHANGELOG.md`.** It is machine-generated and stays that
+   way. The two artifacts answer different questions: "what landed" versus
+   "should I upgrade".
+4. **Never write from `git log`.** Commit subjects are the input ceiling this
+   whole pipeline exists to break. A draft whose sections mirror the commit
+   list is the recognised failure ("a haiku summary of the git log") — if you
+   notice the page reading like grouped commit subjects, the research phase
+   was skipped; go back.
+5. **Write the net delta, not the development journey.** The page answers
+   "what changes when I upgrade from `PREV`", so a state that existed only
+   *between* two commits of the range is invisible to every reader: a
+   feature new in this release is described as it ships, never through the
+   fixes that hardened it inside the same range; a regression introduced
+   and fixed within the range is not a fix worth reporting; work superseded
+   or reverted before `RANGE_END` does not appear at all. Evidence-linked
+   is necessary, not sufficient — development progress is mildly
+   interesting and still not release information. An intermediate PR may
+   still be *cited* where it is the best evidence for how the shipped
+   behaviour works; what must not appear is the sequence of intermediate
+   states as narrative. The summary block is the strictest surface: it
+   positions the release against `PREV` only, never against an rc or an
+   unshipped intermediate ("rebuilt", "now fixed") no reader ever ran.
+
+## Research procedure
+
+### 1. Enumerate the range through the API, not local git
+
+- Commit list: `gh api "repos/OWNER/REPO/compare/PREV...RANGE_END"`
+  (paginate past 250 commits; if PREV is empty this is the whole history —
+  fall back to the release's own compare link or the full commit list). The
+  compare API accepts a tag or a commit SHA as either endpoint, so the same
+  call covers post-release and prepare-time drafting. The compare API is
+  authoritative; a shallow local clone silently truncates ranges.
+- Commit to PR: `gh api "repos/OWNER/REPO/commits/SHA/pulls"` — never regex
+  `(#N)` out of subjects (breaks on squash subjects without the suffix and
+  on passing mentions).
+- PR to issues: the PR's closing-issues references (GraphQL
+  `closingIssuesReferences` on the PR object) — never grep `Closes #N` from
+  bodies; UI-made links have no text form.
+
+### 2. Group before you read deeply
+
+Build the theme map from structure first:
+
+- **Epics are the primary grouping input.** For each linked issue, check for
+  a parent (native sub-issues; epics carry the `epic` label). An epic whose
+  children closed in this range is one theme, and its issue form's "What
+  changes for the user" paragraph — written at epic creation — is the seed
+  for both that theme's section and the release summary. Verify that
+  paragraph against what actually landed; edit it, do not just copy it.
+- The release **milestone** (or the `ships-atomically` label) marks work
+  that was planned to ship together — treat it as one story.
+- A bump of a **first-party upstream** (the `fastmcp-pvl-core` library, or
+  the copier template behind a `chore(copier): update` commit) is a theme
+  lead of its own, researched through the upstream repository — see the
+  dedicated rule below.
+- Everything else falls into themes by subject (each significant feature,
+  contributor-driven changes, platform/infrastructure work, fixes). Where a
+  repository has no epics or milestones, this thematic grouping is the whole
+  map — degrade gracefully; do not invent structure.
+
+### 3. Fan out — one research pass per theme
+
+A single agent holding the whole range regresses to commit subjects, because
+reading the linked issues does not fit alongside drafting. Dispatch **parallel
+research subagents, one per theme**. Each walks its theme's commits → PRs →
+issue bodies **and comments**, and returns a compact structured brief:
+
+- what shipped, in user terms, with the PR/issue links;
+- the motivating problem, quoted from the issue body where possible;
+- who reported or drove it: the issue's `user.login` and
+  `author_association`, not just commit authors;
+- exact enablement: env vars, defaults, config keys, tool names;
+- any concrete numbers (timings, sizes, counts) with their source;
+- the feature's docs page(s), and whether they changed in this range;
+- the **shipped end state only**: where later commits in the range
+  superseded earlier ones, brief the final behaviour and mark the
+  earlier intra-range states as superseded — they are evidence trail,
+  not findings (the net-delta non-negotiable).
+
+The synthesiser writes **from the briefs only**.
+
+### 4. Attribution comes from issue authorship
+
+Commit authors miss most outside contributors: people who file the issue that
+the maintainer then implements are invisible in `git log`. Report reporters.
+Corollary: do not infer outside demand from an issue the maintainer filed —
+if an outside PR preceded the maintainer's tracking issue, the honest
+attribution is the PR.
+
+A quote's citation names the artifact where the quoted words verbatim
+appear, written by the person you attribute them to — fetch that artifact
+and check both before writing the citation. A maintainer-filed tracking
+issue often restates a contributor's words; citing it turns the
+contributor's report into the maintainer's, which is exactly the
+misattribution above wearing a link.
+
+### 5. Synthesis pass, with licence to regroup
+
+After the briefs return, look across them before writing: separate
+deliverables may be one recipe with several delivery channels (write the
+"which do I want" paragraph, not three bullets), and a fix filed under one
+scope may really belong to another theme's story. Conventional-commit scopes
+are not the outline; the reader's questions are. This is also where the
+net-delta non-negotiable gets applied across briefs: collapse any surviving
+journey narration into the shipped end state before a section is written.
+
+### 6. First-party dependency bumps are research leads, not dead ends
+
+A commit that raises the `fastmcp-pvl-core` floor or applies a template
+update (`chore(copier): update to vX.Y.Z`) changes this server's behaviour
+while carrying no content of its own — the change lives in the upstream
+repository, and a downstream issue restating it may not exist. Do not let
+the fan-out dead-end there:
+
+- Read the old and new versions from the range's endpoints (the
+  `pyproject.toml` constraint, `uv.lock`'s pinned entry, or the copier
+  answers file's `_commit`), through the API like every other
+  file-at-ref read. The upstream repository comes from the dependency's
+  project URLs or the answers file's `_src_path`.
+- Research the upstream range between those two versions through the
+  upstream repo's own release artifacts: its `docs/releases/` pages and
+  GitHub release bodies are themselves evidence-linked — read them
+  rather than re-deriving upstream history, and follow into upstream
+  PRs/issues only where they are thin or missing.
+- Surface only what an operator or user of **this** server experiences
+  on upgrade — a security-posture change, a flipped default, new
+  behaviour of a shared helper (redirect handling, error shapes) — in
+  the theme where a reader would look for it, never as a bare
+  "dependencies were bumped" list. Link the upstream evidence directly;
+  the evidence rules do not weaken across a repository boundary.
+- Third-party bumps stay out unless a linked local issue makes one a
+  story (a CVE fix, an outage remedy).
+- The net-delta rule crosses repos too: an upstream change absorbed
+  and already compensated for within this same range is invisible.
+
+## Writing the page
+
+Each significant feature answers, in this order:
+
+1. **What is it** — for someone who has never heard of it.
+2. **Why does it fit this server** — almost always a verbatim quote from the
+   motivating issue; it is never in a commit.
+3. **How do I enable it** — exact env vars, defaults, config; a reader should
+   be able to act without opening another page (but link the guide too).
+4. Then, and only then, the tool/API surface it added.
+
+A list of tools shipped is the failure mode, not the deliverable.
+
+### Upgrade / breaking-changes section
+
+Do **not** trust `!` markers or `BREAKING CHANGE:` footers — trials found
+them wrong in both directions. Derive the section from the actual surfaces
+between `PREV` and `RANGE_END`, read through the API — you have no local
+git (`gh api "repos/OWNER/REPO/contents/PATH?ref=REF" -H "Accept:
+application/vnd.github.raw"` returns the file body directly, no decoding
+pipeline needed; the ref accepts a tag or a commit SHA, so the same call
+covers prepare-time drafting where the tag does not exist yet) —
+classified against the breaking-change policy in `CLAUDE.md` (operator
+surface and public library interface, assessed against the last stable):
+
+- import surface: diff `tests/public_import_surface.txt` at the two refs;
+- operator surface: diff `.env.example` / the config surface at the two refs;
+- tool surface: compare the registered-tools docs at the two refs (not
+  breaking on its own, but worth a migration note when behaviour moved).
+
+Where your classification disagrees with a commit's marker, follow the
+classification and say so in the PR body.
+
+### Docs links — verify before linking
+
+Every feature with a docs page links it, not only the flagship. Locate pages
+rather than assuming them, and **check each linked page is current**: a
+feature whose code changed in the range while its guide did not is a
+candidate staleness bug. Do not link a page you found stale as if it were
+authoritative; list every staleness candidate in the PR body (observation
+voice, `[unverified]` where you did not confirm) so the maintainer can file
+or fix — do not file issues yourself from an automated run.
+
+## Page format
+
+One page per minor: `docs/releases/MINOR.md`. Patch releases append a
+section to the same page (dated per the tag-existence gate below), so a
+minor's story stays in one linkable document.
+Skeleton for a new page (the comment markers are load-bearing — the publish
+workflow extracts summary blocks by tag, and later patch drafts insert only
+inside the patch sentinels):
+
+    # 3.2
+
+    <!-- RELEASE-SUMMARY v3.2.0 START -->
+    One short paragraph, user-facing: what this minor means for someone
+    deciding whether to upgrade. Seeded from the epic form's summary where
+    one exists. This block becomes the GitHub release body.
+    <!-- RELEASE-SUMMARY v3.2.0 END -->
+
+    ## <theme sections, per the writing rules above>
+
+    ## Upgrading
+
+    <the derived upgrade section; omit heading if truly nothing>
+
+    <!-- PATCH-RELEASES-START -->
+    <!-- PATCH-RELEASES-END -->
+
+A patch section goes inside the patch sentinels, oldest first, as:
+
+    ## v3.2.1 (2026-08-20)
+
+    <!-- RELEASE-SUMMARY v3.2.1 START -->
+    One paragraph: what this patch fixes and who should care.
+    <!-- RELEASE-SUMMARY v3.2.1 END -->
+
+    <evidence-linked detail, same rules as above>
+
+The `(2026-08-20)` date suffix follows the same tag-existence gate as the
+shipped-claim rule below: a prepare-time patch draft, whose tag does not
+exist yet, writes the bare `## v3.2.1` heading, and the post-release draft
+appends the real date. The parenthesised form is deliberate: the shipped
+Vale packs reject em dashes (`Google.EmDash`, `ai-tells.EmDashUsage`), so
+an em-dash separator here would fail the skill's own prose gate — write
+page prose without em dashes generally rather than spending vocabulary
+or rewrites on them.
+
+For a **new** page, also add the minor to the list in
+`docs/releases/index.md` (newest first, between its markers; the first real
+entry replaces the seeded placeholder line). Do not edit
+`mkdocs.yml`: the navigation is project-owned. If the nav has no
+Release Notes entry yet, note that in the PR body instead of adding one.
+
+Never claim the target version has shipped before it has. The gate is
+whether the target's stable tag exists at drafting time (read it through
+the API when unsure). At prepare time it does not — an rc target's stable
+may still be weeks out — so a prepare-time draft gives the target's index
+entry and page no "(released <date>)" qualifier and no past-tense shipping
+claim. A post-release backfill or re-draft, whose target tag does exist,
+states the real date — that is the later draft the target earns its date
+from. That later draft need not target the shipped version: every draft,
+whatever its target, also backfills the date onto any index entry or patch
+heading whose tag now exists but which an earlier pre-tag draft left
+undated, using the tag's own timestamp as the source. The backfill covers
+what the draft's checked-out tree carries: on the default branch that is
+every series, so dates lag by at most one default-branch drafting run; a
+draft on a `release/X.Y` branch may have been cut from an old tag that
+lacks newer pages, and the entries missing there wait for the next
+default-branch draft. An operator who wants a date sooner dispatches a
+re-draft or hand-edits the page.
+
+## Quality gates — run them, do not assume them
+
+- **Vale** is the prose gate, including the `ai-tells` LLM-prose detector:
+  run `vale docs/releases/` (the binary and synced style packs are provided
+  by the workflow; locally, `vale sync` first) and iterate until clean.
+  Distinguish the two hit classes: real prose findings get rewritten;
+  domain vocabulary the spell-checker does not know goes into
+  `.vale/styles/config/vocabularies/Base/accept.txt` (add it in the same
+  change) — never contort prose around a vocabulary hit.
+- **Strict docs build**: `uv run mkdocs build --strict` must pass.
+
+## Output
+
+Leave the working tree holding only: the target release page, any other
+release page or `docs/releases/index.md` that the date backfill touched
+(the index also in new-page mode), any `accept.txt` additions, and your
+proposed PR body in
+`.release-notes-pr-body.md` at the repository root (the workflow's mechanical
+step commits the docs paths — onto the release PR's prep branch in the
+primary flow, or as a standalone notes PR from the body file in backfill
+mode — and discards the body file). The PR body must carry:
+
+- the release tag and compare link;
+- a claim-by-claim evidence summary (or a statement that every inline link
+  is the evidence), so the human review is a link check, not archaeology;
+- your breaking-change classification and any disagreement with `!` markers;
+- docs-staleness candidates found in the research;
+- anything you could not source and therefore left out.
+
+**Honest failure beats confident junk.** If the range has too few linked
+issues to support a narrative, write the modest factual page the evidence
+supports. If you cannot produce even that, change nothing and say why in
+your final report — in the primary flow the workflow then fails loudly and
+the operator re-runs or consciously releases with skip_notes; a backfill
+run simply opens no PR.

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,9 @@ site/
 # --- Development / ecosystem ignores (don't ship)
 .mcpregistry_*
 .worktrees/
-.claude/
+# Claude Code local settings; contributor skills are template-owned and tracked.
+.claude/*
+!.claude/skills/
 .mcp.json
 .repowise/
 docs/superpowers/

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,10 +1,12 @@
 # Vale prose linter — https://vale.sh
 #
-# Lints the published `docs/**` site for prose issues. Dev-reference subtrees
-# (`docs/superpowers/**` working specs, `docs/design/**` notes, and
-# `docs/decisions/**` ADRs) are excluded at the CI invocation site
-# (`--glob=!docs/{superpowers,design,decisions}/**`), mirroring the mkdocs
-# `exclude_docs:` block; Vale itself has no notion of "skip this subtree".
+# Lints the user-facing docs site (`docs/**`) plus `README.md` for prose
+# issues. Internal dev docs (`docs/design/**`, `docs/decisions/**`,
+# `docs/superpowers/**`) are excluded by the pre-commit hook (`exclude:`
+# pattern) and the CI step (`--glob='!docs/{superpowers,design,decisions}/**'`),
+# mirroring the mkdocs `exclude_docs:` block; Vale itself has no notion of
+# "skip this subtree", so the exclusion lives at the invocation site. See the
+# Documentation Conventions section in CLAUDE.md.
 #
 # `MinAlertLevel = error` governs both what Vale prints AND its exit code —
 # warnings and suggestions are advisory (visible in `vale --minAlertLevel=
@@ -40,6 +42,20 @@ Vocab = Base
 # If tbhb/vale-ai-tells renames or removes the pinned release, `vale sync`
 # will fail permanently for this project. Periodically check
 # https://github.com/tbhb/vale-ai-tells/releases and bump the URL manually.
+#
+# THIS LINE IS THE SOURCE OF TRUTH for which packs exist, and three places
+# restate it by hand — change it and all three change with it:
+#   1. `BasedOnStyles` below. A style named there that `Packages` does not
+#      fetch makes vale exit 2 with `E100 [loadStyles]`.
+#   2. the `Cache Vale style packages` `path:` list in
+#      `.github/workflows/ci.yml`.
+#   3. the `for p in` list in `.pre-commit-config.yaml`'s `vale-sync` hook.
+#      A pack missing there is never seen as missing, so the hook never
+#      syncs and the `vale` hook right after it fails on packaging.
+# In the TEMPLATE repo, CI asserts these three plus its own workflow's cache
+# list against this line, so drift there fails loudly. This file is
+# `_skip_if_exists` (see above), so your copy is yours: nothing in this
+# project's CI checks that the three above still match a pack you add here.
 Packages = Google, proselint, write-good, https://github.com/tbhb/vale-ai-tells/releases/download/v1.9.0/ai-tells.zip
 
 [*.md]

--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -33,18 +33,24 @@ ruff
 stdio
 
 # --- Operational / config jargon ---
+ADRs
 allowlist
 backports
 config
+denylist
 deployer
+dev
 env
 hotfix
+repo
 ruleset
 rulesets
+systemd
 truthy
 uncommented
 uncommenting
 unprefixed
+upsert
 upserts
 validators
 

--- a/packaging/mcpb/pyproject.toml.in
+++ b/packaging/mcpb/pyproject.toml.in
@@ -1,5 +1,14 @@
 # Rendered at build time by envsubst. ${VERSION} matches the package release.
 [build-system]
+# Bounded to match the project's own pyproject.toml.  This backend runs only
+# on the fallback launch path -- `server.type: "uv"` with `entry_point`, where
+# the host does `uv run src/server.py` and uv builds this project on the
+# user's machine.  The primary path (`mcp_config.command: "uvx"`) fetches the
+# published wheel and never touches it.
+#
+# Nothing publishes or `twine check`s this project, so the failure in #479
+# cannot happen here.  The bound is for reproducibility: an unpinned backend
+# on an end user's machine resolves to whatever is newest that day.
 requires = ["hatchling>=1.32,<1.33"]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
## Summary

- restore template-owned release-notes and issue/PR authoring skills
- correct the skip-listed `.gitignore` rule that hid them
- reconcile missing template Vale vocabulary and retain the MCPB Hatchling bound

Closes #371

## Root cause

The v4 Copier migration did not manually reconcile the skip-listed `.gitignore`; its retained `.claude/` rule prevented the new template-owned skills from being tracked. Release Prepare therefore could not load `writing-release-notes`.

## Verification

- `git check-ignore` confirms the skills are visible
- both restored skills byte-match template v5.6.3
- full gate: 1169 passed, with one third-party warning
- config generation and release-flow contract passed
- focused local review: no findings