### PR TITLE
chore: prepare release 1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- version list -->
 
+## 1.12.1 (2026-08-25)
+
+### Bug Fixes
+
+- title every registered tool and enforce it registry-wide (#353)
+- restore tracked contributor skills (#372)
+
 ## 1.12.1-rc.0 (2026-08-25)
 
 ### Bug Fixes

--- a/docs/releases/1.12.md
+++ b/docs/releases/1.12.md
@@ -1,6 +1,6 @@
 # 1.12
 
-<!-- notes-range-end: e2d933bb7373e0e60d1e4eff9066cfd35f2cfd62 -->
+<!-- notes-range-end: 9195862e50e5d558f6811de71fd0cda93b4acbec -->
 
 <!-- RELEASE-SUMMARY v1.12.0 START -->
 1.12 gives external images a way into the gallery: `fetch_image` pulls one from a URL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "image-generation-mcp"
-version = "1.12.1-rc.0"
+version = "1.12.1"
 description = "MCP server for AI image generation via OpenAI, Google GenAI, or Stable Diffusion WebUI"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pvliesdonk/image-generation-mcp",
   "title": "Image Generation MCP Server",
   "description": "MCP server for AI image generation via OpenAI, Stable Diffusion (SD WebUI), or placeholders.",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "websiteUrl": "https://pvliesdonk.github.io/image-generation-mcp/",
   "repository": {
     "url": "https://github.com/pvliesdonk/image-generation-mcp",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "image-generation-mcp",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -170,7 +170,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pvliesdonk/image-generation-mcp:v1.12.0",
+      "identifier": "ghcr.io/pvliesdonk/image-generation-mcp:v1.12.1",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{--port}/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -1080,7 +1080,7 @@ wheels = [
 
 [[package]]
 name = "image-generation-mcp"
-version = "1.12.1rc0"
+version = "1.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Merging this pull request releases **1.12.1** — the merge is the release
decision.  On merge, the Release workflow tags the merge commit, creates
the GitHub release, and runs the publish fan-out; for a stable promotion the same-source guard
(`scripts/promotion_guard.sh`) runs first, so drifted source refuses with no
tag created.

This PR also carries the release-notes page under `docs/releases/`,
drafted by the prepare run's notes job — review it as part of the release
(an evidence check: every causal claim must trace to its linked issue or
PR).  The PR is held as a DRAFT until the notes land; the notes job marks
it ready.  Still draft means the notes job is running or failed — check
the prepare run.

Do NOT use GitHub's "Update branch" button on this PR — the only valid
refresh is re-dispatching the Release Prepare workflow, which recreates this
branch from its base.

## Changelog

## Bug Fixes

- title every registered tool and enforce it registry-wide (#353)
- restore tracked contributor skills (#372)
